### PR TITLE
added dev-mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,4 @@ example_traces/
 test_traces/
 SCRATCH.md
 .cursor/
+dev-mode/

--- a/src/noveum_trace/core/config.py
+++ b/src/noveum_trace/core/config.py
@@ -15,6 +15,43 @@ import yaml
 
 from noveum_trace.utils.exceptions import ConfigurationError
 
+
+def _parse_config_bool(value: Any, *, field_name: str) -> bool:
+    """
+    Coerce config dict values to bool (YAML/JSON often yield strings).
+
+    Accepts bool, int (0/1), and common string forms; raises ConfigurationError
+    for unrecognized values.
+    """
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, int):
+        if value == 0:
+            return False
+        if value == 1:
+            return True
+        raise ConfigurationError(
+            f"Invalid boolean for {field_name}: {value!r} "
+            "(expected 0 or 1 when using an integer)"
+        )
+    if isinstance(value, str):
+        s = value.strip().lower()
+        if s in ("true", "1", "yes", "on"):
+            return True
+        if s in ("false", "0", "no", "off", ""):
+            return False
+        raise ConfigurationError(
+            f"Invalid boolean for {field_name}: {value!r} "
+            '(expected "true"/"false", "1"/"0", "yes"/"no", etc.)'
+        )
+    raise ConfigurationError(
+        f"Invalid boolean for {field_name}: {value!r} "
+        f"(unsupported type {type(value).__name__})"
+    )
+
+
 # Configuration constants
 DEFAULT_ENDPOINT = "https://api.noveum.ai/api"
 DEFAULT_TIMEOUT = 30
@@ -245,8 +282,19 @@ class Config:
         config.environment = data.get("environment", "development")
         config.debug = data.get("debug", False)
         config.log_level = data.get("log_level", "ERROR")
-        config.dev_mode = data.get("dev_mode", False)
-        config.dev_traces_dir = data.get("dev_traces_dir")
+        if "dev_mode" in data:
+            config.dev_mode = _parse_config_bool(
+                data["dev_mode"], field_name="dev_mode"
+            )
+        else:
+            config.dev_mode = False
+        dev_traces_dir_raw = data.get("dev_traces_dir")
+        if dev_traces_dir_raw is None:
+            config.dev_traces_dir = None
+        elif isinstance(dev_traces_dir_raw, str) and not dev_traces_dir_raw.strip():
+            config.dev_traces_dir = None
+        else:
+            config.dev_traces_dir = dev_traces_dir_raw
 
         # Handle top-level endpoint parameter
         top_level_endpoint = data.get("endpoint")

--- a/src/noveum_trace/core/config.py
+++ b/src/noveum_trace/core/config.py
@@ -23,6 +23,7 @@ DEFAULT_BATCH_SIZE = 100
 DEFAULT_BATCH_TIMEOUT = 5.0
 DEFAULT_MAX_QUEUE_SIZE = 1000
 DEFAULT_MAX_SPANS_PER_TRACE = 1000
+DEFAULT_DEV_TRACES_DIR = ".noveum_trace_dev"
 
 
 @dataclass
@@ -50,9 +51,11 @@ class TransportConfig:
     max_queue_size: int = DEFAULT_MAX_QUEUE_SIZE
     compression: bool = True
     ssl_verify: bool = (
-        True  # Set to False to disable SSL verification (NOT recommended for production)
+        # Set to False to disable SSL verification (NOT recommended for production)
+        True
     )
-    ca_bundle: Optional[str] = None  # Path to custom CA bundle for corporate proxies
+    # Path to custom CA bundle for corporate proxies
+    ca_bundle: Optional[str] = None
 
 
 @dataclass
@@ -93,6 +96,8 @@ class Config:
     # Additional settings
     debug: bool = False
     log_level: str = "ERROR"
+    dev_mode: bool = False
+    dev_traces_dir: Optional[str] = None
 
     # Private field to store endpoint override
     _endpoint_override: Optional[str] = field(default=None, init=False, repr=False)
@@ -124,6 +129,8 @@ class Config:
         integrations: Optional[IntegrationConfig] = None,
         debug: bool = False,
         log_level: str = "ERROR",
+        dev_mode: bool = False,
+        dev_traces_dir: Optional[str] = None,
     ) -> "Config":
         """Create a Config instance with optional endpoint override."""
         # Create the config instance
@@ -137,6 +144,8 @@ class Config:
             integrations=integrations or IntegrationConfig(),
             debug=debug,
             log_level=log_level,
+            dev_mode=dev_mode,
+            dev_traces_dir=dev_traces_dir,
         )
 
         # Handle endpoint override after initialization
@@ -221,6 +230,8 @@ class Config:
             },
             "debug": self.debug,
             "log_level": self.log_level,
+            "dev_mode": self.dev_mode,
+            "dev_traces_dir": self.dev_traces_dir,
         }
 
     @classmethod
@@ -234,6 +245,8 @@ class Config:
         config.environment = data.get("environment", "development")
         config.debug = data.get("debug", False)
         config.log_level = data.get("log_level", "ERROR")
+        config.dev_mode = data.get("dev_mode", False)
+        config.dev_traces_dir = data.get("dev_traces_dir")
 
         # Handle top-level endpoint parameter
         top_level_endpoint = data.get("endpoint")
@@ -458,6 +471,14 @@ def _load_from_environment() -> Config:
     debug_env = os.getenv("NOVEUM_DEBUG")
     if debug_env:
         config_data["debug"] = debug_env.lower() in ("true", "1", "yes")
+
+    dev_mode_env = os.getenv("NOVEUM_DEV_MODE")
+    if dev_mode_env:
+        config_data["dev_mode"] = dev_mode_env.lower() in ("true", "1", "yes")
+
+    dev_traces_dir_env = os.getenv("NOVEUM_DEV_TRACES_DIR")
+    if dev_traces_dir_env:
+        config_data["dev_traces_dir"] = dev_traces_dir_env
 
     # Try to load from config files
     config_files = [

--- a/src/noveum_trace/transport/http_transport.py
+++ b/src/noveum_trace/transport/http_transport.py
@@ -6,9 +6,11 @@ including request formatting, authentication, and error handling.
 """
 
 import base64
+import json
 import time
 from datetime import datetime, timezone
 from enum import Enum
+from pathlib import Path
 
 # Import for type hints
 from typing import TYPE_CHECKING, Any, NoReturn, Optional
@@ -20,7 +22,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from noveum_trace import __version__
-from noveum_trace.core.config import get_config
+from noveum_trace.core.config import DEFAULT_DEV_TRACES_DIR, get_config
 
 if TYPE_CHECKING:
     from noveum_trace.core.config import Config
@@ -748,6 +750,45 @@ class HttpTransport:
 
         return trace_data
 
+    def _dev_trace_filename_stem(self, trace: dict[str, Any]) -> str:
+        """Filesystem-safe filename stem from a single trace's trace_id."""
+        trace_id = trace.get("trace_id")
+        if trace_id is None:
+            return f"unknown_{time.time_ns()}"
+        safe = "".join(c for c in str(trace_id) if c.isalnum() or c in "-_")
+        return safe if safe else f"unknown_{time.time_ns()}"
+
+    def _write_dev_trace_json_file(self, trace: dict[str, Any]) -> None:
+        """Write one trace dict to ``{trace_id}.json`` (caller checks dev_mode)."""
+        dir_str = self.config.dev_traces_dir or DEFAULT_DEV_TRACES_DIR
+        out_dir = Path(dir_str).expanduser()
+        stem = self._dev_trace_filename_stem(trace)
+        path = out_dir / f"{stem}.json"
+        try:
+            out_dir.mkdir(parents=True, exist_ok=True)
+            path.write_text(json.dumps(trace, indent=2, default=str), encoding="utf-8")
+        except OSError as e:
+            logger.warning("dev_mode: failed to write trace JSON to %s: %s", path, e)
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                "dev_mode: failed to serialize trace JSON for %s: %s", path, e
+            )
+
+    def _write_dev_trace_payload(self, payload: dict[str, Any]) -> None:
+        """Persist each trace as ``{trace_id}.json`` right before the API send.
+
+        Batches write one file per trace; trace IDs are unique.
+        """
+        if not self.config.dev_mode:
+            return
+        traces = payload.get("traces")
+        if isinstance(traces, list) and traces:
+            for trace in traces:
+                if isinstance(trace, dict):
+                    self._write_dev_trace_json_file(trace)
+            return
+        self._write_dev_trace_json_file(payload)
+
     def _send_request(self, trace_data: dict[str, Any]) -> dict[str, Any]:
         """
         Send a single trace request to the Noveum platform.
@@ -771,6 +812,8 @@ class HttpTransport:
             content_type="application/json",
             timeout=self.config.transport.timeout,
         )
+
+        self._write_dev_trace_payload(trace_data)
 
         try:
             # Send request with explicit Content-Type for JSON
@@ -909,6 +952,8 @@ class HttpTransport:
                 logger.debug(
                     f"    [{i+1}] {trace_name} (ID: {trace_id}) - {span_count} spans"
                 )
+
+        self._write_dev_trace_payload(payload)
 
         try:
             # Send request with explicit Content-Type for JSON

--- a/tests/integration/end_to_end/test_real_llm_scenarios.py
+++ b/tests/integration/end_to_end/test_real_llm_scenarios.py
@@ -114,13 +114,17 @@ def validate_trace_via_api(trace_id: str, timeout: int = 120) -> dict[str, Any]:
     headers = {"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"}
 
     url = f"{ENDPOINT.rstrip('/')}/v1/traces/{trace_id}"
+    # Noveum API omits span payloads unless includeSpans=true (see noveum-app-nextjs getTraceByIdHandler).
+    trace_get_params = {"includeSpans": "true"}
 
     # Retry for up to timeout seconds
     start_time = time.time()
     retry_count = 0
     while time.time() - start_time < timeout:
         try:
-            response = requests.get(url, headers=headers, timeout=5)
+            response = requests.get(
+                url, headers=headers, params=trace_get_params, timeout=5
+            )
 
             if response.status_code == 200:
                 trace_data = response.json()
@@ -132,6 +136,20 @@ def validate_trace_via_api(trace_id: str, timeout: int = 120) -> dict[str, Any]:
                         assert (
                             trace["trace_id"] == trace_id
                         ), f"Trace ID mismatch: expected {trace_id}, got {trace['trace_id']}"
+
+                        spans = trace.get("spans") or []
+                        if (
+                            trace_get_params.get("includeSpans") == "true"
+                            and trace.get("span_count", 0) > 0
+                            and len(spans) == 0
+                        ):
+                            print(
+                                f"⏳ Trace {trace_id} has span_count={trace['span_count']} but spans not loaded yet "
+                                f"(attempt {retry_count})"
+                            )
+                            retry_count += 1
+                            time.sleep(RETRY_SLEEP)
+                            continue
 
                         print(
                             f"✅ Successfully validated trace {trace_id} after {retry_count} retries"
@@ -149,6 +167,20 @@ def validate_trace_via_api(trace_id: str, timeout: int = 120) -> dict[str, Any]:
                         assert (
                             trace["trace_id"] == trace_id
                         ), f"Trace ID mismatch: expected {trace_id}, got {trace['trace_id']}"
+
+                        spans = trace.get("spans") or []
+                        if (
+                            trace_get_params.get("includeSpans") == "true"
+                            and trace.get("span_count", 0) > 0
+                            and len(spans) == 0
+                        ):
+                            print(
+                                f"⏳ Trace {trace_id} has span_count={trace['span_count']} but spans not loaded yet "
+                                f"(attempt {retry_count})"
+                            )
+                            retry_count += 1
+                            time.sleep(RETRY_SLEEP)
+                            continue
 
                         print(
                             f"✅ Successfully validated trace {trace_id} after {retry_count} retries"

--- a/tests/unit/core/test_config_comprehensive.py
+++ b/tests/unit/core/test_config_comprehensive.py
@@ -339,6 +339,29 @@ class TestConfig:
         assert config.dev_mode is True
         assert config.dev_traces_dir == "/var/tmp/traces"
 
+    def test_config_from_dict_dev_mode_string_coercion(self):
+        """dev_mode from YAML/JSON files is often a string; coerce to bool."""
+        assert Config.from_dict({"dev_mode": "false"}).dev_mode is False
+        assert Config.from_dict({"dev_mode": "FALSE"}).dev_mode is False
+        assert Config.from_dict({"dev_mode": "true"}).dev_mode is True
+        assert Config.from_dict({"dev_mode": "0"}).dev_mode is False
+        assert Config.from_dict({"dev_mode": "1"}).dev_mode is True
+        assert Config.from_dict({"dev_mode": "no"}).dev_mode is False
+        assert Config.from_dict({"dev_mode": "yes"}).dev_mode is True
+        assert Config.from_dict({"dev_mode": "off"}).dev_mode is False
+        assert Config.from_dict({"dev_mode": "on"}).dev_mode is True
+        assert Config.from_dict({}).dev_mode is False
+        assert Config.from_dict({"dev_mode": None}).dev_mode is False
+        assert Config.from_dict({"dev_mode": 0}).dev_mode is False
+        assert Config.from_dict({"dev_mode": 1}).dev_mode is True
+
+    def test_config_from_dict_dev_mode_invalid(self):
+        with pytest.raises(ConfigurationError, match="Invalid boolean for dev_mode"):
+            Config.from_dict({"dev_mode": "maybe"})
+
+    def test_config_from_dict_dev_traces_dir_empty_string(self):
+        assert Config.from_dict({"dev_traces_dir": "   "}).dev_traces_dir is None
+
     def test_config_from_dict_with_endpoint(self):
         """Test Config.from_dict() method with endpoint."""
         data = {"endpoint": "https://custom.api.com"}

--- a/tests/unit/core/test_config_comprehensive.py
+++ b/tests/unit/core/test_config_comprehensive.py
@@ -299,6 +299,8 @@ class TestConfig:
             environment="production",
             debug=True,
             log_level="DEBUG",
+            dev_mode=True,
+            dev_traces_dir="/tmp/noveum-dev-traces",
         )
 
         data = config.to_dict()
@@ -308,6 +310,8 @@ class TestConfig:
         assert data["environment"] == "production"
         assert data["debug"] is True
         assert data["log_level"] == "DEBUG"
+        assert data["dev_mode"] is True
+        assert data["dev_traces_dir"] == "/tmp/noveum-dev-traces"
         assert "tracing" in data
         assert "transport" in data
         assert "security" in data
@@ -321,6 +325,8 @@ class TestConfig:
             "environment": "production",
             "debug": True,
             "log_level": "DEBUG",
+            "dev_mode": True,
+            "dev_traces_dir": "/var/tmp/traces",
         }
 
         config = Config.from_dict(data)
@@ -330,6 +336,8 @@ class TestConfig:
         assert config.environment == "production"
         assert config.debug is True
         assert config.log_level == "DEBUG"
+        assert config.dev_mode is True
+        assert config.dev_traces_dir == "/var/tmp/traces"
 
     def test_config_from_dict_with_endpoint(self):
         """Test Config.from_dict() method with endpoint."""

--- a/tests/unit/transport/test_http_transport_comprehensive.py
+++ b/tests/unit/transport/test_http_transport_comprehensive.py
@@ -5,6 +5,7 @@ This module provides extensive test coverage for the HttpTransport class,
 including all methods, error conditions, and edge cases.
 """
 
+import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1289,3 +1290,98 @@ class TestHttpTransportIntegration:
         # Verify subsequent exports are rejected by the real export_trace method
         with pytest.raises(TransportError, match="Transport has been shutdown"):
             transport.export_trace(trace)
+
+
+class TestHttpTransportDevMode:
+    """dev_mode persists trace JSON bodies to disk immediately before POST."""
+
+    def test_dev_mode_writes_batch_payload(self, tmp_path):
+        config = Config(
+            dev_mode=True,
+            dev_traces_dir=str(tmp_path),
+        )
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = "{}"
+        transport.session.post = Mock(return_value=mock_response)
+
+        traces = [{"trace_id": "abc-uuid", "name": "t", "spans": []}]
+        transport._send_trace_batch(traces)
+
+        out_file = tmp_path / "abc-uuid.json"
+        assert out_file.is_file()
+        saved = json.loads(out_file.read_text(encoding="utf-8"))
+        assert saved == traces[0]
+
+        transport.session.post.assert_called_once()
+        posted = transport.session.post.call_args.kwargs["json"]
+        assert posted["traces"] == traces
+
+    def test_dev_mode_batch_writes_one_file_per_trace(self, tmp_path):
+        config = Config(
+            dev_mode=True,
+            dev_traces_dir=str(tmp_path),
+        )
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = "{}"
+        transport.session.post = Mock(return_value=mock_response)
+
+        traces = [
+            {"trace_id": "trace-a", "name": "a", "spans": []},
+            {"trace_id": "trace-b", "name": "b", "spans": []},
+        ]
+        transport._send_trace_batch(traces)
+
+        assert (
+            json.loads((tmp_path / "trace-a.json").read_text(encoding="utf-8"))
+            == traces[0]
+        )
+        assert (
+            json.loads((tmp_path / "trace-b.json").read_text(encoding="utf-8"))
+            == traces[1]
+        )
+        assert len(list(tmp_path.glob("*.json"))) == 2
+
+    def test_dev_mode_disabled_writes_nothing(self, tmp_path):
+        config = Config(
+            dev_mode=False,
+            dev_traces_dir=str(tmp_path),
+        )
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.text = "{}"
+        transport.session.post = Mock(return_value=mock_response)
+
+        transport._send_trace_batch([{"trace_id": "x", "name": "t", "spans": []}])
+
+        assert list(tmp_path.glob("*.json")) == []
+
+    def test_dev_mode_writes_single_trace_payload(self, tmp_path):
+        config = Config(
+            dev_mode=True,
+            dev_traces_dir=str(tmp_path),
+        )
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"success": True}
+        transport.session.post = Mock(return_value=mock_response)
+
+        trace_data = {"trace_id": "single-tid", "name": "n"}
+        transport._send_request(trace_data)
+
+        out_file = tmp_path / "single-tid.json"
+        assert out_file.is_file()
+        assert json.loads(out_file.read_text(encoding="utf-8")) == trace_data


### PR DESCRIPTION
<h1 data-pm-slice="0 0 []">Dev-mode: save trace JSON before API send</h1><h2>Context</h2><ul><li><p>Traces reach the API in <code>[HttpTransport._send_trace_batch](src/noveum_trace/transport/http_transport.py)</code>: it builds <code>payload = {"traces": traces, "timestamp": ...}</code>, optionally passes through <code>_compress_payload</code> (currently a no-op), then calls <code>session.post(..., json=payload)</code>.</p></li><li><p><code>[_send_request](src/noveum_trace/transport/http_transport.py)</code> (single <code>/v1/trace</code>) exists but is <strong>not</strong> called from <code>src/</code> today—only tests invoke it. The live path is batching only.</p></li><li><p>Audio goes through <code>[_send_single_audio](src/noveum_trace/transport/http_transport.py)</code> (multipart to <code>/v1/audio</code>), not the trace JSON payload, so <strong>no extra stripping is required</strong> to avoid saving audio files—only hook trace JSON send paths.</p></li></ul><pre data-language="mermaid" data-type="mermaid" class="language-mermaid"><code class="language-mermaid">flowchart LR
  export_trace[export_trace] --&gt; batch[BatchProcessor]
  batch --&gt; send_batch[_send_batch]
  send_batch --&gt; trace_batch[_send_trace_batch]
  trace_batch --&gt; dev_dump[dev dump JSON]
  dev_dump --&gt; post[session.post json]
  send_batch --&gt; audio[_send_single_audio]
  audio --&gt; multipart[multipart no dump]</code></pre><h2>Configuration</h2><p>Add two fields on the main <code>[Config](src/noveum_trace/core/config.py)</code> dataclass (alongside existing <code>debug</code> / <code>log_level</code>):</p>
Field | Type | Default | Purpose
-- | -- | -- | --
dev_mode | bool | False | Enable writing trace request JSON to disk
dev_traces_dir | Optional[str] | None | Output directory; when dev_mode is on and this is None, use a fixed default relative to the process cwd (e.g. .noveum_trace_dev)

<p>Wire through:</p><ul><li><p><code>[Config.create](src/noveum_trace/core/config.py)</code>, <code>[to_dict](src/noveum_trace/core/config.py)</code>, <code>[from_dict](src/noveum_trace/core/config.py)</code> (including <code>TransportConfig(...)</code> construction block if any transport-level YAML keys are avoided—prefer <strong>top-level</strong> <code>dev_mode</code> / <code>dev_traces_dir</code> for symmetry with <code>debug</code>).</p></li><li><p><code>[_load_from_environment](src/noveum_trace/core/config.py)</code>: <code>NOVEUM_DEV_MODE</code> (same truthy parsing pattern as <code>NOVEUM_DEBUG</code>) and optional <code>NOVEUM_DEV_TRACES_DIR</code>.</p></li></ul><p><code>[init()](src/noveum_trace/__init__.py)</code> already passes unknown kwargs into <code>configure()</code>, so <code>noveum_trace.init(..., dev_mode=True, dev_traces_dir="/tmp/traces")</code> will work once <code>from_dict</code> understands the keys.</p><h2>Transport implementation</h2><p>In <code>[http_transport.py](src/noveum_trace/transport/http_transport.py)</code>:</p><ol><li><p>Add a small private helper, e.g. <code>_write_dev_trace_payload(self, payload: dict[str, Any], *, label: str) -&gt; None</code>:</p><ul><li><p>Return immediately unless <code>self.config.dev_mode</code>.</p></li><li><p>Resolve directory: <code>Path(dev_traces_dir).expanduser()</code> with default when unset; <code>mkdir(parents=True, exist_ok=True)</code>.</p></li><li><p>Generate a unique filename (e.g. <code>traces_{time.time_ns()}.json</code> or include a short prefix from the first <code>trace_id</code> in <code>payload.get("traces", [])</code> if present—keep filesystem-safe).</p></li><li><p>Serialize with <code>json.dumps(..., indent=2, default=str)</code> and <code>utf-8</code> write.</p></li><li><p>On <code>OSError</code> / serialization issues: log a <strong>warning</strong> and <strong>do not</strong> raise (must not block export).</p></li></ul></li><li><p>Call the helper in <strong><code>_send_trace_batch</code></strong> immediately before the <code>try:</code> that performs <code>session.post</code>, passing the same <code>payload</code> object passed to <code>json=payload</code>.</p></li><li><p><strong>Optional consistency</strong>: call the same helper from <strong><code>_send_request</code></strong> with <code>label="single"</code> or wrap <code>trace_data</code> in a minimal envelope for the filename—low value today but keeps behavior consistent if that path is ever used again.</p></li></ol><p><strong>Do not</strong> call from <code>_send_single_audio</code> or <code>_send_single_image</code>.</p><h2>Tests</h2><p>Add a focused unit test (e.g. in <code>[tests/unit/transport/test_http_transport_comprehensive.py](tests/unit/transport/test_http_transport_comprehensive.py)</code> or a small new file):</p><ul><li><p>Build <code>HttpTransport</code> with a <code>Config</code> where <code>dev_mode=True</code> and <code>dev_traces_dir</code> set to a <code>tmp_path</code> fixture.</p></li><li><p>Mock <code>session.post</code> to avoid network.</p></li><li><p>Call <code>_send_trace_batch</code> with a tiny fake traces list.</p></li><li><p>Assert one <code>.json</code> file appears under <code>tmp_path</code>, parses as JSON, and matches the posted payload structure (<code>traces</code>, <code>timestamp</code>).</p></li><li><p>Optionally assert that when <code>dev_mode=False</code>, no file is created.</p></li></ul><h2>Documentation (optional)</h2><p>Only if you want it discoverable without reading code: a short note in README or examples—skipped unless you ask, per repo convention.</p>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development mode (configurable via settings or environment variables) that, when enabled, persists traces as JSON files to a local dev directory (default: .noveum_trace_dev) for offline inspection.

* **Tests**
  * Added coverage for dev-mode persistence and strict parsing/validation of the new config options; improved end-to-end trace validation to better wait for spans when present.

* **Chores**
  * Updated ignore patterns to exclude the development output directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->