### PR TITLE
feat: add version support to tracing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ noveum_trace.init(
     api_key="your-api-key",          # or NOVEUM_API_KEY env var
     project="my-app",                # or NOVEUM_PROJECT env var
     environment="production",        # optional — default "development"
-    version="v1.0.0",               # optional — maps to service_version in ClickHouse
+    service_version="v1.0.0",        # optional — or NOVEUM_SERVICE_VERSION env var; maps to service_version in ClickHouse
     endpoint="https://api.noveum.ai/api",  # optional — override for self-hosted
     transport_config={               # optional — tune batching
         "batch_size": 50,
@@ -916,9 +916,9 @@ The `docs/examples/` directory contains runnable examples from the test suite:
 | `NOVEUM_PROJECT` | Project name | `my-app` |
 | `NOVEUM_ENVIRONMENT` | Environment name | `production` |
 | `NOVEUM_ENDPOINT` | API endpoint override | `https://api.noveum.ai/api` |
-| `NOVEUM_VERSION` | The application/agent version string | `v1.0.0` |
+| `NOVEUM_SERVICE_VERSION` | The service/application version string | `v1.0.0` |
 
-`version` maps to `service_version` and enables filtering/comparison in the Noveum UI and MCP.
+`service_version` is exported as `service_version` on each trace and enables filtering/comparison in the Noveum UI and MCP.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ noveum_trace.init(
     api_key="your-api-key",          # or NOVEUM_API_KEY env var
     project="my-app",                # or NOVEUM_PROJECT env var
     environment="production",        # optional — default "development"
+    version="v1.0.0",               # optional — maps to service_version in ClickHouse
     endpoint="https://api.noveum.ai/api",  # optional — override for self-hosted
     transport_config={               # optional — tune batching
         "batch_size": 50,
@@ -904,6 +905,20 @@ The `docs/examples/` directory contains runnable examples from the test suite:
 | `agent_example.py` | `create_agent`, agent graph patterns |
 | `comprehensive_tool_calling_examples.py` | Tool call tracing |
 | `image_example.py` | Multimodal / image tracing |
+
+---
+
+## Environment variables
+
+| Variable | Description | Example |
+|---|---|---|
+| `NOVEUM_API_KEY` | Noveum API key | `nv-...` |
+| `NOVEUM_PROJECT` | Project name | `my-app` |
+| `NOVEUM_ENVIRONMENT` | Environment name | `production` |
+| `NOVEUM_ENDPOINT` | API endpoint override | `https://api.noveum.ai/api` |
+| `NOVEUM_VERSION` | The application/agent version string | `v1.0.0` |
+
+`version` maps to `service_version` and enables filtering/comparison in the Noveum UI and MCP.
 
 ---
 

--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -128,6 +128,7 @@ def init(
     api_key: Optional[str] = None,
     endpoint: Optional[str] = None,
     environment: Optional[str] = None,
+    version: Optional[str] = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -140,6 +141,7 @@ def init(
         api_key: Noveum API key (defaults to NOVEUM_API_KEY env var)
         endpoint: API endpoint (defaults to https://api.noveum.ai/api)
         environment: Environment name (dev, staging, prod)
+        version: Application/agent version string (e.g. "v1.0.0")
         **kwargs: Additional configuration options including:
                  - transport_config: Transport layer configuration
                  - tracing_config: Tracing behavior configuration
@@ -151,6 +153,7 @@ def init(
         >>> noveum_trace.init(
         ...     project="my-llm-app",
         ...     environment="production",
+        ...     version="v1.0.0",
         ...     transport_config={
         ...         "batch_size": 10,
         ...         "batch_timeout": 1.0
@@ -175,6 +178,8 @@ def init(
         config["endpoint"] = endpoint if endpoint is not None else DEFAULT_ENDPOINT
         if environment is not None:
             config["environment"] = environment
+        if version is not None:
+            config["version"] = version
 
         # Handle special config parameter mappings
         config_mappings = {

--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -128,7 +128,7 @@ def init(
     api_key: Optional[str] = None,
     endpoint: Optional[str] = None,
     environment: Optional[str] = None,
-    version: Optional[str] = None,
+    service_version: Optional[str] = None,
     **kwargs: Any,
 ) -> None:
     """
@@ -141,7 +141,9 @@ def init(
         api_key: Noveum API key (defaults to NOVEUM_API_KEY env var)
         endpoint: API endpoint (defaults to https://api.noveum.ai/api)
         environment: Environment name (dev, staging, prod)
-        version: Application/agent version string (e.g. "v1.0.0")
+        service_version: Service/application version string (e.g. "v1.0.0").
+            Exported as ``service_version`` on each trace. Defaults to the
+            NOVEUM_SERVICE_VERSION env var.
         **kwargs: Additional configuration options including:
                  - transport_config: Transport layer configuration
                  - tracing_config: Tracing behavior configuration
@@ -153,7 +155,7 @@ def init(
         >>> noveum_trace.init(
         ...     project="my-llm-app",
         ...     environment="production",
-        ...     version="v1.0.0",
+        ...     service_version="v1.0.0",
         ...     transport_config={
         ...         "batch_size": 10,
         ...         "batch_timeout": 1.0
@@ -178,8 +180,8 @@ def init(
         config["endpoint"] = endpoint if endpoint is not None else DEFAULT_ENDPOINT
         if environment is not None:
             config["environment"] = environment
-        if version is not None:
-            config["version"] = version
+        if service_version is not None:
+            config["service_version"] = service_version
 
         # Handle special config parameter mappings
         config_mappings = {

--- a/src/noveum_trace/core/config.py
+++ b/src/noveum_trace/core/config.py
@@ -129,7 +129,7 @@ class Config:
     project: Optional[str] = None
     api_key: Optional[str] = None
     environment: str = "development"
-    version: Optional[str] = None
+    service_version: Optional[str] = None
 
     # Component configurations
     tracing: TracingConfig = field(default_factory=TracingConfig)
@@ -166,7 +166,7 @@ class Config:
         project: Optional[str] = None,
         api_key: Optional[str] = None,
         environment: str = "development",
-        version: Optional[str] = None,
+        service_version: Optional[str] = None,
         endpoint: Optional[str] = None,
         tracing: Optional[TracingConfig] = None,
         transport: Optional[TransportConfig] = None,
@@ -183,7 +183,7 @@ class Config:
             project=project,
             api_key=api_key,
             environment=environment,
-            version=version,
+            service_version=service_version,
             tracing=tracing or TracingConfig(),
             transport=transport or TransportConfig(),
             security=security or SecurityConfig(),
@@ -269,7 +269,7 @@ class Config:
             "project": self.project,
             "api_key": self.api_key,
             "environment": self.environment,
-            "version": self.version,
+            "service_version": self.service_version,
             "tracing": {
                 "enabled": self.tracing.enabled,
                 "sample_rate": self.tracing.sample_rate,
@@ -318,7 +318,7 @@ class Config:
         config.project = data.get("project")
         config.api_key = data.get("api_key")
         config.environment = data.get("environment", "development")
-        config.version = data.get("version")
+        config.service_version = data.get("service_version")
         config.debug = data.get("debug", False)
         config.log_level = data.get("log_level", "ERROR")
         if "dev_mode" in data:
@@ -560,8 +560,8 @@ def _load_from_environment() -> Config:
             config_data["transport"] = {}
         config_data["transport"]["ca_bundle"] = ca_bundle_env
 
-    if os.getenv("NOVEUM_VERSION"):
-        config_data["version"] = os.getenv("NOVEUM_VERSION")
+    if os.getenv("NOVEUM_SERVICE_VERSION"):
+        config_data["service_version"] = os.getenv("NOVEUM_SERVICE_VERSION")
 
     debug_env = os.getenv("NOVEUM_DEBUG")
     if debug_env:

--- a/src/noveum_trace/core/config.py
+++ b/src/noveum_trace/core/config.py
@@ -129,6 +129,7 @@ class Config:
     project: Optional[str] = None
     api_key: Optional[str] = None
     environment: str = "development"
+    version: Optional[str] = None
 
     # Component configurations
     tracing: TracingConfig = field(default_factory=TracingConfig)
@@ -165,6 +166,7 @@ class Config:
         project: Optional[str] = None,
         api_key: Optional[str] = None,
         environment: str = "development",
+        version: Optional[str] = None,
         endpoint: Optional[str] = None,
         tracing: Optional[TracingConfig] = None,
         transport: Optional[TransportConfig] = None,
@@ -181,6 +183,7 @@ class Config:
             project=project,
             api_key=api_key,
             environment=environment,
+            version=version,
             tracing=tracing or TracingConfig(),
             transport=transport or TransportConfig(),
             security=security or SecurityConfig(),
@@ -266,6 +269,7 @@ class Config:
             "project": self.project,
             "api_key": self.api_key,
             "environment": self.environment,
+            "version": self.version,
             "tracing": {
                 "enabled": self.tracing.enabled,
                 "sample_rate": self.tracing.sample_rate,
@@ -314,6 +318,7 @@ class Config:
         config.project = data.get("project")
         config.api_key = data.get("api_key")
         config.environment = data.get("environment", "development")
+        config.version = data.get("version")
         config.debug = data.get("debug", False)
         config.log_level = data.get("log_level", "ERROR")
         if "dev_mode" in data:
@@ -554,6 +559,9 @@ def _load_from_environment() -> Config:
         if "transport" not in config_data:
             config_data["transport"] = {}
         config_data["transport"]["ca_bundle"] = ca_bundle_env
+
+    if os.getenv("NOVEUM_VERSION"):
+        config_data["version"] = os.getenv("NOVEUM_VERSION")
 
     debug_env = os.getenv("NOVEUM_DEBUG")
     if debug_env:

--- a/src/noveum_trace/transport/http_transport.py
+++ b/src/noveum_trace/transport/http_transport.py
@@ -751,8 +751,8 @@ class HttpTransport:
             "version": self._get_sdk_version(),
         }
 
-        if self.config.version:
-            trace_data["service_version"] = self.config.version
+        if self.config.service_version:
+            trace_data["service_version"] = self.config.service_version
 
         # Add project information
         if self.config.project:

--- a/src/noveum_trace/transport/http_transport.py
+++ b/src/noveum_trace/transport/http_transport.py
@@ -751,6 +751,9 @@ class HttpTransport:
             "version": self._get_sdk_version(),
         }
 
+        if self.config.version:
+            trace_data["service_version"] = self.config.version
+
         # Add project information
         if self.config.project:
             trace_data["project"] = self.config.project
@@ -776,7 +779,7 @@ class HttpTransport:
         path = out_dir / f"{stem}.json"
         try:
             out_dir.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(trace, indent=2, default=str), encoding="utf-8")
+            path.write_text(json.dumps(trace, indent=2, default=str, ensure_ascii=False), encoding="utf-8")
         except OSError as e:
             logger.warning("dev_mode: failed to write trace JSON to %s: %s", path, e)
         except (TypeError, ValueError) as e:

--- a/src/noveum_trace/transport/http_transport.py
+++ b/src/noveum_trace/transport/http_transport.py
@@ -779,7 +779,10 @@ class HttpTransport:
         path = out_dir / f"{stem}.json"
         try:
             out_dir.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(trace, indent=2, default=str, ensure_ascii=False), encoding="utf-8")
+            path.write_text(
+                json.dumps(trace, indent=2, default=str, ensure_ascii=False),
+                encoding="utf-8",
+            )
         except OSError as e:
             logger.warning("dev_mode: failed to write trace JSON to %s: %s", path, e)
         except (TypeError, ValueError) as e:

--- a/src/noveum_trace/utils/serialization.py
+++ b/src/noveum_trace/utils/serialization.py
@@ -39,15 +39,13 @@ def convert_to_json_string(value: Any) -> Any:
     """
     if isinstance(value, dict):
         try:
-            return json.dumps(value, default=str)
+            return json.dumps(value, default=str, ensure_ascii=False)
         except (TypeError, ValueError):
-            # If JSON serialization fails, fall back to string representation
             return str(value)
     elif isinstance(value, (list, tuple)):
         try:
-            return json.dumps(value, default=str)
+            return json.dumps(value, default=str, ensure_ascii=False)
         except (TypeError, ValueError):
-            # If JSON serialization fails, fall back to string representation
             return str(value)
     return value
 

--- a/tests/unit/core/test_config_comprehensive.py
+++ b/tests/unit/core/test_config_comprehensive.py
@@ -512,6 +512,65 @@ class TestConfig:
         assert config.endpoint == "https://top-level.com"
 
 
+class TestConfigServiceVersion:
+    """Test the service version (``version``) configuration field."""
+
+    def test_version_default_is_none(self):
+        """Version defaults to None when not provided."""
+        assert Config().version is None
+
+    def test_config_custom_version(self):
+        """Config accepts an explicit version value."""
+        config = Config(version="v1.0.0")
+
+        assert config.version == "v1.0.0"
+
+    def test_config_create_with_version(self):
+        """Config.create() forwards the version value."""
+        config = Config.create(version="v2.3.4")
+
+        assert config.version == "v2.3.4"
+
+    def test_config_create_version_default_is_none(self):
+        """Config.create() leaves version as None when omitted."""
+        assert Config.create().version is None
+
+    def test_config_to_dict_includes_version(self):
+        """to_dict() serializes the version field."""
+        config = Config(version="v1.2.3")
+
+        data = config.to_dict()
+
+        assert data["version"] == "v1.2.3"
+
+    def test_config_to_dict_version_none(self):
+        """to_dict() includes version as None when unset."""
+        data = Config().to_dict()
+
+        assert "version" in data
+        assert data["version"] is None
+
+    def test_config_from_dict_with_version(self):
+        """from_dict() reads the version field."""
+        config = Config.from_dict({"version": "v9.9.9"})
+
+        assert config.version == "v9.9.9"
+
+    def test_config_from_dict_without_version(self):
+        """from_dict() defaults version to None when absent."""
+        config = Config.from_dict({"project": "test-project"})
+
+        assert config.version is None
+
+    def test_config_version_round_trip(self):
+        """version survives a to_dict() / from_dict() round trip."""
+        original = Config(version="v1.0.0")
+
+        restored = Config.from_dict(original.to_dict())
+
+        assert restored.version == "v1.0.0"
+
+
 class TestDeepMergeDicts:
     """Test deep merge dictionary functionality."""
 
@@ -607,6 +666,22 @@ class TestConfigurationLoading:
                 assert config.environment == "production"
                 assert config.endpoint == "https://env.api.com"
                 assert config.debug is True
+
+    def test_load_from_environment_with_version(self):
+        """NOVEUM_VERSION maps into the config version field."""
+        with patch.dict(os.environ, {"NOVEUM_VERSION": "v1.0.0"}, clear=True):
+            with patch("noveum_trace.core.config.os.path.exists", return_value=False):
+                config = _load_from_environment()
+
+                assert config.version == "v1.0.0"
+
+    def test_load_from_environment_without_version(self):
+        """version stays None when NOVEUM_VERSION is unset."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("noveum_trace.core.config.os.path.exists", return_value=False):
+                config = _load_from_environment()
+
+                assert config.version is None
 
     def test_load_from_environment_debug_values(self):
         """Test loading debug values from environment."""

--- a/tests/unit/core/test_config_comprehensive.py
+++ b/tests/unit/core/test_config_comprehensive.py
@@ -669,9 +669,7 @@ class TestConfigurationLoading:
 
     def test_load_from_environment_with_service_version(self):
         """NOVEUM_SERVICE_VERSION maps into the config service_version field."""
-        with patch.dict(
-            os.environ, {"NOVEUM_SERVICE_VERSION": "v1.0.0"}, clear=True
-        ):
+        with patch.dict(os.environ, {"NOVEUM_SERVICE_VERSION": "v1.0.0"}, clear=True):
             with patch("noveum_trace.core.config.os.path.exists", return_value=False):
                 config = _load_from_environment()
 

--- a/tests/unit/core/test_config_comprehensive.py
+++ b/tests/unit/core/test_config_comprehensive.py
@@ -513,62 +513,62 @@ class TestConfig:
 
 
 class TestConfigServiceVersion:
-    """Test the service version (``version``) configuration field."""
+    """Test the ``service_version`` configuration field."""
 
-    def test_version_default_is_none(self):
-        """Version defaults to None when not provided."""
-        assert Config().version is None
+    def test_service_version_default_is_none(self):
+        """service_version defaults to None when not provided."""
+        assert Config().service_version is None
 
-    def test_config_custom_version(self):
-        """Config accepts an explicit version value."""
-        config = Config(version="v1.0.0")
+    def test_config_custom_service_version(self):
+        """Config accepts an explicit service_version value."""
+        config = Config(service_version="v1.0.0")
 
-        assert config.version == "v1.0.0"
+        assert config.service_version == "v1.0.0"
 
-    def test_config_create_with_version(self):
-        """Config.create() forwards the version value."""
-        config = Config.create(version="v2.3.4")
+    def test_config_create_with_service_version(self):
+        """Config.create() forwards the service_version value."""
+        config = Config.create(service_version="v2.3.4")
 
-        assert config.version == "v2.3.4"
+        assert config.service_version == "v2.3.4"
 
-    def test_config_create_version_default_is_none(self):
-        """Config.create() leaves version as None when omitted."""
-        assert Config.create().version is None
+    def test_config_create_service_version_default_is_none(self):
+        """Config.create() leaves service_version as None when omitted."""
+        assert Config.create().service_version is None
 
-    def test_config_to_dict_includes_version(self):
-        """to_dict() serializes the version field."""
-        config = Config(version="v1.2.3")
+    def test_config_to_dict_includes_service_version(self):
+        """to_dict() serializes the service_version field."""
+        config = Config(service_version="v1.2.3")
 
         data = config.to_dict()
 
-        assert data["version"] == "v1.2.3"
+        assert data["service_version"] == "v1.2.3"
 
-    def test_config_to_dict_version_none(self):
-        """to_dict() includes version as None when unset."""
+    def test_config_to_dict_service_version_none(self):
+        """to_dict() includes service_version as None when unset."""
         data = Config().to_dict()
 
-        assert "version" in data
-        assert data["version"] is None
+        assert "service_version" in data
+        assert data["service_version"] is None
 
-    def test_config_from_dict_with_version(self):
-        """from_dict() reads the version field."""
-        config = Config.from_dict({"version": "v9.9.9"})
+    def test_config_from_dict_with_service_version(self):
+        """from_dict() reads the service_version field."""
+        config = Config.from_dict({"service_version": "v9.9.9"})
 
-        assert config.version == "v9.9.9"
+        assert config.service_version == "v9.9.9"
 
-    def test_config_from_dict_without_version(self):
-        """from_dict() defaults version to None when absent."""
+    def test_config_from_dict_without_service_version(self):
+        """from_dict() defaults service_version to None when absent."""
         config = Config.from_dict({"project": "test-project"})
 
-        assert config.version is None
+        assert config.service_version is None
 
-    def test_config_version_round_trip(self):
-        """version survives a to_dict() / from_dict() round trip."""
-        original = Config(version="v1.0.0")
+    def test_config_service_version_round_trip(self):
+        """service_version survives a to_dict() / from_dict() round trip."""
+        original = Config(service_version="v1.0.0")
 
         restored = Config.from_dict(original.to_dict())
 
-        assert restored.version == "v1.0.0"
+        assert restored.service_version == "v1.0.0"
 
 
 class TestDeepMergeDicts:
@@ -667,21 +667,23 @@ class TestConfigurationLoading:
                 assert config.endpoint == "https://env.api.com"
                 assert config.debug is True
 
-    def test_load_from_environment_with_version(self):
-        """NOVEUM_VERSION maps into the config version field."""
-        with patch.dict(os.environ, {"NOVEUM_VERSION": "v1.0.0"}, clear=True):
+    def test_load_from_environment_with_service_version(self):
+        """NOVEUM_SERVICE_VERSION maps into the config service_version field."""
+        with patch.dict(
+            os.environ, {"NOVEUM_SERVICE_VERSION": "v1.0.0"}, clear=True
+        ):
             with patch("noveum_trace.core.config.os.path.exists", return_value=False):
                 config = _load_from_environment()
 
-                assert config.version == "v1.0.0"
+                assert config.service_version == "v1.0.0"
 
-    def test_load_from_environment_without_version(self):
-        """version stays None when NOVEUM_VERSION is unset."""
+    def test_load_from_environment_without_service_version(self):
+        """service_version stays None when NOVEUM_SERVICE_VERSION is unset."""
         with patch.dict(os.environ, {}, clear=True):
             with patch("noveum_trace.core.config.os.path.exists", return_value=False):
                 config = _load_from_environment()
 
-                assert config.version is None
+                assert config.service_version is None
 
     def test_load_from_environment_debug_values(self):
         """Test loading debug values from environment."""

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -82,19 +82,19 @@ class TestInitServiceVersion:
     def teardown_method(self):
         self._reset_state()
 
-    def test_init_sets_version(self):
-        """init(version=...) propagates the value into the configuration."""
+    def test_init_sets_service_version(self):
+        """init(service_version=...) propagates the value into the configuration."""
         noveum_trace.init(
             project="test-project",
             api_key="test-key",
-            version="v1.0.0",
+            service_version="v1.0.0",
         )
 
-        assert config_module.get_config().version == "v1.0.0"
+        assert config_module.get_config().service_version == "v1.0.0"
 
-    def test_init_without_version_defaults_to_none(self):
-        """init() without a version leaves the config version as None."""
+    def test_init_without_service_version_defaults_to_none(self):
+        """init() without a service_version leaves the config service_version as None."""
         with patch.dict("os.environ", {}, clear=True):
             noveum_trace.init(project="test-project", api_key="test-key")
 
-        assert config_module.get_config().version is None
+        assert config_module.get_config().service_version is None

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,10 +1,14 @@
 """
 Unit tests for noveum_trace/__init__.py.
 
-Tests import error handling for LiveKit integrations.
+Tests import error handling for LiveKit integrations and the public
+``init()`` entry point.
 """
 
 from unittest.mock import patch
+
+import noveum_trace
+from noveum_trace.core import config as config_module
 
 
 class TestInitLiveKitImports:
@@ -61,3 +65,36 @@ class TestInitLiveKitImports:
         except ImportError:
             # Acceptable if import fails, but should be handled gracefully
             pass
+
+
+class TestInitServiceVersion:
+    """Test the ``version`` parameter of the public ``init()`` function."""
+
+    def _reset_state(self):
+        """Reset global client and configuration so init() runs cleanly."""
+        with noveum_trace._client_lock:
+            noveum_trace._client = None
+        config_module._config = None
+
+    def setup_method(self):
+        self._reset_state()
+
+    def teardown_method(self):
+        self._reset_state()
+
+    def test_init_sets_version(self):
+        """init(version=...) propagates the value into the configuration."""
+        noveum_trace.init(
+            project="test-project",
+            api_key="test-key",
+            version="v1.0.0",
+        )
+
+        assert config_module.get_config().version == "v1.0.0"
+
+    def test_init_without_version_defaults_to_none(self):
+        """init() without a version leaves the config version as None."""
+        with patch.dict("os.environ", {}, clear=True):
+            noveum_trace.init(project="test-project", api_key="test-key")
+
+        assert config_module.get_config().version is None

--- a/tests/unit/transport/test_http_transport_comprehensive.py
+++ b/tests/unit/transport/test_http_transport_comprehensive.py
@@ -533,8 +533,8 @@ class TestHttpTransportTraceFormatting:
             assert result["sdk"]["name"] == "noveum-trace-python"
 
     def test_format_trace_for_export_with_service_version(self):
-        """Trace formatting includes service_version when version is configured."""
-        config = Config.create(version="v1.0.0")
+        """Trace formatting includes service_version when it is configured."""
+        config = Config.create(service_version="v1.0.0")
 
         with patch("noveum_trace.transport.http_transport.BatchProcessor"):
             transport = HttpTransport(config)
@@ -549,7 +549,7 @@ class TestHttpTransportTraceFormatting:
             assert result["service_version"] == "v1.0.0"
 
     def test_format_trace_for_export_no_service_version(self):
-        """Trace formatting omits service_version when version is unset."""
+        """Trace formatting omits service_version when it is unset."""
         config = Config.create()
 
         with patch("noveum_trace.transport.http_transport.BatchProcessor"):

--- a/tests/unit/transport/test_http_transport_comprehensive.py
+++ b/tests/unit/transport/test_http_transport_comprehensive.py
@@ -532,6 +532,38 @@ class TestHttpTransportTraceFormatting:
             assert "environment" not in result
             assert result["sdk"]["name"] == "noveum-trace-python"
 
+    def test_format_trace_for_export_with_service_version(self):
+        """Trace formatting includes service_version when version is configured."""
+        config = Config.create(version="v1.0.0")
+
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+            trace = Mock(spec=Trace)
+            trace.trace_id = "test-id"
+            trace.name = "test-trace"
+            trace.to_dict.return_value = {"trace_id": "test-id", "spans": []}
+
+            result = transport._format_trace_for_export(trace)
+
+            assert result["service_version"] == "v1.0.0"
+
+    def test_format_trace_for_export_no_service_version(self):
+        """Trace formatting omits service_version when version is unset."""
+        config = Config.create()
+
+        with patch("noveum_trace.transport.http_transport.BatchProcessor"):
+            transport = HttpTransport(config)
+
+            trace = Mock(spec=Trace)
+            trace.trace_id = "test-id"
+            trace.name = "test-trace"
+            trace.to_dict.return_value = {"trace_id": "test-id"}
+
+            result = transport._format_trace_for_export(trace)
+
+            assert "service_version" not in result
+
 
 class TestHttpTransportTraceToDict:
     """Test the new trace_to_dict method for object serialization."""


### PR DESCRIPTION
# Pull Request

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Performance testing

## Test Configuration

* Python version:
* Operating System:
* Dependencies:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional Notes

Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `service_version` parameter to initialization, mapped to `NOVEUM_SERVICE_VERSION`.
  * Trace exports now include `service_version` when provided, enabling filtering/comparison.

* **Improvements**
  * JSON serialization now preserves non-ASCII characters (no unnecessary escaping).
  * Dev-mode trace JSON output is written in UTF-8 for correct character rendering.

* **Tests**
  * Added unit coverage for `service_version` configuration defaults, serialization/deserialization, environment-variable mapping, and export payload inclusion/omission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->