### PR TITLE
Emit warning logs in noveum-trace when 429 code is received from the backend

### DIFF
--- a/src/noveum_trace/transport/http_transport.py
+++ b/src/noveum_trace/transport/http_transport.py
@@ -551,6 +551,9 @@ class HttpTransport:
             backoff_factor=self.config.transport.retry_backoff,
             status_forcelist=[429, 500, 502, 503, 504],
             allowed_methods=["POST"],
+            # Ensure we receive the final response (e.g., 429) after retries,
+            # so higher-level handlers can inspect status_code and log properly.
+            raise_on_status=False,
         )
 
         adapter = HTTPAdapter(max_retries=retry_strategy)
@@ -1073,6 +1076,10 @@ class HttpTransport:
                 trace_count=len(traces),
             )
             raise TransportError(f"HTTP error: {e}") from e
+        except TransportError:
+            # Preserve specific TransportError messages (401/403/429 branches)
+            # without wrapping or double-logging.
+            raise
         except Exception as e:
             log_error_always(
                 logger,
@@ -1166,6 +1173,8 @@ class HttpTransport:
                 audio_uuid=audio_uuid,
             )
             raise TransportError(f"Audio upload timeout: {e}") from e
+        except TransportError:
+            raise
         except Exception as e:
             log_error_always(
                 logger,
@@ -1278,6 +1287,8 @@ class HttpTransport:
                 image_uuid=image_uuid,
             )
             raise TransportError(f"Image upload timeout: {e}") from e
+        except TransportError:
+            raise
         except Exception as e:
             log_error_always(
                 logger,

--- a/src/noveum_trace/transport/http_transport.py
+++ b/src/noveum_trace/transport/http_transport.py
@@ -866,7 +866,10 @@ class HttpTransport:
                 raise TransportError("Access forbidden - check project permissions")
             elif response.status_code == 429:
                 log_error_always(
-                    logger, "Rate limit exceeded", status=response.status_code, url=url
+                    logger,
+                    "Rate limit exceeded (HTTP 429) from Noveum API",
+                    status=response.status_code,
+                    url=url,
                 )
                 raise TransportError("Rate limit exceeded")
             else:
@@ -1021,7 +1024,7 @@ class HttpTransport:
             elif response.status_code == 429:
                 log_error_always(
                     logger,
-                    "Rate limit exceeded",
+                    "Rate limit exceeded (HTTP 429) from Noveum API",
                     status=response.status_code,
                     url=url,
                     trace_count=len(traces),
@@ -1137,6 +1140,15 @@ class HttpTransport:
 
             if response.status_code in [200, 201]:
                 logger.info(f"✅ Successfully sent audio {audio_uuid}")
+            elif response.status_code == 429:
+                log_error_always(
+                    logger,
+                    "Rate limit exceeded (HTTP 429) while uploading audio",
+                    status=response.status_code,
+                    url=url,
+                    audio_uuid=audio_uuid,
+                )
+                raise TransportError("Rate limit exceeded")
             else:
                 log_error_always(
                     logger,
@@ -1240,6 +1252,15 @@ class HttpTransport:
 
             if response.status_code in [200, 201]:
                 logger.info(f"✅ Successfully sent image {image_uuid}")
+            elif response.status_code == 429:
+                log_error_always(
+                    logger,
+                    "Rate limit exceeded (HTTP 429) while uploading image",
+                    status=response.status_code,
+                    url=url,
+                    image_uuid=image_uuid,
+                )
+                raise TransportError("Rate limit exceeded")
             else:
                 log_error_always(
                     logger,
@@ -1295,16 +1316,24 @@ class HttpTransport:
             log_trace_flow(logger, "Performing health check", url=url)
 
             response = self.session.get(url, timeout=10)
-            is_healthy = response.status_code == 200
 
-            if is_healthy:
+            if response.status_code == 200:
                 logger.debug(f"✅ Health check passed for {url}")
-            else:
-                logger.warning(
-                    f"⚠️  Health check failed for {url} (status: {response.status_code})"
-                )
+                return True
 
-            return is_healthy
+            if response.status_code == 429:
+                log_error_always(
+                    logger,
+                    "Rate limit exceeded (HTTP 429) from Noveum API during health check",
+                    status=response.status_code,
+                    url=url,
+                )
+                return False
+
+            logger.warning(
+                f"⚠️  Health check failed for {url} (status: {response.status_code})"
+            )
+            return False
         except Exception as e:
             logger.warning(
                 f"⚠️  Health check failed for {self.config.transport.endpoint}: {e}"

--- a/src/noveum_trace/transport/http_transport.py
+++ b/src/noveum_trace/transport/http_transport.py
@@ -870,7 +870,7 @@ class HttpTransport:
             elif response.status_code == 429:
                 log_error_always(
                     logger,
-                    "Rate limit exceeded (HTTP 429) from Noveum API",
+                    "Rate limit exceeded/Quota exceeded (HTTP 429) from Noveum API",
                     status=response.status_code,
                     url=url,
                 )

--- a/tests/unit/transport/test_http_transport_comprehensive.py
+++ b/tests/unit/transport/test_http_transport_comprehensive.py
@@ -151,6 +151,8 @@ class TestHttpTransportSessionCreation:
             if not isinstance(transport.session, Mock):
                 assert isinstance(http_adapter, HTTPAdapter)
                 assert isinstance(https_adapter, HTTPAdapter)
+                assert http_adapter.max_retries.raise_on_status is False
+                assert 429 in set(http_adapter.max_retries.status_forcelist)
 
 
 class TestHttpTransportContentTypeHeaders:
@@ -1138,6 +1140,84 @@ class TestHttpTransportSendBatch:
             # assert "Successfully sent batch of 2 traces" in caplog.text
             # Just verify the request was made
             transport.session.post.assert_called_once()
+
+    @patch("noveum_trace.transport.http_transport.log_error_always")
+    def test_send_trace_batch_rate_limit_error(self, mock_log_error):
+        """Trace batch POST returns 429 → TransportError and a single log_error_always."""
+        config = Config.create()
+
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+            mock_response = Mock()
+            mock_response.status_code = 429
+
+            transport.session.post = Mock(return_value=mock_response)
+
+            traces = [{"trace_id": "test-1", "name": "n", "spans": []}]
+
+            with pytest.raises(TransportError, match="Rate limit exceeded"):
+                transport._send_trace_batch(traces)
+
+        mock_log_error.assert_called_once()
+
+
+class TestHttpTransportMediaRateLimitHandling:
+    """Ensure media 429 errors are not wrapped by generic handlers."""
+
+    @patch("noveum_trace.transport.http_transport.log_error_always")
+    def test_send_single_audio_rate_limit_not_wrapped(self, mock_log_error):
+        config = Config.create(api_key="test-key")
+
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+            transport.session = Mock()
+            transport.session.headers = {"Authorization": "Bearer test-key"}
+            mock_response = Mock()
+            mock_response.status_code = 429
+            transport.session.post = Mock(return_value=mock_response)
+
+            audio_item = {
+                "audio_uuid": "au-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "audio_data": b"wav-bytes",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "metadata": {},
+            }
+
+            with pytest.raises(TransportError, match="Rate limit exceeded"):
+                transport._send_single_audio(audio_item)
+
+        mock_log_error.assert_called_once()
+        assert "while uploading audio" in mock_log_error.call_args[0][1]
+
+    @patch("noveum_trace.transport.http_transport.log_error_always")
+    def test_send_single_image_rate_limit_not_wrapped(self, mock_log_error):
+        config = Config.create(api_key="test-key")
+
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+            transport.session = Mock()
+            transport.session.headers = {"Authorization": "Bearer test-key"}
+            mock_response = Mock()
+            mock_response.status_code = 429
+            transport.session.post = Mock(return_value=mock_response)
+
+            image_item = {
+                "image_uuid": "img-1",
+                "trace_id": "trace-1",
+                "span_id": "span-1",
+                "image_data": b"jpeg-bytes",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "metadata": {"format": "jpeg"},
+            }
+
+            with pytest.raises(TransportError, match="Rate limit exceeded"):
+                transport._send_single_image(image_item)
+
+        mock_log_error.assert_called_once()
+        assert "while uploading image" in mock_log_error.call_args[0][1]
 
 
 class TestHttpTransportCompressionAndHealth:

--- a/tests/unit/transport/test_http_transport_comprehensive.py
+++ b/tests/unit/transport/test_http_transport_comprehensive.py
@@ -1193,6 +1193,24 @@ class TestHttpTransportCompressionAndHealth:
 
             assert result is False
 
+    @patch("noveum_trace.transport.http_transport.log_error_always")
+    def test_health_check_rate_limit(self, mock_log_error):
+        """Health check treats HTTP 429 like other Noveum API rate limits."""
+        config = Config.create(endpoint="https://api.test.com")
+
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+            mock_response = Mock()
+            mock_response.status_code = 429
+
+            transport.session.get = Mock(return_value=mock_response)
+
+            result = transport.health_check()
+
+            assert result is False
+            mock_log_error.assert_called_once()
+
     def test_health_check_exception(self):
         """Test health check with exception."""
         config = Config.create(endpoint="https://api.test.com")


### PR DESCRIPTION
## Description

This PR improves visibility into **rate limiting (HTTP 429)** responses returned by the Noveum backend by emitting explicit `log_error_always(...)` logs wherever the SDK performs Noveum API calls (single trace, batch traces, audio/image uploads, and health checks). It also adds/updates unit tests to validate the 429 behavior across these code paths.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test improvements
- [x] Documentation update

## How Has This Been Tested?

- [x] Unit tests

### Repro commands

```bash
python -m pytest tests/unit/transport/ -q
pre-commit run --all-files
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings (pre-commit hooks pass)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- 429 handling is now explicitly logged via `log_error_always` in `HttpTransport` for:
  - `/v1/trace`, `/v1/traces`, `/v1/audio`, `/v1/image`, and `/health`
- Unit tests now assert that 429 triggers both `TransportError("Rate limit exceeded")` (or `False` for health check) **and** a call to `log_error_always(...)`.
- Running `pre-commit run --all-files` reformatted a few `docs/examples/*.py` files and fixed trailing whitespace / EOF issues in docs files as part of hook enforcement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rate-limit (HTTP 429) responses across all export and media operations.
  * Enhanced error logging for rate-limit scenarios to include request context and avoid obscuring original errors.
  * Health checks now return a clear failure on rate-limiting.

* **Tests**
  * Added tests covering rate-limit handling and logging for export, media uploads, and health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->