### PR TITLE
fix: novaguard fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ livekit = ["livekit>=1.0.19,<2", "livekit-agents>=1.0.0"]
 pipecat = ["pipecat-ai>=0.0.108"]
 pipecat-otel = ["pipecat-ai>=0.0.108", "opentelemetry-api>=1.0.0", "opentelemetry-sdk>=1.0.0"]
 crewai = ["crewai>=0.177.0; python_version>='3.10'"]
+bedrock = ["boto3>=1.34.0"]
 
 # Optional: spaCy for ``PiiPseudonymizer`` NER (heavier than the core SDK; regex-only
 # pseudonymization works without this extra). After install, run:
@@ -100,6 +101,7 @@ dev = [
     "openai>=1.0.0",
     "anthropic>=0.3.0",
     "langchain-core>=0.1.0",
+    "boto3>=1.34.0",
 
     # Development utilities
     "pre-commit>=3.0.0",
@@ -113,6 +115,7 @@ test = [
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
     "pytest-asyncio>=0.21.0",
+    "boto3>=1.34.0",
 ]
 
 # Linting dependencies
@@ -272,6 +275,10 @@ module = [
     "pipecat.*",
     "crewai",
     "crewai.*",
+    "boto3",
+    "boto3.*",
+    "botocore",
+    "botocore.*",
     "google",
     "google.*",
     "google.generativeai",

--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -132,6 +132,7 @@ def init(
     service_version: Optional[str] = None,
     policies: Optional[list[Any]] = None,
     guard_enabled: bool = False,
+    guard_fail_open_on_backend_unavailable: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -147,6 +148,11 @@ def init(
         service_version: Service/application version string (e.g. "v1.0.0").
             Exported as ``service_version`` on each trace. Defaults to the
             NOVEUM_SERVICE_VERSION env var.
+        guard_fail_open_on_backend_unavailable: When the Guard control plane is
+            unreachable, block every guarded call (fail closed, default) or keep
+            enforcing the last-known policies (fail open, ``True``). Fail open
+            trades strict enforcement for availability so a transient
+            control-plane blip does not become a full LLM outage.
         **kwargs: Additional configuration options including:
                  - transport_config: Transport layer configuration
                  - tracing_config: Tracing behavior configuration
@@ -242,7 +248,12 @@ def init(
                     api_key=api_key or "",
                     base_url=endpoint or DEFAULT_ENDPOINT,
                 )
-                _engine = PolicyEngine(_api_client)
+                _engine = PolicyEngine(
+                    _api_client,
+                    fail_open_on_backend_unavailable=(
+                        guard_fail_open_on_backend_unavailable
+                    ),
+                )
                 # Use a unique sentinel when project is not provided so that
                 # different uninamed callers do not share the same spend scope.
                 _project_id = (

--- a/src/noveum_trace/guard/__init__.py
+++ b/src/noveum_trace/guard/__init__.py
@@ -2,7 +2,8 @@ from noveum_trace.guard._state import attach_policy, detach_policy, refresh
 from noveum_trace.guard.api_client import GuardAPIClient
 from noveum_trace.guard.decision import PolicyDecision
 from noveum_trace.guard.engine import PolicyEngine
-from noveum_trace.guard.exceptions import NoveumGuardBlocked
+from noveum_trace.guard.exceptions import GuardBackendUnavailable, NoveumGuardBlocked
+from noveum_trace.guard.integrations.bedrock import instrument_bedrock
 from noveum_trace.guard.integrations.crewai import NoveumCrewAIInterceptor
 from noveum_trace.guard.policies import AbstractPolicy, CostCapPolicy
 from noveum_trace.guard.poller import PolicyPoller
@@ -12,6 +13,7 @@ from noveum_trace.guard.transport import (
     async_http_client,
     http_client,
 )
+from noveum_trace.guard.transport.adapters.base import default_registry
 from noveum_trace.guard.types import (
     Action,
     BlockResponseMode,
@@ -23,12 +25,39 @@ from noveum_trace.guard.types import (
     PolicyDeps,
 )
 
+
+def supported_providers() -> list[str]:
+    """Provider names NovaGuard can enforce policies on, across both mechanisms.
+
+    Most entries (OpenAI + OpenAI-compatible hosts, Anthropic) come from the
+    default ProviderAdapter registry: enforcement requires one explicit
+    ``http_client()``/``async_http_client()`` call PER client instance you
+    construct (``openai.OpenAI(http_client=noveum_trace.guard.http_client())``).
+
+    "bedrock" is covered differently: AWS Bedrock (boto3/botocore) never
+    produces an httpx.Request, so it can't go through that registry — see the
+    module docstring in ``guard.transport.adapters.base`` for why. Instead,
+    ``instrument_bedrock()`` is called ONCE, process-wide, typically right
+    after ``noveum_trace.init(...)`` — it patches botocore itself, so it
+    covers every bedrock-runtime client the app builds afterward (or already
+    built), from any boto3.Session(), not just one client instance. Both
+    mechanisms are equally one line and equally explicit opt-in; they differ
+    in scope — per-client-instance (OpenAI/Anthropic) vs. process-wide
+    (Bedrock) — not in whether wiring is required at all.
+
+    Google Vertex AI / the native Gemini SDK are still not covered by either
+    mechanism.
+    """
+    return sorted({*default_registry().provider_names(), "bedrock"})
+
+
 __all__ = [
     # Core
     "GuardAPIClient",
     "PolicyDecision",
     "PolicyEngine",
     "NoveumGuardBlocked",
+    "GuardBackendUnavailable",
     "PolicyPoller",
     # Policies
     "AbstractPolicy",
@@ -40,6 +69,7 @@ __all__ = [
     "async_http_client",
     # Integrations
     "NoveumCrewAIInterceptor",
+    "instrument_bedrock",
     # Types / enums
     "Action",
     "BlockResponseMode",
@@ -53,4 +83,6 @@ __all__ = [
     "attach_policy",
     "detach_policy",
     "refresh",
+    # Coverage introspection
+    "supported_providers",
 ]

--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import logging
 import threading
 from dataclasses import dataclass
 from typing import Any, Optional
 
-_log = logging.getLogger(__name__)
+from noveum_trace.guard.exceptions import GuardBackendUnavailable
 
 
 @dataclass
@@ -137,13 +136,15 @@ class GuardAPIClient:
         dict with at least a ``"type"`` key (e.g. ``"cost_cap"``) plus the policy's
         own parameters (e.g. ``max_usd``, ``window``).
 
-        Returns an empty list when:
-        - No API key is configured (stub / test mode).
-        - The backend is unreachable or returns a non-2xx status.
-        - The response cannot be parsed as JSON.
+        Returns an empty list only when no API key is configured (stub / test
+        mode — a legitimate, silent case).
 
-        The caller (``PolicyPoller``) is responsible for catching all exceptions;
-        this method only swallows expected "not configured" cases.
+        Raises:
+            GuardBackendUnavailable: an API key IS configured but the backend
+                request failed (network error, non-2xx status, or the response
+                could not be parsed as JSON). The caller (``PolicyPoller``) is
+                responsible for deciding how to react — this method does not
+                silently degrade to "no policies" for a real failure.
         """
         if not self.api_key:
             # Running in stub / in-memory mode — return locally stored configs
@@ -168,19 +169,17 @@ class GuardAPIClient:
                 data = resp.json()
                 policies: list[dict[str, Any]] = data.get("policies", [])
                 return policies
-            _log.debug(
-                "fetch_remote_policies: backend returned %s for project %r",
-                resp.status_code,
-                project_id,
+            raise GuardBackendUnavailable(
+                f"fetch_remote_policies: backend returned "
+                f"{resp.status_code} for project {project_id!r}"
             )
-            return []
+        except GuardBackendUnavailable:
+            raise
         except Exception as exc:  # network error, JSON decode error, etc.
-            _log.debug(
-                "fetch_remote_policies: skipped for project %r — %s",
-                project_id,
-                exc,
-            )
-            return []
+            raise GuardBackendUnavailable(
+                f"fetch_remote_policies: request failed for project "
+                f"{project_id!r} — {exc}"
+            ) from exc
 
     # Inspection (tests + debug)
 

--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -136,8 +136,9 @@ class GuardAPIClient:
         dict with at least a ``"type"`` key (e.g. ``"cost_cap"``) plus the policy's
         own parameters (e.g. ``max_usd``, ``window``).
 
-        Returns an empty list only when no API key is configured (stub / test
-        mode — a legitimate, silent case).
+        Returns an empty list when no API key is configured (stub / test mode)
+        or when the backend responds successfully but the project has zero
+        configured policies — both legitimate, silent cases.
 
         Raises:
             GuardBackendUnavailable: an API key IS configured but the backend

--- a/src/noveum_trace/guard/engine.py
+++ b/src/noveum_trace/guard/engine.py
@@ -77,6 +77,10 @@ class PolicyEngine:
                     )
             self._backend_unavailable.set()
         else:
+            if self._backend_unavailable.is_set():
+                _log.info(
+                    "NovaGuard control plane reachable again; policy sync recovered."
+                )
             self._backend_unavailable.clear()
 
     def is_backend_unavailable(self) -> bool:

--- a/src/noveum_trace/guard/engine.py
+++ b/src/noveum_trace/guard/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import threading
 from typing import Any, Callable, Optional
 
@@ -14,6 +15,8 @@ from noveum_trace.guard.types import (
     PolicyDeps,
 )
 
+_log = logging.getLogger(__name__)
+
 
 class PolicyEngine:
     """Thin orchestrator. All enforcement logic lives in policies.
@@ -23,10 +26,20 @@ class PolicyEngine:
     - Post → all post() hooks run before any block is surfaced.
     """
 
-    def __init__(self, api_client: GuardAPIClient) -> None:
+    def __init__(
+        self,
+        api_client: GuardAPIClient,
+        *,
+        fail_open_on_backend_unavailable: bool = False,
+    ) -> None:
         self._api_client = api_client
         self._policies: list[AbstractPolicy] = []
         self._lock = threading.Lock()
+        # Set by PolicyPoller on a backend fetch failure (vs. legitimately zero policies).
+        self._backend_unavailable = threading.Event()
+        # Fail closed by default when backend is unreachable; set True to keep
+        # enforcing last-known policies instead (availability over strict enforcement).
+        self._fail_open_on_backend_unavailable = fail_open_on_backend_unavailable
 
     # Policy registration
 
@@ -43,6 +56,40 @@ class PolicyEngine:
         with self._lock:
             return list(self._policies)
 
+    # Backend availability
+
+    def set_backend_unavailable(self, unavailable: bool) -> None:
+        """Toggle the control-plane-unreachable flag (set by PolicyPoller)."""
+        if unavailable:
+            # Log once per transition (not per call) so the operational impact
+            # is loud without spamming the hot path.
+            if not self._backend_unavailable.is_set():
+                if self._fail_open_on_backend_unavailable:
+                    _log.warning(
+                        "NovaGuard control plane unreachable; failing OPEN — "
+                        "continuing to enforce last-known policies "
+                        "(guard_fail_open_on_backend_unavailable=True)."
+                    )
+                else:
+                    _log.warning(
+                        "NovaGuard control plane unreachable; failing CLOSED — "
+                        "blocking all guarded calls until policy sync recovers."
+                    )
+            self._backend_unavailable.set()
+        else:
+            self._backend_unavailable.clear()
+
+    def is_backend_unavailable(self) -> bool:
+        return self._backend_unavailable.is_set()
+
+    def has_post_blocking_policies(self) -> bool:
+        """True when any attached policy can return a blocking post() decision.
+
+        Used by the transport to decide whether a streaming response must be
+        buffered in full before any bytes reach the caller.
+        """
+        return any(p.can_block_post for p in self.policies)
+
     # Call lifecycle
 
     def pre_call(
@@ -55,6 +102,27 @@ class PolicyEngine:
         Returns (block_decision | None, ran_pairs).
         On block: rollback all previously ran policies; caller must NOT forward the request.
         """
+        if (
+            self._backend_unavailable.is_set()
+            and not self._fail_open_on_backend_unavailable
+        ):
+            # Control plane unreachable and configured to fail closed: block
+            # rather than silently keep enforcing stale (or absent) policy
+            # state. No policies ran, so there is nothing to release. When
+            # fail_open_on_backend_unavailable is set we skip this and fall
+            # through to enforce the last-known attached policies instead.
+            return (
+                PolicyDecision.block(
+                    "_guard_control_plane",
+                    Phase.pre,
+                    reason=(
+                        "NovaGuard control plane unreachable; failing closed "
+                        "until policy sync recovers"
+                    ),
+                ),
+                [],
+            )
+
         deps = PolicyDeps(api=self._api_client)
         ran: list[tuple[AbstractPolicy, PolicyDecision]] = []
 

--- a/src/noveum_trace/guard/exceptions.py
+++ b/src/noveum_trace/guard/exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from noveum_trace.utils.exceptions import NoveumTraceError
 
-__all__ = ["NoveumGuardBlocked"]
+__all__ = ["NoveumGuardBlocked", "GuardBackendUnavailable"]
 
 
 class NoveumGuardBlocked(NoveumTraceError):
@@ -19,3 +19,12 @@ class NoveumGuardBlocked(NoveumTraceError):
         self.reason = reason
         self.decision = decision
         super().__init__(f"Blocked by {policy_name}: {reason}")
+
+
+class GuardBackendUnavailable(NoveumTraceError):
+    """Raised when the Guard control plane cannot be reached.
+
+    Distinct from "not configured" (no API key — legitimate stub/test mode):
+    this means an API key IS configured but the backend request failed
+    (network error, non-2xx status, or an unparsable response).
+    """

--- a/src/noveum_trace/guard/integrations/__init__.py
+++ b/src/noveum_trace/guard/integrations/__init__.py
@@ -1,3 +1,7 @@
+from noveum_trace.guard.integrations.bedrock import instrument_bedrock
 from noveum_trace.guard.integrations.crewai import NoveumCrewAIInterceptor
 
-__all__ = ["NoveumCrewAIInterceptor"]
+__all__ = [
+    "NoveumCrewAIInterceptor",
+    "instrument_bedrock",
+]

--- a/src/noveum_trace/guard/integrations/bedrock.py
+++ b/src/noveum_trace/guard/integrations/bedrock.py
@@ -1,0 +1,624 @@
+from __future__ import annotations
+
+import dataclasses
+import io
+import json
+import logging
+import threading
+import uuid
+import weakref
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+from noveum_trace.guard.exceptions import NoveumGuardBlocked
+from noveum_trace.guard.types import ParsedRequest, ParsedResponse, PolicyContext
+from noveum_trace.utils.llm_utils import estimate_cost, estimate_token_count
+
+if TYPE_CHECKING:
+    from noveum_trace.guard.decision import PolicyDecision
+    from noveum_trace.guard.engine import PolicyEngine
+    from noveum_trace.guard.policies.base import AbstractPolicy
+
+logger = logging.getLogger(__name__)
+
+_CONVERSE_OPERATIONS = {"Converse", "ConverseStream"}
+_STREAMING_OPERATIONS = {"InvokeModelWithResponseStream", "ConverseStream"}
+_KNOWN_OPERATIONS = _CONVERSE_OPERATIONS | {
+    "InvokeModel",
+    "InvokeModelWithResponseStream",
+}
+
+
+def _model_family(model_id: str) -> str:
+    for prefix in ("anthropic.", "amazon.titan", "meta.llama", "cohere.", "mistral."):
+        if model_id.startswith(prefix):
+            return prefix
+    return ""
+
+
+def _parse_invoke_model_body(
+    model_id: str, body: dict[str, Any]
+) -> tuple[Any, Optional[int]]:
+    """Return (prompt-shaped content for token estimation, max_tokens).
+
+    Bedrock's raw InvokeModel body shape differs per model family; unrecognized
+    families fall back to the whole body as text so pre-call blocking still
+    has something to estimate against.
+    """
+    family = _model_family(model_id)
+    if family == "anthropic.":
+        return body.get("messages", []), body.get("max_tokens")
+    if family == "amazon.titan":
+        max_tokens = (body.get("textGenerationConfig") or {}).get("maxTokenCount")
+        return body.get("inputText", ""), max_tokens
+    if family == "meta.llama":
+        return body.get("prompt", ""), body.get("max_gen_len")
+    if family == "cohere.":
+        return body.get("message") or body.get("prompt", ""), body.get("max_tokens")
+    if family == "mistral.":
+        return body.get("prompt", ""), body.get("max_tokens")
+    return json.dumps(body), None
+
+
+def _parse_invoke_model_usage(
+    model_id: str, response_body: dict[str, Any]
+) -> tuple[Optional[int], Optional[int]]:
+    """Return (input_tokens, output_tokens), or (None, None) if unrecognized.
+
+    Callers must treat (None, None) as "unknown" — release the reservation
+    rather than guess a cost, per the same convention used for streaming SSE
+    reconciliation elsewhere in the guard transport.
+    """
+    family = _model_family(model_id)
+    if family == "anthropic.":
+        usage = response_body.get("usage") or {}
+        if "input_tokens" in usage and "output_tokens" in usage:
+            return usage["input_tokens"], usage["output_tokens"]
+    elif family == "amazon.titan":
+        if "inputTextTokenCount" in response_body:
+            results = response_body.get("results") or [{}]
+            return response_body["inputTextTokenCount"], results[0].get("tokenCount")
+    elif family == "meta.llama":
+        if "prompt_token_count" in response_body:
+            return (
+                response_body["prompt_token_count"],
+                response_body.get("generation_token_count"),
+            )
+    elif family == "cohere.":
+        billed = (response_body.get("meta") or {}).get("billed_units") or {}
+        if "input_tokens" in billed:
+            return billed.get("input_tokens"), billed.get("output_tokens")
+    return None, None
+
+
+def _is_embeddings_model(model_id: str) -> bool:
+    """True for Bedrock embedding models (Titan Embed, Cohere Embed).
+
+    Embedding InvokeModel bodies/responses differ from text-generation ones and
+    never carry output tokens, so they need distinct request/usage parsing plus
+    kind="embeddings" — otherwise CostCapPolicy reserves a chat-style output
+    allowance (up to 4096 tokens) for a call that produces none, over-reserving
+    and potentially blocking spuriously at pre().
+    """
+    return "embed" in model_id.lower()
+
+
+def _parse_embeddings_input(model_id: str, body: dict[str, Any]) -> Any:
+    """Return prompt-shaped content for input-token estimation of an embed call."""
+    if _model_family(model_id) == "cohere.":
+        texts = body.get("texts") or []
+        return " ".join(t for t in texts if isinstance(t, str))
+    # Titan Embed (text & image) uses a single inputText field.
+    return body.get("inputText", "")
+
+
+def _parse_embeddings_usage(
+    model_id: str, response_body: dict[str, Any]
+) -> Optional[int]:
+    """Return exact input_tokens if the embed response reports them, else None.
+
+    Titan embed responses include ``inputTextTokenCount``; Cohere embed responses
+    carry no token count (the caller falls back to the request-time estimate).
+    Output tokens are always 0 for embeddings.
+    """
+    if _model_family(model_id) == "amazon.titan":
+        count = response_body.get("inputTextTokenCount")
+        if isinstance(count, int):
+            return count
+    return None
+
+
+def _extract_event_usage(
+    event: dict[str, Any], operation_name: str
+) -> Optional[tuple[Optional[int], Optional[int]]]:
+    """Return (input_tokens, output_tokens) if this event carries usage, else None.
+
+    Shared by the lazy tee reconciler and the buffer-before-yield enforcement
+    path so both read usage from the stream identically.
+    """
+    if operation_name == "ConverseStream":
+        usage = (event.get("metadata") or {}).get("usage")
+        if usage:
+            return usage.get("inputTokens"), usage.get("outputTokens")
+        return None
+
+    # InvokeModelWithResponseStream: AWS injects a trailing
+    # amazon-bedrock-invocationMetrics field into the final chunk for every
+    # model family, regardless of the underlying model's own response shape.
+    chunk = (event.get("chunk") or {}).get("bytes")
+    if not chunk:
+        return None
+    try:
+        payload = json.loads(chunk)
+    except (TypeError, ValueError):
+        return None
+    metrics = payload.get("amazon-bedrock-invocationMetrics")
+    if metrics:
+        return metrics.get("inputTokenCount"), metrics.get("outputTokenCount")
+    return None
+
+
+def _extract_event_text(event: dict[str, Any], operation_name: str) -> Optional[str]:
+    """Best-effort incremental completion text from one stream event.
+
+    Only needed for the buffered enforcement path, where a post-phase content
+    policy may inspect the assembled output. Token accounting does not depend on
+    it — an unrecognized shape simply contributes no text.
+    """
+    if operation_name == "ConverseStream":
+        delta = (event.get("contentBlockDelta") or {}).get("delta") or {}
+        text = delta.get("text")
+        return text if isinstance(text, str) else None
+
+    chunk = (event.get("chunk") or {}).get("bytes")
+    if not chunk:
+        return None
+    try:
+        payload = json.loads(chunk)
+    except (TypeError, ValueError):
+        return None
+    # Per-family InvokeModel chunk shapes: anthropic delta.text, titan
+    # outputText, llama generation, cohere/mistral text, mistral outputs[].text.
+    delta = payload.get("delta")
+    if isinstance(delta, dict) and isinstance(delta.get("text"), str):
+        return delta["text"]
+    for key in ("outputText", "generation", "text", "completion"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    outputs = payload.get("outputs")
+    if isinstance(outputs, list) and outputs and isinstance(outputs[0], dict):
+        text = outputs[0].get("text")
+        return text if isinstance(text, str) else None
+    return None
+
+
+def _rebuffer_streaming_body(raw_bytes: bytes) -> Any:
+    """Replace a single-read StreamingBody with a fresh one over the same bytes.
+
+    Local import: botocore is only needed here (and only ever reached when the
+    caller already holds a live boto3 client), so the module itself stays
+    importable without boto3/botocore installed.
+    """
+    import botocore.response
+
+    return botocore.response.StreamingBody(io.BytesIO(raw_bytes), len(raw_bytes))
+
+
+class _BedrockStreamReconciler:
+    """Tees a Bedrock EventStream; reconciles the Guard reservation on exhaustion.
+
+    Mirrors ``_SyncStreamReconciler`` in ``guard.transport.sync_transport``,
+    adapted to botocore's dict-yielding EventStream instead of a raw byte
+    stream. Pre-call blocking already happened before this object exists —
+    this only affects post-call cost reconciliation accuracy.
+    """
+
+    def __init__(
+        self,
+        inner: Any,
+        engine: PolicyEngine,
+        ctx: PolicyContext,
+        ran: list[tuple[AbstractPolicy, PolicyDecision]],
+        parsed_req: ParsedRequest,
+        operation_name: str,
+    ) -> None:
+        self._inner = inner
+        self._engine = engine
+        self._ctx = ctx
+        self._ran = ran
+        self._parsed_req = parsed_req
+        self._operation_name = operation_name
+        self._reconciled = False
+        self._input_tokens: Optional[int] = None
+        self._output_tokens: Optional[int] = None
+
+    def __iter__(self) -> Any:
+        try:
+            for event in self._inner:
+                self._observe(event)
+                yield event
+        finally:
+            self._reconcile()
+
+    def _observe(self, event: dict[str, Any]) -> None:
+        usage = _extract_event_usage(event, self._operation_name)
+        if usage is not None:
+            self._input_tokens, self._output_tokens = usage
+
+    def _reconcile(self) -> None:
+        if self._reconciled:
+            return
+        self._reconciled = True
+
+        if self._input_tokens is None or self._output_tokens is None:
+            logger.warning(
+                "NovaGuard: no usage metrics found in Bedrock %s stream for "
+                "model %r; releasing reservation without exact cost reconciliation",
+                self._operation_name,
+                self._parsed_req.model,
+            )
+            self._engine.release_all(self._ctx, self._ran)
+            return
+
+        cost_usd = estimate_cost(
+            self._parsed_req.model, self._input_tokens, self._output_tokens
+        )["total_cost"]
+        resp = ParsedResponse(
+            model=self._parsed_req.model,
+            text=None,
+            input_tokens=self._input_tokens,
+            output_tokens=self._output_tokens,
+            cost_usd=cost_usd,
+        )
+        post_block = self._engine.post_call(resp, self._ctx, self._ran)
+        if post_block is not None:
+            # Policy attached mid-stream after dispatch; bytes already yielded, can only log.
+            logger.error(
+                "NovaGuard: policy %r returned a post-phase block on a Bedrock "
+                "%s stream; cannot be enforced after events are yielded (reason: %s)",
+                post_block.policy_name,
+                self._operation_name,
+                post_block.reason,
+            )
+
+
+# Parsing / reconciliation helpers — module-level since one _guarded_make_api_call
+# call spans pre-call -> real call -> post-call, with no cross-callback state to hand off.
+
+
+def _parse_request(operation_name: str, params: dict[str, Any]) -> ParsedRequest:
+    model_id = params.get("modelId", "")
+    stream = operation_name in _STREAMING_OPERATIONS
+    kind = "chat"
+
+    if operation_name in _CONVERSE_OPERATIONS:
+        messages = params.get("messages", [])
+        max_tokens = (params.get("inferenceConfig") or {}).get("maxTokens")
+        estimated = estimate_token_count(messages, model=model_id, provider="bedrock")
+    else:
+        body = params.get("body")
+        if isinstance(body, (bytes, str)):
+            try:
+                body_dict = json.loads(body)
+            except (TypeError, ValueError):
+                body_dict = {}
+        elif isinstance(body, dict):
+            body_dict = body
+        else:
+            body_dict = {}
+        if _is_embeddings_model(model_id):
+            kind = "embeddings"
+            messages = []
+            max_tokens = None
+            content = _parse_embeddings_input(model_id, body_dict)
+            estimated = estimate_token_count(
+                content, model=model_id, provider="bedrock"
+            )
+        else:
+            content, max_tokens = _parse_invoke_model_body(model_id, body_dict)
+            messages = content if isinstance(content, list) else []
+            estimated = estimate_token_count(
+                content, model=model_id, provider="bedrock"
+            )
+
+    return ParsedRequest(
+        provider="bedrock",
+        model=model_id,
+        messages=messages,
+        stream=stream,
+        max_tokens=max_tokens,
+        estimated_input_tokens=estimated,
+        raw_body=b"",
+        kind=kind,
+    )
+
+
+def _reconcile_non_streaming(
+    operation_name: str,
+    parsed_req: ParsedRequest,
+    parsed: dict[str, Any],
+    engine: PolicyEngine,
+    ctx: PolicyContext,
+    ran: list[tuple[AbstractPolicy, PolicyDecision]],
+) -> None:
+    model_id = parsed_req.model
+
+    if operation_name in _CONVERSE_OPERATIONS:
+        usage = parsed.get("usage") or {}
+        input_tokens = usage.get("inputTokens")
+        output_tokens = usage.get("outputTokens")
+    else:
+        # InvokeModel: parsed["body"] is a single-read StreamingBody. Read
+        # it once for usage extraction, then substitute a fresh, fully
+        # buffered one so the caller's own response["body"].read() still works.
+        raw_bytes = parsed["body"].read()
+        parsed["body"] = _rebuffer_streaming_body(raw_bytes)
+        try:
+            body_dict = json.loads(raw_bytes)
+        except (TypeError, ValueError):
+            body_dict = {}
+        if parsed_req.kind == "embeddings":
+            # Embeddings never produce output tokens. Prefer the exact input
+            # count from the response (Titan's inputTextTokenCount); Cohere embed
+            # carries none, so fall back to the request-time estimate rather than
+            # releasing — that estimate is what the cap was reserved against.
+            exact = _parse_embeddings_usage(model_id, body_dict)
+            input_tokens = (
+                exact if exact is not None else parsed_req.estimated_input_tokens
+            )
+            output_tokens = 0
+        else:
+            input_tokens, output_tokens = _parse_invoke_model_usage(model_id, body_dict)
+
+    if input_tokens is None or output_tokens is None:
+        logger.warning(
+            "NovaGuard: no usage found in Bedrock %s response for model %r; "
+            "releasing reservation without exact cost reconciliation",
+            operation_name,
+            model_id,
+        )
+        engine.release_all(ctx, ran)
+        return
+
+    cost_usd = estimate_cost(model_id, input_tokens, output_tokens)["total_cost"]
+    resp = ParsedResponse(
+        model=model_id,
+        text=None,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+    )
+    post_block = engine.post_call(resp, ctx, ran)
+    if post_block is not None:
+        raise NoveumGuardBlocked(post_block.policy_name, post_block.reason, post_block)
+
+
+def _buffer_and_enforce_stream(
+    parsed: dict[str, Any],
+    engine: PolicyEngine,
+    ctx: PolicyContext,
+    ran: list[tuple[AbstractPolicy, PolicyDecision]],
+    parsed_req: ParsedRequest,
+    operation_name: str,
+    key: str,
+) -> dict[str, Any]:
+    """Buffer the whole event stream, run post_call BEFORE any event is yielded.
+
+    Mirrors ``build_buffered_stream_response`` on the httpx transport path: used
+    only when a post-blocking policy is attached
+    (``engine.has_post_blocking_policies()``). A post-phase block can then be
+    enforced by raising ``NoveumGuardBlocked`` before the caller sees a single
+    event — instead of only being logged after the bytes are already yielded, as
+    the lazy ``_BedrockStreamReconciler`` path does. The tradeoff (paid only
+    here) is full-latency-before-first-event instead of true streaming.
+    """
+    events = list(parsed[key])
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    text_parts: list[str] = []
+    for event in events:
+        usage = _extract_event_usage(event, operation_name)
+        if usage is not None:
+            input_tokens, output_tokens = usage
+        chunk_text = _extract_event_text(event, operation_name)
+        if chunk_text:
+            text_parts.append(chunk_text)
+
+    # Absent usage → cost is unknown (0.0); a content policy can still inspect
+    # the assembled text. Matches the httpx buffered path's has_usage handling.
+    if input_tokens is not None and output_tokens is not None:
+        cost_usd = estimate_cost(parsed_req.model, input_tokens, output_tokens)[
+            "total_cost"
+        ]
+    else:
+        cost_usd = 0.0
+    resp = ParsedResponse(
+        model=parsed_req.model,
+        text="".join(text_parts) if text_parts else None,
+        input_tokens=input_tokens or 0,
+        output_tokens=output_tokens or 0,
+        cost_usd=cost_usd,
+    )
+    post_block = engine.post_call(resp, ctx, ran)
+    if post_block is not None:
+        raise NoveumGuardBlocked(post_block.policy_name, post_block.reason, post_block)
+    # Allowed: replay the buffered events so the caller iterates normally.
+    parsed[key] = events
+    return parsed
+
+
+def _wrap_streaming_result(
+    parsed: dict[str, Any],
+    engine: PolicyEngine,
+    ctx: PolicyContext,
+    ran: list[tuple[AbstractPolicy, PolicyDecision]],
+    parsed_req: ParsedRequest,
+    operation_name: str,
+) -> dict[str, Any]:
+    key = "stream" if operation_name == "ConverseStream" else "body"
+    if parsed is None or parsed.get(key) is None:
+        # Nothing to tee — release rather than leave the reservation inflight.
+        engine.release_all(ctx, ran)
+        return parsed
+    if engine.has_post_blocking_policies():
+        # A policy that can block post() is attached: a block can't be enforced
+        # on events already yielded, so buffer the whole stream and enforce
+        # before releasing anything to the caller.
+        try:
+            return _buffer_and_enforce_stream(
+                parsed, engine, ctx, ran, parsed_req, operation_name, key
+            )
+        except NoveumGuardBlocked:
+            # Intended post-phase enforcement — post_call already reconciled the
+            # reservation, so this must NOT release (that would double-refund).
+            raise
+        except Exception:
+            # Draining the stream failed before we could reconcile — release the
+            # reservation instead of leaking it inflight (mirrors the httpx
+            # buffered path's release-on-error in sync_transport).
+            engine.release_all(ctx, ran)
+            raise
+    parsed[key] = _BedrockStreamReconciler(
+        parsed[key], engine, ctx, ran, parsed_req, operation_name
+    )
+    return parsed
+
+
+# Patching BaseClient._make_api_call (not a subclass method) covers every
+# bedrock-runtime client from any session, past or future — same technique
+# OpenTelemetry/Sentry/Datadog use for botocore.
+
+_patch_lock = threading.Lock()
+_patched = False
+_original_make_api_call: Optional[Callable[..., Any]] = None
+
+# Per-client advanced override: instrument_bedrock(client, engine=..., context=...).
+# Keyed by weak reference so instrumented clients can still be garbage collected.
+_client_overrides: weakref.WeakKeyDictionary[
+    Any, tuple[PolicyEngine, PolicyContext]
+] = weakref.WeakKeyDictionary()
+# Process-wide default set via instrument_bedrock(engine=..., context=...) with no
+# client — takes precedence over noveum_trace.init() so callers don't need init() first.
+_global_override: Optional[tuple[PolicyEngine, PolicyContext]] = None
+
+
+def _resolve_for_client(client: Any) -> Optional[tuple[PolicyEngine, PolicyContext]]:
+    """Resolution order: per-client override > global override > live guard._state.
+
+    Returns None when nothing is configured anywhere — the wrapper must treat
+    that as "pass through unguarded", not raise, since it runs on every
+    Bedrock call for the life of the process, not once at an explicit setup
+    call site.
+    """
+    override = _client_overrides.get(client)
+    if override is not None:
+        return override
+    if _global_override is not None:
+        return _global_override
+    from noveum_trace.guard.transport.helper import _resolve_or_none
+
+    return _resolve_or_none(None, None)
+
+
+def _guarded_make_api_call(
+    self: Any, operation_name: str, api_params: dict[str, Any]
+) -> Any:
+    assert _original_make_api_call is not None
+    service_model = getattr(self.meta, "service_model", None)
+    if service_model is None or service_model.service_name != "bedrock-runtime":
+        return _original_make_api_call(self, operation_name, api_params)
+    if operation_name not in _KNOWN_OPERATIONS:
+        return _original_make_api_call(self, operation_name, api_params)
+
+    resolved = _resolve_for_client(self)
+    if resolved is None:
+        return _original_make_api_call(self, operation_name, api_params)
+    engine, base_context = resolved
+
+    ctx = dataclasses.replace(base_context, call_id=str(uuid.uuid4()))
+    parsed_req = _parse_request(operation_name, api_params)
+
+    block, ran = engine.pre_call(parsed_req, ctx)
+    if block is not None:
+        raise NoveumGuardBlocked(block.policy_name, block.reason, block)
+
+    try:
+        parsed = _original_make_api_call(self, operation_name, api_params)
+    except Exception:
+        engine.release_all(ctx, ran)
+        raise
+
+    if operation_name in _STREAMING_OPERATIONS:
+        return _wrap_streaming_result(
+            parsed, engine, ctx, ran, parsed_req, operation_name
+        )
+
+    _reconcile_non_streaming(operation_name, parsed_req, parsed, engine, ctx, ran)
+    return parsed
+
+
+def _install_global_patch() -> None:
+    global _patched, _original_make_api_call
+    if _patched:
+        return
+    with _patch_lock:
+        if _patched:
+            return
+        import botocore.client
+
+        _original_make_api_call = botocore.client.BaseClient._make_api_call
+        botocore.client.BaseClient._make_api_call = _guarded_make_api_call
+        _patched = True
+
+
+def _uninstrument_bedrock_for_tests() -> None:
+    """Restore the unpatched botocore method and clear all override state.
+
+    Not part of the public API — imported directly by test teardown fixtures
+    only, since this is a genuine process-wide mutation of third-party class
+    state that must never leak across test modules.
+    """
+    global _patched, _original_make_api_call, _global_override
+    with _patch_lock:
+        if _patched and _original_make_api_call is not None:
+            import botocore.client
+
+            botocore.client.BaseClient._make_api_call = _original_make_api_call
+        _patched = False
+        _original_make_api_call = None
+    _client_overrides.clear()
+    _global_override = None
+
+
+def instrument_bedrock(
+    client: Optional[Any] = None,
+    *,
+    engine: Optional[PolicyEngine] = None,
+    context: Optional[PolicyContext] = None,
+) -> Optional[Any]:
+    """Guard AWS Bedrock (boto3 bedrock-runtime) calls, process-wide by default.
+
+    Global form — call once after ``noveum_trace.init()``; every bedrock-runtime
+    client built afterward, from any session, is guarded.
+
+    Advanced form — ``instrument_bedrock(client, engine=..., context=...)`` binds
+    one client to its own engine/context instead of the process-wide default
+    (still installs the global patch). engine and context must be supplied together.
+    """
+    if (engine is None) != (context is None):
+        raise ValueError(
+            "engine and context must be provided together or both omitted; "
+            "supplying only one leads to mismatched policy binding."
+        )
+
+    _install_global_patch()
+
+    if client is not None:
+        if engine is not None and context is not None:
+            _client_overrides[client] = (engine, context)
+        return client
+
+    if engine is not None and context is not None:
+        global _global_override
+        _global_override = (engine, context)
+    return None

--- a/src/noveum_trace/guard/policies/base.py
+++ b/src/noveum_trace/guard/policies/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import threading
 from abc import ABC
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
 from noveum_trace.guard.decision import PolicyDecision
 from noveum_trace.guard.types import (
@@ -32,6 +32,8 @@ class AbstractPolicy(ABC):
     poll_interval: Optional[float] = (
         None  # seconds; None means poller skips this policy
     )
+    # True only if post() can block; transport must buffer streams to enforce it.
+    can_block_post: ClassVar[bool] = False
 
     def __init__(self) -> None:
         self.data_map: dict[str, Any] = {}  # private mutable state; guard with _lock

--- a/src/noveum_trace/guard/policies/cost_cap.py
+++ b/src/noveum_trace/guard/policies/cost_cap.py
@@ -94,6 +94,13 @@ class CostCapPolicy(AbstractPolicy):
             return self._organization_id or self._project_id or ""
 
     def _estimate_reserved_usd(self, parsed: ParsedRequest) -> float:
+        if parsed.kind == "embeddings":
+            # Embeddings never produce output tokens; guessing a chat-style
+            # max_output_tokens fallback here would over- or under-reserve
+            # depending on registry presence, for no reason.
+            return estimate_cost(parsed.model, parsed.estimated_input_tokens, 0)[
+                "total_cost"
+            ]
         info = get_model_info(parsed.model)
         max_out = parsed.max_tokens or (info.max_output_tokens if info else 4096)
         return estimate_cost(parsed.model, parsed.estimated_input_tokens, max_out)[

--- a/src/noveum_trace/guard/poller.py
+++ b/src/noveum_trace/guard/poller.py
@@ -6,6 +6,8 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any, Optional
 
+from noveum_trace.guard.exceptions import GuardBackendUnavailable
+
 if TYPE_CHECKING:
     from noveum_trace.guard.engine import PolicyEngine
     from noveum_trace.guard.policies.base import AbstractPolicy
@@ -197,9 +199,19 @@ class PolicyPoller:
             remote_policies: list[dict[str, Any]] = api.fetch_remote_policies(
                 project_id
             )
+        except GuardBackendUnavailable as exc:
+            # A real backend failure (not "no policies configured") — fail
+            # closed rather than silently keep running on stale policy state.
+            _log.error("PolicyPoller: backend unreachable — %s", exc)
+            self._engine.set_backend_unavailable(True)
+            return
         except Exception as exc:
+            # Unexpected bug in fetch_remote_policies itself — never let it
+            # kill the daemon thread, but don't change availability state.
             _log.debug("PolicyPoller: fetch_remote_policies failed — %s", exc)
             return
+
+        self._engine.set_backend_unavailable(False)
 
         if not remote_policies:
             return

--- a/src/noveum_trace/guard/transport/adapters/base.py
+++ b/src/noveum_trace/guard/transport/adapters/base.py
@@ -61,6 +61,10 @@ class AdapterRegistry:
     def register(self, adapter: ProviderAdapter) -> None:
         self._adapters.append(adapter)
 
+    def provider_names(self) -> list[str]:
+        """Provider names covered by the registered adapters (see module docstring)."""
+        return [a.provider_name for a in self._adapters]
+
     @staticmethod
     def _host_matches(host: str, pattern: str) -> bool:
         """Return True only when pattern is an exact match or a proper ancestor domain.
@@ -103,8 +107,8 @@ class AdapterRegistry:
         return None
 
 
-# Module-level default registry populated by the two concrete adapters below.
-# Transport code imports this singleton; tests can replace it.
+# Only sees httpx-routed traffic, so Bedrock/Vertex can't match here; Bedrock
+# is covered separately via guard.instrument_bedrock(). See supported_providers().
 _default_registry: Optional[AdapterRegistry] = None
 
 

--- a/src/noveum_trace/guard/transport/adapters/openai_adapter.py
+++ b/src/noveum_trace/guard/transport/adapters/openai_adapter.py
@@ -26,8 +26,27 @@ class OpenAIAdapter(ProviderAdapter):
 
     def parse_request(self, req: httpx.Request) -> ParsedRequest:
         body = json.loads(req.content)
-        messages = body.get("messages", [])
         model = body.get("model", "")
+
+        # An embeddings body ({model, input}) has no "messages" — chat-shaped
+        # parsing would silently estimate near-zero cost for it (empty
+        # messages list) and bypass the cost cap entirely.
+        if "messages" not in body and "input" in body:
+            estimated = estimate_token_count(
+                body["input"], model=model, provider="openai"
+            )
+            return ParsedRequest(
+                provider="openai",
+                model=model,
+                messages=[],
+                stream=False,
+                max_tokens=None,
+                estimated_input_tokens=estimated,
+                raw_body=req.content,
+                kind="embeddings",
+            )
+
+        messages = body.get("messages", [])
         estimated = estimate_token_count(messages, model=model, provider="openai")
         return ParsedRequest(
             provider="openai",
@@ -46,9 +65,15 @@ class OpenAIAdapter(ProviderAdapter):
         usage = body.get("usage", {})
         model = body.get("model", "")
         input_tokens = usage.get("prompt_tokens", 0)
-        output_tokens = usage.get("completion_tokens", 0)
-        choices = body.get("choices", [])
-        text = choices[0].get("message", {}).get("content") if choices else None
+        if "data" in body and "choices" not in body:
+            # Embeddings responses have "data", not "choices", and never
+            # produce completion tokens.
+            output_tokens = 0
+            text = None
+        else:
+            choices = body.get("choices", [])
+            output_tokens = usage.get("completion_tokens", 0)
+            text = choices[0].get("message", {}).get("content") if choices else None
         return ParsedResponse(
             model=model,
             text=text,

--- a/src/noveum_trace/guard/transport/async_transport.py
+++ b/src/noveum_trace/guard/transport/async_transport.py
@@ -70,7 +70,8 @@ class _AsyncStreamReconciler(httpx.AsyncByteStream):
 class NoveumAsyncTransport(httpx.AsyncBaseTransport):
     """Async httpx transport that enforces Guard policies around every LLM call.
 
-    Same data flow as NoveumTransport; all I/O awaited.
+    Same data flow as NoveumTransport (including the buffered-streaming path
+    when a post-blocking policy is attached); all I/O awaited.
     """
 
     def __init__(
@@ -79,15 +80,31 @@ class NoveumAsyncTransport(httpx.AsyncBaseTransport):
         context: PolicyContext,
         inner: Optional[httpx.AsyncBaseTransport] = None,
         registry: Optional[AdapterRegistry] = None,
+        on_unmatched_request: str = "passthrough",
     ) -> None:
         self._engine = engine
         self._context = context
         self._inner = inner or httpx.AsyncHTTPTransport()
         self._registry = registry or default_registry()
+        self._on_unmatched_request = on_unmatched_request
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         adapter = self._registry.for_request(request)
         if adapter is None:
+            if self._on_unmatched_request == "block":
+                from noveum_trace.guard.transport.helper import (
+                    build_generic_block_response,
+                )
+
+                _log.error(
+                    "NovaGuard: no adapter found for request %s %s — blocking "
+                    "(on_unmatched_request='block')",
+                    request.method,
+                    request.url,
+                )
+                return build_generic_block_response(
+                    f"No NovaGuard adapter for {request.method} {request.url}"
+                )
             _log.error(
                 "NovaGuard: no adapter found for request %s %s — passing through unguarded",
                 request.method,
@@ -110,9 +127,27 @@ class NoveumAsyncTransport(httpx.AsyncBaseTransport):
             self._engine.release_all(ctx, ran)
             raise
 
-        # Wrap streaming responses so the reservation is reconciled when the
-        # caller finishes consuming the stream (instead of staying inflight forever).
         if parsed_req.stream:
+            if self._engine.has_post_blocking_policies():
+                # A policy that can block post() is attached: a block can't be
+                # enforced on bytes already flushed, so buffer the full
+                # response before releasing anything to the caller.
+                from noveum_trace.guard.transport.helper import (
+                    build_buffered_stream_response,
+                )
+
+                try:
+                    await response.aread()
+                    return build_buffered_stream_response(
+                        response, request, adapter, self._engine, ctx, ran, parsed_req
+                    )
+                except Exception:
+                    self._engine.release_all(ctx, ran)
+                    raise
+
+            # No post-blocking policy: true streaming, lazy reconcile on consume.
+            # Narrow response.stream's broad type; always AsyncByteStream here.
+            assert isinstance(response.stream, httpx.AsyncByteStream)
             reconciler = _AsyncStreamReconciler(
                 response.stream, self._engine, ctx, ran, parsed_req
             )

--- a/src/noveum_trace/guard/transport/helper.py
+++ b/src/noveum_trace/guard/transport/helper.py
@@ -275,6 +275,24 @@ def _resolve(
     return resolved
 
 
+_ON_UNMATCHED_REQUEST_VALUES = ("passthrough", "block")
+
+
+def _validate_on_unmatched_request(value: str) -> None:
+    """Reject anything but "passthrough"/"block" before NoveumTransport sees it.
+
+    NoveumTransport/NoveumAsyncTransport only special-case "block" internally
+    and silently fall through to passthrough for any other string — so a typo
+    (e.g. "Block") would otherwise degrade to the opposite of what the caller
+    asked for without warning.
+    """
+    if value not in _ON_UNMATCHED_REQUEST_VALUES:
+        raise ValueError(
+            f"on_unmatched_request must be one of {_ON_UNMATCHED_REQUEST_VALUES}, "
+            f"got {value!r}"
+        )
+
+
 def http_client(
     engine: Optional[PolicyEngine] = None,
     context: Optional[PolicyContext] = None,
@@ -296,6 +314,7 @@ def http_client(
     synthetic 403 instead, for defense-in-depth deployments that want to
     guarantee nothing bypasses Guard coverage).
     """
+    _validate_on_unmatched_request(on_unmatched_request)
     resolved_engine, resolved_context = _resolve(engine, context)
     transport = NoveumTransport(
         engine=resolved_engine,
@@ -324,6 +343,7 @@ def async_http_client(
 
     See http_client() for on_unmatched_request.
     """
+    _validate_on_unmatched_request(on_unmatched_request)
     resolved_engine, resolved_context = _resolve(engine, context)
     transport = NoveumAsyncTransport(
         engine=resolved_engine,

--- a/src/noveum_trace/guard/transport/helper.py
+++ b/src/noveum_trace/guard/transport/helper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gzip
 import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 import httpx
@@ -19,21 +20,33 @@ if TYPE_CHECKING:
 _logger = get_sdk_logger("guard.transport")
 
 
-def _parse_sse_usage(body: bytes, provider: str) -> tuple[int, int] | None:
-    """Extract (input_tokens, output_tokens) from a fully-buffered SSE stream body.
+@dataclass
+class SSEEventData:
+    input_tokens: int
+    output_tokens: int
+    text: Optional[str]
+    has_usage: bool  # whether any usage event was found (cost is only trustworthy then)
 
-    Returns None when usage data is absent (e.g. OpenAI without
-    stream_options.include_usage=True).
+
+def _parse_sse_event_data(body: bytes, provider: str) -> SSEEventData:
+    """Extract usage and assembled completion text from a fully-buffered SSE body.
+
+    ``has_usage`` is False when no usage event was found (e.g. OpenAI without
+    stream_options.include_usage=True) — callers that need cost accounting
+    should treat that as "unknown" rather than "zero". ``text`` is best-effort
+    assembled from delta events regardless of usage presence, since a
+    post-phase content policy may need it even when cost can't be computed.
 
     Anthropic always includes usage in message_start / message_delta events.
     OpenAI only includes usage in the final chunk when the caller opts in.
     """
-    text = body.decode("utf-8", errors="ignore")
+    decoded = body.decode("utf-8", errors="ignore")
     input_tokens = 0
     output_tokens = 0
-    found = False
+    has_usage = False
+    text_parts: list[str] = []
 
-    for line in text.splitlines():
+    for line in decoded.splitlines():
         if not line.startswith("data: "):
             continue
         data = line[6:].strip()
@@ -49,20 +62,34 @@ def _parse_sse_usage(body: bytes, provider: str) -> tuple[int, int] | None:
             if event_type == "message_start":
                 usage = event.get("message", {}).get("usage", {})
                 input_tokens = usage.get("input_tokens", 0)
-                found = True
+                has_usage = True
             elif event_type == "message_delta":
                 usage = event.get("usage", {})
                 output_tokens = usage.get("output_tokens", 0)
-                found = True
+                has_usage = True
+            elif event_type == "content_block_delta":
+                delta = event.get("delta", {})
+                if delta.get("type") == "text_delta":
+                    text_parts.append(delta.get("text", ""))
         else:
             # OpenAI-compat: usage only present when stream_options.include_usage=True
             usage = event.get("usage")
             if usage:
                 input_tokens = usage.get("prompt_tokens", 0)
                 output_tokens = usage.get("completion_tokens", 0)
-                found = True
+                has_usage = True
+            choices = event.get("choices") or []
+            if choices:
+                delta_content = choices[0].get("delta", {}).get("content")
+                if delta_content:
+                    text_parts.append(delta_content)
 
-    return (input_tokens, output_tokens) if found else None
+    return SSEEventData(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        text="".join(text_parts) if text_parts else None,
+        has_usage=has_usage,
+    )
 
 
 def reconcile_stream(
@@ -89,29 +116,34 @@ def reconcile_stream(
     try:
         body = b"".join(chunks)
         # Raw stream bytes may be gzip-compressed (Content-Encoding: gzip).
-        # Decompress before SSE parsing so _parse_sse_usage sees plain text.
+        # Decompress before SSE parsing so _parse_sse_event_data sees plain text.
         if body[:2] == b"\x1f\x8b":
             try:
                 body = gzip.decompress(body)
             except Exception:
                 pass
-        usage = _parse_sse_usage(body, parsed_req.provider)
-        if usage is None:
+        event_data = _parse_sse_event_data(body, parsed_req.provider)
+        if not event_data.has_usage:
             # Stream has no usage events; release worst-case reservation.
             engine.release_all(ctx, ran)
             return
-        input_tokens, output_tokens = usage
-        costs = estimate_cost(parsed_req.model, input_tokens, output_tokens)
+        costs = estimate_cost(
+            parsed_req.model, event_data.input_tokens, event_data.output_tokens
+        )
         parsed_resp = ParsedResponse(
             model=parsed_req.model,
-            text=None,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
+            text=event_data.text,
+            input_tokens=event_data.input_tokens,
+            output_tokens=event_data.output_tokens,
             cost_usd=costs["total_cost"],
         )
         post_block = engine.post_call(parsed_resp, ctx, ran)
         if post_block is not None:
-            _logger.warning(
+            # A policy with can_block_post=True attached to a truly-streaming
+            # call (has_post_blocking_policies() was False when this call was
+            # dispatched, or the policy was attached mid-stream) — an avoidable
+            # enforcement gap, not an inert code path, hence error not warning.
+            _logger.error(
                 "Guard policy %r returned a post-phase block on a streaming "
                 "response; cannot be enforced after bytes are streamed (reason: %s)",
                 post_block.policy_name,
@@ -121,10 +153,97 @@ def reconcile_stream(
         engine.release_all(ctx, ran)
 
 
-def _resolve(
+def build_buffered_stream_response(
+    response: httpx.Response,
+    request: httpx.Request,
+    adapter: Any,
+    engine: PolicyEngine,
+    ctx: PolicyContext,
+    ran: list[tuple[AbstractPolicy, PolicyDecision]],
+    parsed_req: ParsedRequest,
+) -> httpx.Response:
+    """Enforce post-phase policies on a streaming response before any bytes
+    reach the caller, then either replay it or return a synthetic block.
+
+    Used only when engine.has_post_blocking_policies() is True — otherwise
+    the transport takes the lazy _SyncStreamReconciler/_AsyncStreamReconciler
+    path (true streaming, no buffering). The caller must have already
+    materialized ``response.content`` (response.read() / await
+    response.aread()) before calling this.
+    """
+    from noveum_trace.guard.types import ParsedResponse
+    from noveum_trace.utils.llm_utils import estimate_cost
+
+    event_data = _parse_sse_event_data(response.content, parsed_req.provider)
+    if event_data.has_usage:
+        cost_usd = estimate_cost(
+            parsed_req.model, event_data.input_tokens, event_data.output_tokens
+        )["total_cost"]
+    else:
+        cost_usd = 0.0
+    parsed_resp = ParsedResponse(
+        model=parsed_req.model,
+        text=event_data.text,
+        input_tokens=event_data.input_tokens,
+        output_tokens=event_data.output_tokens,
+        cost_usd=cost_usd,
+    )
+    post_block = engine.post_call(parsed_resp, ctx, ran)
+    if post_block is not None:
+        return adapter.synthetic_block_response(
+            request, post_block, post_block.block_response_mode
+        )
+    # Allowed: replay the exact original SSE bytes as a single materialized
+    # body. httpx/provider SDKs parse SSE the same way whether delivered
+    # incrementally or as one blob — the tradeoff is full-latency-before-
+    # first-byte instead of true incremental streaming, paid only here.
+    #
+    # response.content is already content-decoded (response.read() applied any
+    # Content-Encoding), so we must drop the original Content-Encoding and
+    # Content-Length: replaying decoded bytes under a "gzip" header makes the
+    # provider SDK's httpx read attempt a second gunzip (DecodingError), and
+    # the original Content-Length describes the compressed body, not this one.
+    replay_headers = [
+        (name, value)
+        for name, value in response.headers.items()
+        if name.lower() not in ("content-encoding", "content-length")
+    ]
+    return httpx.Response(
+        status_code=response.status_code,
+        headers=replay_headers,
+        content=response.content,
+        request=request,
+    )
+
+
+def build_generic_block_response(reason: str) -> httpx.Response:
+    """403 response for a request that matched no ProviderAdapter.
+
+    Used by on_unmatched_request="block" — there is no adapter instance to
+    call synthetic_block_response() on, so this builds a provider-agnostic
+    equivalent (same shape as OpenAIAdapter's).
+    """
+    body = json.dumps({"error": {"type": "policy_blocked", "message": reason}}).encode()
+    return httpx.Response(
+        status_code=403, content=body, headers={"content-type": "application/json"}
+    )
+
+
+def _resolve_or_none(
     engine: Optional[PolicyEngine],
     context: Optional[PolicyContext],
-) -> tuple[PolicyEngine, PolicyContext]:
+) -> Optional[tuple[PolicyEngine, PolicyContext]]:
+    """Like _resolve(), but returns None instead of raising when guard isn't
+    configured and neither engine nor context was explicitly supplied.
+
+    Used by call sites that run repeatedly for the life of the process (e.g.
+    the Bedrock global _make_api_call patch's per-call hot path) rather than
+    once at an explicit setup call site — raising there when guard hasn't
+    been initialized yet would break every intercepted call in an
+    unconfigured app; passing the call through unguarded is the safe failure
+    mode instead. Partial provision (exactly one of engine/context) is still
+    a caller bug and still raises, same as _resolve().
+    """
     # Reject partial provision early: both must be supplied together or both omitted.
     if (engine is None) != (context is None):
         raise ValueError(
@@ -138,12 +257,22 @@ def _resolve(
     resolved_engine = _state.get_engine()
     resolved_context = _state.get_context()
     if resolved_engine is None or resolved_context is None:
+        return None
+    return resolved_engine, resolved_context
+
+
+def _resolve(
+    engine: Optional[PolicyEngine],
+    context: Optional[PolicyContext],
+) -> tuple[PolicyEngine, PolicyContext]:
+    resolved = _resolve_or_none(engine, context)
+    if resolved is None:
         raise RuntimeError(
             "NovaGuard not initialized. Call "
             'noveum_trace.init(api_key="...", project="...", policies=[...]) first, '
             "or pass engine and context explicitly."
         )
-    return resolved_engine, resolved_context
+    return resolved
 
 
 def http_client(
@@ -151,6 +280,7 @@ def http_client(
     context: Optional[PolicyContext] = None,
     *,
     inner: Optional[httpx.BaseTransport] = None,
+    on_unmatched_request: str = "passthrough",
     **kwargs: Any,
 ) -> httpx.Client:
     """Return a sync httpx.Client wired through the Guard transport.
@@ -160,10 +290,18 @@ def http_client(
 
     Explicit form:
         openai.OpenAI(http_client=noveum_trace.guard.http_client(engine, ctx))
+
+    on_unmatched_request: "passthrough" (default, forwards requests that match
+    no ProviderAdapter unguarded — today's behavior) or "block" (return a
+    synthetic 403 instead, for defense-in-depth deployments that want to
+    guarantee nothing bypasses Guard coverage).
     """
     resolved_engine, resolved_context = _resolve(engine, context)
     transport = NoveumTransport(
-        engine=resolved_engine, context=resolved_context, inner=inner
+        engine=resolved_engine,
+        context=resolved_context,
+        inner=inner,
+        on_unmatched_request=on_unmatched_request,
     )
     return httpx.Client(transport=transport, **kwargs)
 
@@ -173,6 +311,7 @@ def async_http_client(
     context: Optional[PolicyContext] = None,
     *,
     inner: Optional[httpx.AsyncBaseTransport] = None,
+    on_unmatched_request: str = "passthrough",
     **kwargs: Any,
 ) -> httpx.AsyncClient:
     """Return an async httpx.AsyncClient wired through the Guard transport.
@@ -182,9 +321,14 @@ def async_http_client(
 
     Explicit form:
         anthropic.AsyncAnthropic(http_client=noveum_trace.guard.async_http_client(engine, ctx))
+
+    See http_client() for on_unmatched_request.
     """
     resolved_engine, resolved_context = _resolve(engine, context)
     transport = NoveumAsyncTransport(
-        engine=resolved_engine, context=resolved_context, inner=inner
+        engine=resolved_engine,
+        context=resolved_context,
+        inner=inner,
+        on_unmatched_request=on_unmatched_request,
     )
     return httpx.AsyncClient(transport=transport, **kwargs)

--- a/src/noveum_trace/guard/transport/sync_transport.py
+++ b/src/noveum_trace/guard/transport/sync_transport.py
@@ -78,10 +78,15 @@ class NoveumTransport(httpx.BaseTransport):
       4. engine.pre_call() → block decision or ran list.
          Block → return synthetic 403 (engine already rolled back).
       5. Forward to inner transport.
-      6. Streaming responses are wrapped in _SyncStreamReconciler, which buffers
-         every chunk and reconciles the reservation when the stream is exhausted
-         or closed. Actual token usage is parsed from SSE events; falls back to
-         release_all() if usage data is absent.
+      6. Streaming, no post-blocking policy attached: wrapped in
+         _SyncStreamReconciler, which buffers every chunk and reconciles the
+         reservation when the stream is exhausted or closed. Actual token
+         usage is parsed from SSE events; falls back to release_all() if
+         usage data is absent.
+      6b. Streaming, a post-blocking policy IS attached: the full response is
+         buffered before any bytes reach the caller (see
+         build_buffered_stream_response) so a post-phase block can actually
+         be enforced instead of only logged.
       7. Non-streaming: read + parse response → ParsedResponse.
       8. engine.post_call() → optional block.
          Block → return synthetic 403.
@@ -94,15 +99,31 @@ class NoveumTransport(httpx.BaseTransport):
         context: PolicyContext,
         inner: Optional[httpx.BaseTransport] = None,
         registry: Optional[AdapterRegistry] = None,
+        on_unmatched_request: str = "passthrough",
     ) -> None:
         self._engine = engine
         self._context = context
         self._inner = inner or httpx.HTTPTransport()
         self._registry = registry or default_registry()
+        self._on_unmatched_request = on_unmatched_request
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         adapter = self._registry.for_request(request)
         if adapter is None:
+            if self._on_unmatched_request == "block":
+                from noveum_trace.guard.transport.helper import (
+                    build_generic_block_response,
+                )
+
+                _log.error(
+                    "NovaGuard: no adapter found for request %s %s — blocking "
+                    "(on_unmatched_request='block')",
+                    request.method,
+                    request.url,
+                )
+                return build_generic_block_response(
+                    f"No NovaGuard adapter for {request.method} {request.url}"
+                )
             _log.error(
                 "NovaGuard: no adapter found for request %s %s — passing through unguarded",
                 request.method,
@@ -125,9 +146,27 @@ class NoveumTransport(httpx.BaseTransport):
             self._engine.release_all(ctx, ran)
             raise
 
-        # Wrap streaming responses so the reservation is reconciled when the
-        # caller finishes consuming the stream (instead of staying inflight forever).
         if parsed_req.stream:
+            if self._engine.has_post_blocking_policies():
+                # A policy that can block post() is attached: a block can't be
+                # enforced on bytes already flushed, so buffer the full
+                # response before releasing anything to the caller.
+                from noveum_trace.guard.transport.helper import (
+                    build_buffered_stream_response,
+                )
+
+                try:
+                    response.read()
+                    return build_buffered_stream_response(
+                        response, request, adapter, self._engine, ctx, ran, parsed_req
+                    )
+                except Exception:
+                    self._engine.release_all(ctx, ran)
+                    raise
+
+            # No post-blocking policy: true streaming, lazy reconcile on consume.
+            # Narrow response.stream's broad type; always SyncByteStream here.
+            assert isinstance(response.stream, httpx.SyncByteStream)
             reconciler = _SyncStreamReconciler(
                 response.stream, self._engine, ctx, ran, parsed_req
             )

--- a/src/noveum_trace/guard/types.py
+++ b/src/noveum_trace/guard/types.py
@@ -37,6 +37,10 @@ class ParsedRequest:
     max_tokens: Optional[int]
     estimated_input_tokens: int
     raw_body: bytes  # original serialized body for rewrite
+    # "chat" (default) | "embeddings" — embeddings requests have no output
+    # tokens and no chat "messages" shape; policies use this to avoid
+    # mis-costing them as chat completions.
+    kind: str = "chat"
 
 
 @dataclass

--- a/src/noveum_trace/utils/llm_utils.py
+++ b/src/noveum_trace/utils/llm_utils.py
@@ -113,12 +113,18 @@ def normalize_model_name(model: str) -> str:
         if model.startswith(prefix):
             model = model[len(prefix) :]
 
+    # Remove Bedrock-style version suffix (e.g. ":0", ":1") first, then the
+    # "-vN" suffix, *before* the date regexes below. Bedrock IDs put the date
+    # in the middle (e.g. "anthropic.claude-3-5-sonnet-20240620-v1:0"), so the
+    # ":0" and "-v1" must be peeled off before the trailing-date regex can see
+    # and strip the "-20240620" — otherwise the date is left in and the name
+    # never matches the registry key.
+    model = re.sub(r":\d+$", "", model)
+    model = re.sub(r"-v\d+(\.\d+)*$", "", model)  # Remove version numbers
+
     # Handle date-based versions
     model = re.sub(r"-\d{8}$", "", model)  # Remove YYYYMMDD
     model = re.sub(r"-\d{4}-\d{2}-\d{2}$", "", model)  # Remove YYYY-MM-DD
-
-    # Handle version numbers at the end
-    model = re.sub(r"-v\d+(\.\d+)*$", "", model)  # Remove version numbers
 
     return model
 

--- a/src/noveum_trace/utils/model_registry.py
+++ b/src/noveum_trace/utils/model_registry.py
@@ -661,6 +661,146 @@ MODEL_REGISTRY: dict[str, ModelInfo] = {
         supports_function_calling=True,
         training_cutoff="2024",
     ),
+    # -----------------------------------------------------------------------
+    # OpenAI Embeddings — no output tokens; verify pricing before relying on
+    # it for billing-critical enforcement, per this file's own pricing caveat.
+    # -----------------------------------------------------------------------
+    "text-embedding-3-small": ModelInfo(
+        provider="openai",
+        name="text-embedding-3-small",
+        context_window=8191,
+        max_output_tokens=0,
+        input_cost_per_1m=0.02,
+        output_cost_per_1m=0.0,
+    ),
+    "text-embedding-3-large": ModelInfo(
+        provider="openai",
+        name="text-embedding-3-large",
+        context_window=8191,
+        max_output_tokens=0,
+        input_cost_per_1m=0.13,
+        output_cost_per_1m=0.0,
+    ),
+    "text-embedding-ada-002": ModelInfo(
+        provider="openai",
+        name="text-embedding-ada-002",
+        context_window=8191,
+        max_output_tokens=0,
+        input_cost_per_1m=0.10,
+        output_cost_per_1m=0.0,
+    ),
+    # -----------------------------------------------------------------------
+    # AWS Bedrock — keyed by the Bedrock model ID as returned by
+    # normalize_model_name() (provider prefix like "anthropic."/"amazon."
+    # is kept since it isn't a slash-separated prefix the normaliser strips).
+    # Bedrock pricing can diverge from the vendor's direct API pricing for
+    # the same underlying model, hence separate provider="bedrock" entries
+    # rather than reusing the direct-API keys above. Verify latest pricing
+    # from AWS Bedrock docs before relying on this for billing-critical
+    # enforcement, per this file's own pricing caveat.
+    # -----------------------------------------------------------------------
+    "anthropic.claude-3-5-sonnet": ModelInfo(
+        provider="bedrock",
+        name="anthropic.claude-3-5-sonnet",
+        context_window=200000,
+        max_output_tokens=8192,
+        input_cost_per_1m=3.00,
+        output_cost_per_1m=15.00,
+        supports_vision=True,
+        supports_function_calling=True,
+    ),
+    "anthropic.claude-3-haiku": ModelInfo(
+        provider="bedrock",
+        name="anthropic.claude-3-haiku",
+        context_window=200000,
+        max_output_tokens=4096,
+        input_cost_per_1m=0.25,
+        output_cost_per_1m=1.25,
+        supports_vision=True,
+        supports_function_calling=True,
+    ),
+    "anthropic.claude-3-opus": ModelInfo(
+        provider="bedrock",
+        name="anthropic.claude-3-opus",
+        context_window=200000,
+        max_output_tokens=4096,
+        input_cost_per_1m=15.00,
+        output_cost_per_1m=75.00,
+        supports_vision=True,
+        supports_function_calling=True,
+    ),
+    "amazon.titan-text-express": ModelInfo(
+        provider="bedrock",
+        name="amazon.titan-text-express",
+        context_window=8192,
+        max_output_tokens=8192,
+        input_cost_per_1m=0.20,
+        output_cost_per_1m=0.60,
+    ),
+    "amazon.titan-text-lite": ModelInfo(
+        provider="bedrock",
+        name="amazon.titan-text-lite",
+        context_window=4096,
+        max_output_tokens=4096,
+        input_cost_per_1m=0.15,
+        output_cost_per_1m=0.20,
+    ),
+    "amazon.titan-embed-text": ModelInfo(
+        provider="bedrock",
+        name="amazon.titan-embed-text",
+        context_window=8192,
+        max_output_tokens=0,
+        input_cost_per_1m=0.02,
+        output_cost_per_1m=0.0,
+    ),
+    "meta.llama3-70b-instruct": ModelInfo(
+        provider="bedrock",
+        name="meta.llama3-70b-instruct",
+        context_window=8192,
+        max_output_tokens=2048,
+        input_cost_per_1m=2.65,
+        output_cost_per_1m=3.50,
+        supports_function_calling=True,
+    ),
+    "meta.llama3-8b-instruct": ModelInfo(
+        provider="bedrock",
+        name="meta.llama3-8b-instruct",
+        context_window=8192,
+        max_output_tokens=2048,
+        input_cost_per_1m=0.30,
+        output_cost_per_1m=0.60,
+        supports_function_calling=True,
+    ),
+    # Both the 2402 and 2407 Mistral Large snapshots ship on Bedrock and share
+    # the same pricing, so key both — normalize_model_name() keeps the 4-digit
+    # "-2402"/"-2407" (it only strips 8-digit dates), so one entry can't cover both.
+    "mistral.mistral-large-2402": ModelInfo(
+        provider="bedrock",
+        name="mistral.mistral-large-2402",
+        context_window=128000,
+        max_output_tokens=8192,
+        input_cost_per_1m=4.00,
+        output_cost_per_1m=12.00,
+        supports_function_calling=True,
+    ),
+    "mistral.mistral-large-2407": ModelInfo(
+        provider="bedrock",
+        name="mistral.mistral-large-2407",
+        context_window=128000,
+        max_output_tokens=8192,
+        input_cost_per_1m=4.00,
+        output_cost_per_1m=12.00,
+        supports_function_calling=True,
+    ),
+    "cohere.command-r-plus": ModelInfo(
+        provider="bedrock",
+        name="cohere.command-r-plus",
+        context_window=128000,
+        max_output_tokens=4096,
+        input_cost_per_1m=3.00,
+        output_cost_per_1m=15.00,
+        supports_function_calling=True,
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/guard/test_bedrock.py
+++ b/tests/integration/guard/test_bedrock.py
@@ -1,0 +1,963 @@
+"""Integration tests for the Bedrock guard integration / instrument_bedrock().
+
+instrument_bedrock() installs a single process-wide monkeypatch of
+``botocore.client.BaseClient._make_api_call``, filtered internally to
+bedrock-runtime clients. One function call frame spans pre-call blocking,
+the real call, and post-call reconciliation — no event-hook handoff, and no
+dependency on any particular client instance being explicitly wired.
+
+Direct-handler tests exercise parsing/reconciliation logic without a live
+boto3 client. The TestGlobalWiring / TestInstrumentBedrockWiring classes
+prove the end-to-end flow (patch installed -> real call -> block/reconcile)
+using botocore.stub.Stubber against a real boto3 client with dummy
+credentials — including a client that was never explicitly instrumented,
+which is the scenario the old per-client event-hook design could not cover.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+
+import boto3
+import botocore.config
+import botocore.response
+import pytest
+from botocore.exceptions import ClientError
+from botocore.stub import Stubber
+
+from noveum_trace.guard.api_client import GuardAPIClient
+from noveum_trace.guard.decision import PolicyDecision
+from noveum_trace.guard.engine import PolicyEngine
+from noveum_trace.guard.exceptions import NoveumGuardBlocked
+from noveum_trace.guard.integrations.bedrock import (
+    _BedrockStreamReconciler,
+    _is_embeddings_model,
+    _parse_embeddings_input,
+    _parse_embeddings_usage,
+    _parse_invoke_model_body,
+    _parse_invoke_model_usage,
+    _parse_request,
+    _reconcile_non_streaming,
+    _uninstrument_bedrock_for_tests,
+    instrument_bedrock,
+)
+from noveum_trace.guard.policies.base import AbstractPolicy
+from noveum_trace.guard.policies.cost_cap import CostCapPolicy
+from noveum_trace.guard.types import EnforcementMode, Phase, PolicyContext
+
+# ---------------------------------------------------------------------------
+# Teardown — the patch is process-wide, so it must never leak across tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_bedrock_patch():
+    yield
+    _uninstrument_bedrock_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(project_id: str = "test-proj") -> PolicyContext:
+    return PolicyContext(
+        project_id=project_id,
+        organization_id=None,
+        environment="test",
+        trace_id=None,
+        span_id=None,
+        call_id=str(uuid.uuid4()),
+    )
+
+
+def _converse_params(
+    model_id: str = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+) -> dict:
+    return {
+        "modelId": model_id,
+        "messages": [{"role": "user", "content": [{"text": "Hello!"}]}],
+        "inferenceConfig": {"maxTokens": 100},
+    }
+
+
+def _invoke_model_params(
+    model_id: str = "anthropic.claude-3-5-sonnet-20241022-v2:0",
+) -> dict:
+    body = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 100,
+        "messages": [{"role": "user", "content": "Hello!"}],
+    }
+    return {
+        "modelId": model_id,
+        "body": json.dumps(body).encode(),
+        "contentType": "application/json",
+    }
+
+
+def _streaming_body(payload: dict) -> botocore.response.StreamingBody:
+    raw = json.dumps(payload).encode()
+    return botocore.response.StreamingBody(io.BytesIO(raw), len(raw))
+
+
+def _client() -> boto3.client:
+    return boto3.client(
+        "bedrock-runtime",
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+
+
+class _AlwaysBlockPolicy(AbstractPolicy):
+    name = "always_block"
+
+    def pre(self, parsed, ctx, deps) -> PolicyDecision:
+        return PolicyDecision.block(self.name, Phase.pre, reason="blocked by test")
+
+
+class _BlockInPostPolicy(AbstractPolicy):
+    name = "block_in_post"
+
+    def pre(self, parsed, ctx, deps) -> PolicyDecision:
+        return PolicyDecision.allow(self.name, Phase.pre)
+
+    def post(self, resp, ctx, decision, deps) -> PolicyDecision:
+        return PolicyDecision.block(self.name, Phase.post, reason="post block")
+
+
+def _engine_with(*policies: AbstractPolicy) -> PolicyEngine:
+    api = GuardAPIClient()
+    engine = PolicyEngine(api_client=api)
+    for policy in policies:
+        engine.attach(policy)
+    return engine
+
+
+def _cost_cap(max_usd: float = 100.0, project_id: str = "test-proj") -> CostCapPolicy:
+    return CostCapPolicy(
+        max_usd=max_usd, mode=EnforcementMode.strict, project_id=project_id
+    )
+
+
+_APPLY_GUARDRAIL_PARAMS = {
+    "guardrailIdentifier": "test-guardrail",
+    "guardrailVersion": "DRAFT",
+    "source": "INPUT",
+    "content": [{"text": {"text": "hello"}}],
+}
+
+_APPLY_GUARDRAIL_RESPONSE = {
+    "usage": {
+        "topicPolicyUnits": 0,
+        "contentPolicyUnits": 0,
+        "wordPolicyUnits": 0,
+        "sensitiveInformationPolicyUnits": 0,
+        "sensitiveInformationPolicyFreeUnits": 0,
+        "contextualGroundingPolicyUnits": 0,
+    },
+    "action": "NONE",
+    "outputs": [],
+    "assessments": [],
+}
+
+
+# ---------------------------------------------------------------------------
+# Global wiring via botocore.stub.Stubber — instrument_bedrock() with no
+# client argument, exercised through a real (Stubber-mocked) boto3 client.
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalWiring:
+    def test_converse_reconciles_cost_on_success(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(engine=engine, context=_ctx("test-proj"))
+
+        stubber.add_response(
+            "converse",
+            {
+                "output": {
+                    "message": {"role": "assistant", "content": [{"text": "hi"}]}
+                },
+                "usage": {"inputTokens": 20, "outputTokens": 10, "totalTokens": 30},
+                "stopReason": "end_turn",
+                "metrics": {"latencyMs": 100},
+            },
+            _converse_params(),
+        )
+        stubber.activate()
+
+        response = client.converse(**_converse_params())
+        assert response["usage"]["outputTokens"] == 10
+        assert api.current_spend("test-proj") >= 0
+
+    def test_unknown_operation_is_ignored(self):
+        # ApplyGuardrail isn't in _KNOWN_OPERATIONS — an always-block policy
+        # must not affect it.
+        client = _client()
+        stubber = Stubber(client)
+        engine = _engine_with(_AlwaysBlockPolicy())
+        instrument_bedrock(engine=engine, context=_ctx())
+
+        stubber.add_response(
+            "apply_guardrail", _APPLY_GUARDRAIL_RESPONSE, _APPLY_GUARDRAIL_PARAMS
+        )
+        stubber.activate()
+
+        response = client.apply_guardrail(**_APPLY_GUARDRAIL_PARAMS)
+        assert response["action"] == "NONE"
+
+    def test_raises_guard_blocked_on_pre_block(self):
+        client = _client()
+        stubber = Stubber(client)  # no add_response — call must never reach it
+        engine = _engine_with(_AlwaysBlockPolicy())
+        instrument_bedrock(engine=engine, context=_ctx())
+        stubber.activate()
+
+        with pytest.raises(NoveumGuardBlocked) as exc_info:
+            client.converse(**_converse_params())
+
+        assert exc_info.value.policy_name == "always_block"
+
+    def test_budget_rolled_back_after_block(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        cost_cap = _cost_cap()
+        cost_cap.priority = 10
+        engine.attach(cost_cap)
+        blocker = _AlwaysBlockPolicy()
+        blocker.priority = 20
+        engine.attach(blocker)
+        instrument_bedrock(engine=engine, context=_ctx("test-proj"))
+        stubber.activate()
+
+        with pytest.raises(NoveumGuardBlocked):
+            client.converse(**_converse_params())
+
+        assert api.current_spend("test-proj") == pytest.approx(0.0)
+
+    def test_raises_guard_blocked_on_post_block(self):
+        client = _client()
+        stubber = Stubber(client)
+        engine = _engine_with(_BlockInPostPolicy())
+        instrument_bedrock(engine=engine, context=_ctx())
+
+        stubber.add_response(
+            "converse",
+            {
+                "output": {
+                    "message": {"role": "assistant", "content": [{"text": "hi"}]}
+                },
+                "usage": {"inputTokens": 5, "outputTokens": 5, "totalTokens": 10},
+                "stopReason": "end_turn",
+                "metrics": {"latencyMs": 100},
+            },
+            _converse_params(),
+        )
+        stubber.activate()
+
+        with pytest.raises(NoveumGuardBlocked):
+            client.converse(**_converse_params())
+
+    def test_converse_missing_usage_releases_instead_of_guessing(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(engine=engine, context=_ctx("test-proj"))
+
+        stubber.add_response(
+            "converse",
+            {
+                "output": {
+                    "message": {"role": "assistant", "content": [{"text": "hi"}]}
+                },
+                "usage": {"inputTokens": 0, "outputTokens": 0, "totalTokens": 0},
+                "stopReason": "end_turn",
+                "metrics": {"latencyMs": 100},
+            },
+            _converse_params(),
+        )
+        stubber.activate()
+
+        client.converse(**_converse_params())
+        # Zero usage is still "usage present" (unlike InvokeModel's fully
+        # absent case below) — spend reflects the (zero) reported tokens.
+        assert api.current_spend("test-proj") >= 0
+
+    def test_invoke_model_reconciles_and_body_still_readable(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(engine=engine, context=_ctx("test-proj"))
+
+        resp_payload = {
+            "usage": {"input_tokens": 20, "output_tokens": 10},
+            "content": [{"type": "text", "text": "hello"}],
+        }
+        stubber.add_response(
+            "invoke_model",
+            {"body": _streaming_body(resp_payload), "contentType": "application/json"},
+            _invoke_model_params(),
+        )
+        stubber.activate()
+
+        response = client.invoke_model(**_invoke_model_params())
+        assert json.loads(response["body"].read()) == resp_payload
+        assert api.current_spend("test-proj") > 0
+
+    def test_invoke_model_unrecognized_family_releases_instead_of_guessing(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(engine=engine, context=_ctx("test-proj"))
+
+        params = _invoke_model_params(model_id="unknown-vendor.some-model-v1:0")
+        stubber.add_response(
+            "invoke_model",
+            {
+                "body": _streaming_body({"some": "unrecognized shape"}),
+                "contentType": "application/json",
+            },
+            params,
+        )
+        stubber.activate()
+
+        client.invoke_model(**params)
+        assert api.current_spend("test-proj") == pytest.approx(0.0)
+
+    def test_after_call_error_releases_reservation(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(engine=engine, context=_ctx("test-proj"))
+
+        stubber.add_client_error("converse", service_error_code="ValidationException")
+        stubber.activate()
+
+        with pytest.raises(ClientError):
+            client.converse(**_converse_params())
+
+        assert api.current_spend("test-proj") == pytest.approx(0.0)
+
+    def test_second_client_from_independent_session_is_also_guarded(self):
+        # The scenario the old per-client event-hook design couldn't cover:
+        # a client never passed to instrument_bedrock(), built from its own
+        # boto3.Session(), is still guarded by the process-wide patch.
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(engine=engine, context=_ctx("test-proj"))
+
+        client = boto3.Session().client(
+            "bedrock-runtime",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        )
+        stubber = Stubber(client)
+        resp_payload = {
+            "usage": {"input_tokens": 20, "output_tokens": 10},
+            "content": [{"type": "text", "text": "hello"}],
+        }
+        stubber.add_response(
+            "invoke_model",
+            {"body": _streaming_body(resp_payload), "contentType": "application/json"},
+            _invoke_model_params(),
+        )
+        stubber.activate()
+
+        response = client.invoke_model(**_invoke_model_params())
+        assert json.loads(response["body"].read()) == resp_payload
+        assert api.current_spend("test-proj") > 0
+
+    def test_non_bedrock_client_is_unaffected(self):
+        # Any other botocore client goes through the same patched
+        # _make_api_call — confirm it passes through untouched even with an
+        # always-block policy configured globally.
+        instrument_bedrock(engine=_engine_with(_AlwaysBlockPolicy()), context=_ctx())
+
+        sts = boto3.client(
+            "sts",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+        )
+        stubber = Stubber(sts)
+        stubber.add_response(
+            "get_caller_identity",
+            {
+                "UserId": "AIDA",
+                "Account": "123456789012",
+                "Arn": "arn:aws:iam::123456789012:user/test",
+            },
+            {},
+        )
+        stubber.activate()
+
+        response = sts.get_caller_identity()
+        assert response["Account"] == "123456789012"
+
+
+# ---------------------------------------------------------------------------
+# Streaming reconciler — unaffected by the wiring redesign, still constructed
+# directly with a module-level _parse_request() instead of an interceptor
+# instance method.
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingReconciler:
+    def test_converse_stream_reconciles_from_metadata_event(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        ctx = _ctx("test-proj")
+        parsed_req = _parse_request("ConverseStream", _converse_params())
+        block, ran = engine.pre_call(parsed_req, ctx)
+        assert block is None
+
+        events = [
+            {"messageStart": {"role": "assistant"}},
+            {"contentBlockDelta": {"delta": {"text": "hi"}}},
+            {"metadata": {"usage": {"inputTokens": 15, "outputTokens": 8}}},
+        ]
+        reconciler = _BedrockStreamReconciler(
+            events, engine, ctx, ran, parsed_req, "ConverseStream"
+        )
+        list(reconciler)  # fully consume
+
+        assert api.current_spend("test-proj") >= 0
+
+    def test_invoke_model_stream_reconciles_from_invocation_metrics(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        ctx = _ctx("test-proj")
+        parsed_req = _parse_request(
+            "InvokeModelWithResponseStream", _invoke_model_params()
+        )
+        block, ran = engine.pre_call(parsed_req, ctx)
+        assert block is None
+
+        final_chunk = json.dumps(
+            {
+                "amazon-bedrock-invocationMetrics": {
+                    "inputTokenCount": 12,
+                    "outputTokenCount": 6,
+                }
+            }
+        ).encode()
+        events = [
+            {"chunk": {"bytes": json.dumps({"type": "content_block_delta"}).encode()}},
+            {"chunk": {"bytes": final_chunk}},
+        ]
+        reconciler = _BedrockStreamReconciler(
+            events, engine, ctx, ran, parsed_req, "InvokeModelWithResponseStream"
+        )
+        list(reconciler)
+
+        assert api.current_spend("test-proj") >= 0
+
+    def test_no_usage_metrics_releases_instead_of_guessing(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        ctx = _ctx("test-proj")
+        parsed_req = _parse_request("ConverseStream", _converse_params())
+        block, ran = engine.pre_call(parsed_req, ctx)
+        assert block is None
+
+        reconciler = _BedrockStreamReconciler(
+            [{"messageStart": {}}], engine, ctx, ran, parsed_req, "ConverseStream"
+        )
+        list(reconciler)
+
+        assert api.current_spend("test-proj") == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Buffered stream enforcement — when a post-blocking policy is attached, the
+# stream is fully buffered and post_call runs BEFORE any event is yielded, so a
+# post-phase block is actually enforced (raises) instead of only logged. Mirrors
+# the httpx transport's build_buffered_stream_response path.
+# ---------------------------------------------------------------------------
+
+
+class _BlockInPostStreaming(AbstractPolicy):
+    name = "block_in_post_streaming"
+    can_block_post = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_text: str | None = None
+
+    def pre(self, parsed, ctx, deps) -> PolicyDecision:
+        return PolicyDecision.allow(self.name, Phase.pre)
+
+    def post(self, resp, ctx, decision, deps) -> PolicyDecision:
+        self.seen_text = resp.text
+        return PolicyDecision.block(self.name, Phase.post, reason="post block")
+
+
+class _ObservePostStreaming(AbstractPolicy):
+    """Post-blocking-capable policy that never actually blocks; records text."""
+
+    name = "observe_post_streaming"
+    can_block_post = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_text: str | None = None
+
+    def pre(self, parsed, ctx, deps) -> PolicyDecision:
+        return PolicyDecision.allow(self.name, Phase.pre)
+
+    def post(self, resp, ctx, decision, deps) -> PolicyDecision:
+        self.seen_text = resp.text
+        return PolicyDecision.allow(self.name, Phase.post)
+
+
+class TestBufferedStreamEnforcement:
+    def _run(self, operation_name, events, policy):
+        from noveum_trace.guard.integrations.bedrock import _wrap_streaming_result
+
+        engine = _engine_with(policy)
+        ctx = _ctx("test-proj")
+        parsed_req = _parse_request(
+            operation_name,
+            (
+                _converse_params()
+                if operation_name == "ConverseStream"
+                else _invoke_model_params()
+            ),
+        )
+        block, ran = engine.pre_call(parsed_req, ctx)
+        assert block is None
+        key = "stream" if operation_name == "ConverseStream" else "body"
+        return _wrap_streaming_result(
+            {key: iter(events)}, engine, ctx, ran, parsed_req, operation_name
+        )
+
+    def test_converse_stream_post_block_raises_before_yield(self):
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "leaked"}}},
+            {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 3}}},
+        ]
+        policy = _BlockInPostStreaming()
+        with pytest.raises(NoveumGuardBlocked):
+            self._run("ConverseStream", events, policy)
+        # The assembled completion text reached post() before any event escaped.
+        assert policy.seen_text == "leaked"
+
+    def test_converse_stream_allowed_replays_events(self):
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "hi there"}}},
+            {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 3}}},
+        ]
+        policy = _ObservePostStreaming()
+        parsed = self._run("ConverseStream", events, policy)
+        # Caller still iterates every original event (buffered, then replayed).
+        assert list(parsed["stream"]) == events
+        assert policy.seen_text == "hi there"
+
+    def test_invoke_model_stream_post_block_raises_before_yield(self):
+        final_chunk = json.dumps(
+            {
+                "amazon-bedrock-invocationMetrics": {
+                    "inputTokenCount": 7,
+                    "outputTokenCount": 4,
+                }
+            }
+        ).encode()
+        events = [
+            {
+                "chunk": {
+                    "bytes": json.dumps(
+                        {"type": "content_block_delta", "delta": {"text": "leaked"}}
+                    ).encode()
+                }
+            },
+            {"chunk": {"bytes": final_chunk}},
+        ]
+        policy = _BlockInPostStreaming()
+        with pytest.raises(NoveumGuardBlocked):
+            self._run("InvokeModelWithResponseStream", events, policy)
+        assert policy.seen_text == "leaked"
+
+    def test_stream_drain_error_releases_reservation(self):
+        from noveum_trace.guard.integrations.bedrock import _wrap_streaming_result
+
+        # A cost-cap reservation is taken in pre(); if buffering the stream
+        # raises before post_call reconciles, the reservation must be released
+        # rather than leaked inflight.
+        cost_cap = _cost_cap()
+        engine = _engine_with(cost_cap, _ObservePostStreaming())
+        ctx = _ctx("test-proj")
+        parsed_req = _parse_request("ConverseStream", _converse_params())
+        block, ran = engine.pre_call(parsed_req, ctx)
+        assert block is None
+        assert engine._api_client.inflight_count() == 1  # reserved
+
+        def _boom():
+            yield {"contentBlockDelta": {"delta": {"text": "partial"}}}
+            raise RuntimeError("stream dropped")
+
+        with pytest.raises(RuntimeError, match="stream dropped"):
+            _wrap_streaming_result(
+                {"stream": _boom()}, engine, ctx, ran, parsed_req, "ConverseStream"
+            )
+
+        assert engine._api_client.inflight_count() == 0  # released, not leaked
+        assert engine._api_client.current_spend("test-proj") == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Bedrock embeddings models (Titan Embed, Cohere Embed) — routed through
+# InvokeModel but parsed as kind="embeddings": input-only reservation (no
+# chat-style output allowance) and output_tokens forced to 0 on reconcile.
+# ---------------------------------------------------------------------------
+
+
+class _RecordPostPolicy(AbstractPolicy):
+    name = "record_post"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.resp = None
+
+    def pre(self, parsed, ctx, deps) -> PolicyDecision:
+        return PolicyDecision.allow(self.name, Phase.pre)
+
+    def post(self, resp, ctx, decision, deps) -> PolicyDecision:
+        self.resp = resp
+        return PolicyDecision.allow(self.name, Phase.post)
+
+
+def _invoke_embed_params(model_id: str, body: dict) -> dict:
+    return {"modelId": model_id, "body": json.dumps(body).encode()}
+
+
+class TestBedrockEmbeddings:
+    def test_is_embeddings_model(self):
+        assert _is_embeddings_model("amazon.titan-embed-text-v2:0")
+        assert _is_embeddings_model("cohere.embed-english-v3")
+        assert not _is_embeddings_model("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        assert not _is_embeddings_model("amazon.titan-text-express-v1")
+
+    def test_parse_embeddings_input_titan(self):
+        assert (
+            _parse_embeddings_input(
+                "amazon.titan-embed-text-v2:0", {"inputText": "hello world"}
+            )
+            == "hello world"
+        )
+
+    def test_parse_embeddings_input_cohere_joins_texts(self):
+        assert (
+            _parse_embeddings_input(
+                "cohere.embed-english-v3", {"texts": ["one", "two"]}
+            )
+            == "one two"
+        )
+
+    def test_parse_embeddings_usage_titan_reports_input(self):
+        assert (
+            _parse_embeddings_usage(
+                "amazon.titan-embed-text-v2:0", {"inputTextTokenCount": 12}
+            )
+            == 12
+        )
+
+    def test_parse_embeddings_usage_cohere_returns_none(self):
+        # Cohere embed responses carry no token count.
+        assert (
+            _parse_embeddings_usage("cohere.embed-english-v3", {"embeddings": [[0.1]]})
+            is None
+        )
+
+    def test_titan_embed_request_is_kind_embeddings(self):
+        parsed = _parse_request(
+            "InvokeModel",
+            _invoke_embed_params(
+                "amazon.titan-embed-text-v2:0", {"inputText": "hello world"}
+            ),
+        )
+        assert parsed.kind == "embeddings"
+        assert parsed.max_tokens is None
+        assert parsed.estimated_input_tokens > 0
+
+    def test_cohere_embed_request_is_kind_embeddings(self):
+        parsed = _parse_request(
+            "InvokeModel",
+            _invoke_embed_params(
+                "cohere.embed-english-v3",
+                {"texts": ["hello world"], "input_type": "search_document"},
+            ),
+        )
+        assert parsed.kind == "embeddings"
+        assert parsed.estimated_input_tokens > 0
+
+    def test_titan_embed_reconciles_with_exact_input_and_zero_output(self):
+        rec = _RecordPostPolicy()
+        engine = _engine_with(rec)
+        ctx = _ctx("test-proj")
+        parsed_req = _parse_request(
+            "InvokeModel",
+            _invoke_embed_params(
+                "amazon.titan-embed-text-v2:0", {"inputText": "hello world"}
+            ),
+        )
+        block, ran = engine.pre_call(parsed_req, ctx)
+        assert block is None
+
+        resp = {
+            "body": _streaming_body(
+                {"embedding": [0.1, 0.2], "inputTextTokenCount": 12}
+            )
+        }
+        _reconcile_non_streaming("InvokeModel", parsed_req, resp, engine, ctx, ran)
+
+        # Exact input from the response; embeddings never produce output tokens.
+        assert rec.resp is not None
+        assert rec.resp.input_tokens == 12
+        assert rec.resp.output_tokens == 0
+        # The caller's body is still readable after our peek.
+        assert json.loads(resp["body"].read())["inputTextTokenCount"] == 12
+
+    def test_cohere_embed_falls_back_to_estimate_instead_of_releasing(self):
+        rec = _RecordPostPolicy()
+        engine = _engine_with(rec)
+        ctx = _ctx("test-proj")
+        parsed_req = _parse_request(
+            "InvokeModel",
+            _invoke_embed_params(
+                "cohere.embed-english-v3", {"texts": ["hello world foo bar"]}
+            ),
+        )
+        assert parsed_req.estimated_input_tokens > 0
+        block, ran = engine.pre_call(parsed_req, ctx)
+        assert block is None
+
+        # Cohere embed response has no token count — reconcile must fall back to
+        # the request-time estimate rather than releasing (which would record
+        # nothing against the cap).
+        resp = {"body": _streaming_body({"embeddings": [[0.1, 0.2]], "id": "x"})}
+        _reconcile_non_streaming("InvokeModel", parsed_req, resp, engine, ctx, ran)
+
+        assert rec.resp is not None
+        assert rec.resp.input_tokens == parsed_req.estimated_input_tokens
+        assert rec.resp.output_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Request/usage body parsing helpers — pure functions, unaffected.
+# ---------------------------------------------------------------------------
+
+
+class TestParseInvokeModelBody:
+    def test_anthropic_family_extracts_messages(self):
+        messages = [{"role": "user", "content": "hi"}]
+        content, max_tokens = _parse_invoke_model_body(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            {"messages": messages, "max_tokens": 256},
+        )
+        assert content == messages
+        assert max_tokens == 256
+
+    def test_titan_family_extracts_input_text(self):
+        content, max_tokens = _parse_invoke_model_body(
+            "amazon.titan-text-express-v1",
+            {"inputText": "hello", "textGenerationConfig": {"maxTokenCount": 512}},
+        )
+        assert content == "hello"
+        assert max_tokens == 512
+
+    def test_unrecognized_family_falls_back_to_json(self):
+        content, max_tokens = _parse_invoke_model_body(
+            "some.unknown-v1", {"foo": "bar"}
+        )
+        assert "foo" in content
+        assert max_tokens is None
+
+
+class TestParseInvokeModelUsage:
+    def test_anthropic_family(self):
+        input_tokens, output_tokens = _parse_invoke_model_usage(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            {"usage": {"input_tokens": 10, "output_tokens": 5}},
+        )
+        assert (input_tokens, output_tokens) == (10, 5)
+
+    def test_titan_family(self):
+        input_tokens, output_tokens = _parse_invoke_model_usage(
+            "amazon.titan-text-express-v1",
+            {"inputTextTokenCount": 8, "results": [{"tokenCount": 4}]},
+        )
+        assert (input_tokens, output_tokens) == (8, 4)
+
+    def test_unrecognized_family_returns_none(self):
+        assert _parse_invoke_model_usage("some.unknown-v1", {"foo": "bar"}) == (
+            None,
+            None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-instance override — instrument_bedrock(client, engine=, context=) binds
+# ONE specific client to a distinct engine/context instead of the
+# process-wide default. Still installs the global patch under the hood.
+# ---------------------------------------------------------------------------
+
+
+class TestInstrumentBedrockWiring:
+    def test_invoke_model_reconciles_and_body_readable(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        ctx = _ctx("test-proj")
+        instrument_bedrock(client, engine=engine, context=ctx)
+
+        resp_payload = {
+            "usage": {"input_tokens": 20, "output_tokens": 10},
+            "content": [{"type": "text", "text": "hello"}],
+        }
+        stubber.add_response(
+            "invoke_model",
+            {"body": _streaming_body(resp_payload), "contentType": "application/json"},
+            _invoke_model_params(),
+        )
+        stubber.activate()
+
+        response = client.invoke_model(**_invoke_model_params())
+        assert json.loads(response["body"].read()) == resp_payload
+        assert api.current_spend("test-proj") > 0
+
+    def test_converse_reconciles(self):
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        ctx = _ctx("test-proj")
+        instrument_bedrock(client, engine=engine, context=ctx)
+
+        stubber.add_response(
+            "converse",
+            {
+                "output": {
+                    "message": {"role": "assistant", "content": [{"text": "hi"}]}
+                },
+                "usage": {"inputTokens": 12, "outputTokens": 7, "totalTokens": 19},
+                "stopReason": "end_turn",
+                "metrics": {"latencyMs": 100},
+            },
+            _converse_params(),
+        )
+        stubber.activate()
+
+        response = client.converse(**_converse_params())
+        assert response["usage"]["outputTokens"] == 7
+        assert api.current_spend("test-proj") > 0
+
+    def test_blocking_policy_prevents_call(self):
+        # Previously worked around with a tight connect_timeout because
+        # Stubber.activate() uses register_first on before-parameter-build,
+        # always pre-empting an event-based interceptor regardless of
+        # registration order. Patching _make_api_call itself sidesteps that
+        # entirely: our wrapper raises before the real (Stubber-instrumented)
+        # _make_api_call body — and hence before any of Stubber's own event
+        # hooks — ever runs, so a plain Stubber (with no response queued)
+        # works and proves the call never reaches the network.
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_AlwaysBlockPolicy())
+        ctx = _ctx("test-proj")
+        instrument_bedrock(client, engine=engine, context=ctx)
+        stubber.activate()
+
+        with pytest.raises(NoveumGuardBlocked):
+            client.converse(**_converse_params())
+
+    def test_client_override_takes_precedence_over_global_default(self):
+        # A client with its own override must use ITS engine, not whatever
+        # instrument_bedrock() set as the process-wide default.
+        instrument_bedrock(engine=_engine_with(_AlwaysBlockPolicy()), context=_ctx())
+
+        client = _client()
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(client, engine=engine, context=_ctx("test-proj"))
+
+        stubber.add_response(
+            "converse",
+            {
+                "output": {
+                    "message": {"role": "assistant", "content": [{"text": "hi"}]}
+                },
+                "usage": {"inputTokens": 5, "outputTokens": 5, "totalTokens": 10},
+                "stopReason": "end_turn",
+                "metrics": {"latencyMs": 100},
+            },
+            _converse_params(),
+        )
+        stubber.activate()
+
+        # Must not raise — this client's own override allows the call.
+        client.converse(**_converse_params())
+        assert api.current_spend("test-proj") > 0
+
+    def test_config_botocore_config_still_applies(self):
+        # Sanity check that instrumentation doesn't interfere with normal
+        # client configuration (e.g. a custom botocore.config.Config).
+        client = boto3.client(
+            "bedrock-runtime",
+            region_name="us-east-1",
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            config=botocore.config.Config(retries={"max_attempts": 0}),
+        )
+        stubber = Stubber(client)
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(_cost_cap())
+        instrument_bedrock(client, engine=engine, context=_ctx("test-proj"))
+
+        stubber.add_response(
+            "converse",
+            {
+                "output": {
+                    "message": {"role": "assistant", "content": [{"text": "hi"}]}
+                },
+                "usage": {"inputTokens": 5, "outputTokens": 5, "totalTokens": 10},
+                "stopReason": "end_turn",
+                "metrics": {"latencyMs": 100},
+            },
+            _converse_params(),
+        )
+        stubber.activate()
+
+        client.converse(**_converse_params())
+        assert api.current_spend("test-proj") > 0

--- a/tests/unit/guard/test_adapters.py
+++ b/tests/unit/guard/test_adapters.py
@@ -201,6 +201,82 @@ class TestOpenAIAdapterParseResponse:
 
 
 # ---------------------------------------------------------------------------
+# OpenAIAdapter — embeddings (P2.1)
+# ---------------------------------------------------------------------------
+
+
+def _openai_embeddings_request(body: dict | None = None) -> httpx.Request:
+    payload = body or {
+        "model": "text-embedding-3-small",
+        "input": "hello world, this is a fairly long embeddings input",
+    }
+    return httpx.Request(
+        "POST",
+        "https://api.openai.com/v1/embeddings",
+        content=json.dumps(payload).encode(),
+        headers={"content-type": "application/json"},
+    )
+
+
+class TestOpenAIAdapterEmbeddings:
+    def test_parse_request_marks_kind_embeddings(self):
+        adapter = OpenAIAdapter()
+        parsed = adapter.parse_request(_openai_embeddings_request())
+        assert parsed.kind == "embeddings"
+
+    def test_parse_request_messages_empty(self):
+        adapter = OpenAIAdapter()
+        parsed = adapter.parse_request(_openai_embeddings_request())
+        assert parsed.messages == []
+
+    def test_parse_request_estimates_tokens_from_input_not_zero(self):
+        adapter = OpenAIAdapter()
+        parsed = adapter.parse_request(_openai_embeddings_request())
+        # A non-trivial "input" string must not collapse to a near-zero
+        # estimate the way chat-shaped parsing (empty messages) would.
+        assert parsed.estimated_input_tokens > 1
+
+    def test_parse_request_handles_list_input(self):
+        adapter = OpenAIAdapter()
+        req = _openai_embeddings_request(
+            {
+                "model": "text-embedding-3-small",
+                "input": ["first string", "second string here"],
+            }
+        )
+        parsed = adapter.parse_request(req)
+        assert parsed.kind == "embeddings"
+        assert parsed.estimated_input_tokens > 1
+
+    def test_parse_request_chat_body_unaffected(self):
+        """A normal chat body must still parse as kind="chat"."""
+        adapter = OpenAIAdapter()
+        parsed = adapter.parse_request(_openai_request())
+        assert parsed.kind == "chat"
+
+    def test_parse_response_output_tokens_zero(self):
+        adapter = OpenAIAdapter()
+        body = {
+            "object": "list",
+            "model": "text-embedding-3-small",
+            "data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+            "usage": {"prompt_tokens": 12, "total_tokens": 12},
+        }
+        resp = httpx.Response(200, content=json.dumps(body).encode())
+        parsed = adapter.parse_response(_openai_embeddings_request(), resp)
+        assert parsed.output_tokens == 0
+        assert parsed.input_tokens == 12
+        assert parsed.text is None
+
+    def test_parse_response_chat_body_unaffected(self):
+        """A normal chat response must still extract completion_tokens."""
+        adapter = OpenAIAdapter()
+        resp = httpx.Response(200, content=_openai_response_body())
+        parsed = adapter.parse_response(_openai_request(), resp)
+        assert parsed.output_tokens == 20
+
+
+# ---------------------------------------------------------------------------
 # OpenAIAdapter — synthetic_block_response
 # ---------------------------------------------------------------------------
 
@@ -434,3 +510,35 @@ class TestAdapterRegistry:
         registry.register(adapter)
         req = httpx.Request("POST", "https://custom.example.com/v1/chat", content=b"{}")
         assert registry.for_request(req) is adapter
+
+    def test_provider_names_lists_registered_adapters(self):
+        registry = AdapterRegistry([OpenAIAdapter(), AnthropicAdapter()])
+        assert set(registry.provider_names()) == {"openai", "anthropic"}
+
+
+# ---------------------------------------------------------------------------
+# supported_providers() — coverage introspection (P2.2)
+# ---------------------------------------------------------------------------
+
+
+class TestSupportedProviders:
+    def test_returns_openai_and_anthropic(self):
+        import noveum_trace.guard as guard
+
+        providers = guard.supported_providers()
+        assert "openai" in providers
+        assert "anthropic" in providers
+
+    def test_includes_bedrock_via_interceptor(self):
+        """Bedrock is covered via instrument_bedrock(), not the httpx registry —
+        see supported_providers()'s docstring for the distinction."""
+        import noveum_trace.guard as guard
+
+        providers = guard.supported_providers()
+        assert "bedrock" in providers
+
+    def test_does_not_include_vertex(self):
+        import noveum_trace.guard as guard
+
+        providers = guard.supported_providers()
+        assert "vertex" not in providers

--- a/tests/unit/guard/test_api_client.py
+++ b/tests/unit/guard/test_api_client.py
@@ -3,9 +3,11 @@
 import threading
 import uuid
 
+import httpx
 import pytest
 
 from noveum_trace.guard.api_client import GuardAPIClient
+from noveum_trace.guard.exceptions import GuardBackendUnavailable
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -178,6 +180,82 @@ class TestReset:
 # ---------------------------------------------------------------------------
 # Thread safety — 100 concurrent reservations
 # ---------------------------------------------------------------------------
+
+
+class _FakeHTTPResponse:
+    def __init__(self, status_code: int, json_data=None):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def json(self):
+        return self._json_data
+
+
+class _FakeHTTPClient:
+    """Stand-in for httpx.Client, injected via monkeypatch."""
+
+    def __init__(self, *, response=None, raise_exc=None):
+        self._response = response
+        self._raise_exc = raise_exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def get(self, url, headers=None):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# fetch_remote_policies() — stub mode vs. real-backend failure handling
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRemotePolicies:
+    def test_no_api_key_returns_empty_list(self):
+        """Stub mode (no api_key) with nothing stored — legitimate silent case."""
+        api = GuardAPIClient()
+        assert api.fetch_remote_policies("proj") == []
+
+    def test_no_api_key_returns_stored_config(self):
+        api = GuardAPIClient()
+        api.set_policy_config("proj", {"type": "cost_cap", "max_usd": 10.0})
+        result = api.fetch_remote_policies("proj")
+        assert result == [{"type": "cost_cap", "max_usd": 10.0}]
+
+    def test_real_backend_success_returns_policies(self, monkeypatch):
+        api = GuardAPIClient(api_key="secret", base_url="https://api.noveum.ai")
+        fake_response = _FakeHTTPResponse(
+            200, {"policies": [{"type": "cost_cap", "max_usd": 5.0}]}
+        )
+        monkeypatch.setattr(
+            httpx, "Client", lambda **kw: _FakeHTTPClient(response=fake_response)
+        )
+        result = api.fetch_remote_policies("proj")
+        assert result == [{"type": "cost_cap", "max_usd": 5.0}]
+
+    def test_real_backend_non_200_raises_backend_unavailable(self, monkeypatch):
+        api = GuardAPIClient(api_key="secret", base_url="https://api.noveum.ai")
+        fake_response = _FakeHTTPResponse(500)
+        monkeypatch.setattr(
+            httpx, "Client", lambda **kw: _FakeHTTPClient(response=fake_response)
+        )
+        with pytest.raises(GuardBackendUnavailable):
+            api.fetch_remote_policies("proj")
+
+    def test_real_backend_network_error_raises_backend_unavailable(self, monkeypatch):
+        api = GuardAPIClient(api_key="secret", base_url="https://api.noveum.ai")
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            lambda **kw: _FakeHTTPClient(raise_exc=httpx.ConnectError("boom")),
+        )
+        with pytest.raises(GuardBackendUnavailable):
+            api.fetch_remote_policies("proj")
 
 
 class TestConcurrency:

--- a/tests/unit/guard/test_cost_cap.py
+++ b/tests/unit/guard/test_cost_cap.py
@@ -35,6 +35,7 @@ def _req(
     model: str = "gpt-4o-mini",
     max_tokens: int = 100,
     estimated_input_tokens: int = 50,
+    kind: str = "chat",
 ) -> ParsedRequest:
     return ParsedRequest(
         provider="openai",
@@ -44,6 +45,7 @@ def _req(
         max_tokens=max_tokens,
         estimated_input_tokens=estimated_input_tokens,
         raw_body=b"{}",
+        kind=kind,
     )
 
 
@@ -450,3 +452,60 @@ class TestMaxTokensFallback:
         decision = policy.pre(req, _ctx(), deps)
 
         assert not decision.is_blocking  # should not crash; just estimate with default
+
+
+# ---------------------------------------------------------------------------
+# Embeddings requests (P2.1) — reserved cost must reflect real input size
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingsCostAccounting:
+    def test_large_embeddings_input_is_blocked_under_tight_cap(self):
+        """Before the fix, kind="chat" parsing of an embeddings-shaped request
+        (empty messages) would estimate near-zero cost regardless of actual
+        input size, silently admitting it under any cap. With kind="embeddings"
+        the reservation reflects the real (possibly large) input token count."""
+        api = GuardAPIClient()
+        policy = CostCapPolicy(
+            max_usd=0.000001,  # tiny cap
+            mode=EnforcementMode.strict,
+            project_id="proj",
+        )
+        deps = PolicyDeps(api=api)
+
+        req = _req(
+            model="text-embedding-3-small",
+            estimated_input_tokens=1_000_000,  # large embeddings input
+            kind="embeddings",
+        )
+        decision = policy.pre(req, _ctx(), deps)
+
+        assert decision.is_blocking
+
+    def test_embeddings_reservation_ignores_max_output_tokens_fallback(self):
+        """kind="embeddings" must not apply the chat max_output_tokens (or the
+        4096 fallback) — embeddings never produce output tokens."""
+        policy = CostCapPolicy(
+            max_usd=100.0, mode=EnforcementMode.strict, project_id="proj"
+        )
+        reserved = policy._estimate_reserved_usd(
+            _req(
+                model="text-embedding-3-small",
+                estimated_input_tokens=1000,
+                kind="embeddings",
+            )
+        )
+        # Input-only cost at $0.02/1M tokens for 1000 tokens.
+        assert reserved == pytest.approx(0.02 * 1000 / 1_000_000)
+
+
+# ---------------------------------------------------------------------------
+# can_block_post invariant (P1a) — CostCapPolicy never blocks post()
+# ---------------------------------------------------------------------------
+
+
+class TestCanBlockPostInvariant:
+    def test_cost_cap_cannot_block_post(self):
+        """CostCapPolicy.post() only reconciles/reports spend — it must never
+        be treated as capable of blocking a streaming response."""
+        assert CostCapPolicy.can_block_post is False

--- a/tests/unit/guard/test_engine.py
+++ b/tests/unit/guard/test_engine.py
@@ -396,6 +396,117 @@ class TestReleaseAll:
 # ---------------------------------------------------------------------------
 
 
+class TestBackendUnavailableFailClosed:
+    def test_pre_call_blocks_when_backend_unavailable(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(AlwaysAllowPolicy())
+
+        engine.set_backend_unavailable(True)
+        block, ran = engine.pre_call(_req(), _ctx())
+
+        assert block is not None
+        assert block.is_blocking
+        assert ran == []
+
+    def test_no_policies_run_when_backend_unavailable(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        spy = AlwaysAllowPolicy()
+        engine.attach(spy)
+
+        engine.set_backend_unavailable(True)
+        engine.pre_call(_req(), _ctx())
+
+        assert spy.pre_calls == []
+
+    def test_pre_call_resumes_normally_after_recovery(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        spy = AlwaysAllowPolicy()
+        engine.attach(spy)
+
+        engine.set_backend_unavailable(True)
+        engine.set_backend_unavailable(False)
+        block, ran = engine.pre_call(_req(), _ctx())
+
+        assert block is None
+        assert len(spy.pre_calls) == 1
+
+    def test_is_backend_unavailable_reflects_state(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+
+        assert engine.is_backend_unavailable() is False
+        engine.set_backend_unavailable(True)
+        assert engine.is_backend_unavailable() is True
+        engine.set_backend_unavailable(False)
+        assert engine.is_backend_unavailable() is False
+
+
+class TestBackendUnavailableFailOpen:
+    def test_pre_call_still_enforces_when_configured_fail_open(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api, fail_open_on_backend_unavailable=True)
+        spy = AlwaysAllowPolicy()
+        engine.attach(spy)
+
+        engine.set_backend_unavailable(True)
+        block, ran = engine.pre_call(_req(), _ctx())
+
+        # Fail open: no synthetic control-plane block; last-known policies run.
+        assert block is None
+        assert len(spy.pre_calls) == 1
+
+    def test_fail_open_still_honors_a_real_policy_block(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api, fail_open_on_backend_unavailable=True)
+        engine.attach(AlwaysBlockPolicy())
+
+        engine.set_backend_unavailable(True)
+        block, _ = engine.pre_call(_req(), _ctx())
+
+        assert block is not None
+        assert block.is_blocking
+
+    def test_default_is_fail_closed(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(AlwaysAllowPolicy())
+
+        engine.set_backend_unavailable(True)
+        block, ran = engine.pre_call(_req(), _ctx())
+
+        assert block is not None
+        assert ran == []
+
+
+class TestHasPostBlockingPolicies:
+    def test_false_when_no_policies_attached(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        assert engine.has_post_blocking_policies() is False
+
+    def test_false_when_only_cost_cap_attached(self):
+        """CostCapPolicy never blocks post — can_block_post stays False."""
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(
+            CostCapPolicy(max_usd=100.0, mode=EnforcementMode.strict, project_id="p")
+        )
+        assert engine.has_post_blocking_policies() is False
+
+    def test_true_when_a_post_blocking_policy_is_attached(self):
+        class PostBlocker(AbstractPolicy):
+            name = "post_blocker"
+            can_block_post = True
+
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(PostBlocker())
+        assert engine.has_post_blocking_policies() is True
+
+
 class TestMultipleCostCapPolicies:
     def test_two_cost_caps_on_different_projects_are_independent(self):
         """Blocking proj-a must not affect proj-b's budget."""

--- a/tests/unit/guard/test_poller.py
+++ b/tests/unit/guard/test_poller.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 from noveum_trace.guard.api_client import GuardAPIClient
 from noveum_trace.guard.engine import PolicyEngine
+from noveum_trace.guard.exceptions import GuardBackendUnavailable
 from noveum_trace.guard.policies.base import AbstractPolicy
 from noveum_trace.guard.poller import PolicyPoller
 from noveum_trace.guard.types import PolicyDeps
@@ -192,6 +193,69 @@ class TestAttachMidRun:
         poller.force_refresh()
 
         assert len(spy.poll_calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Backend-unavailable handling — fail closed, loudly (P1b)
+# ---------------------------------------------------------------------------
+
+
+class _FakeAPIClient:
+    """Stand-in for GuardAPIClient exposing only fetch_remote_policies()."""
+
+    def __init__(self, *, raise_exc=None, policies=None):
+        self._raise_exc = raise_exc
+        self._policies = policies or []
+        self.calls = 0
+
+    def fetch_remote_policies(self, project_id):
+        self.calls += 1
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._policies
+
+
+class TestBackendUnavailableHandling:
+    def test_backend_unavailable_sets_engine_degraded(self):
+        api = _FakeAPIClient(raise_exc=GuardBackendUnavailable("down"))
+        engine = PolicyEngine(api_client=api)
+        poller = PolicyPoller(engine, project_id="proj")
+
+        poller._fetch_backend_policies()
+
+        assert engine.is_backend_unavailable() is True
+
+    def test_successful_fetch_clears_degraded_state(self):
+        api = _FakeAPIClient(policies=[])
+        engine = PolicyEngine(api_client=api)
+        engine.set_backend_unavailable(True)
+        poller = PolicyPoller(engine, project_id="proj")
+
+        poller._fetch_backend_policies()
+
+        assert engine.is_backend_unavailable() is False
+
+    def test_no_project_id_does_not_change_degraded_state(self):
+        """No project configured — matches today's silent early-return, unchanged."""
+        api = _FakeAPIClient(raise_exc=GuardBackendUnavailable("down"))
+        engine = PolicyEngine(api_client=api)
+        poller = PolicyPoller(engine)  # no project_id, no ambient context
+
+        poller._fetch_backend_policies()
+
+        assert engine.is_backend_unavailable() is False
+        assert api.calls == 0
+
+    def test_unexpected_exception_does_not_set_degraded_state(self):
+        """A bug in fetch_remote_policies itself must not crash the poller
+        thread or falsely flip the engine into fail-closed mode."""
+        api = _FakeAPIClient(raise_exc=RuntimeError("unexpected bug"))
+        engine = PolicyEngine(api_client=api)
+        poller = PolicyPoller(engine, project_id="proj")
+
+        poller._fetch_backend_policies()  # must not raise
+
+        assert engine.is_backend_unavailable() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/guard/test_transport.py
+++ b/tests/unit/guard/test_transport.py
@@ -17,7 +17,10 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 
+from noveum_trace.guard.api_client import GuardAPIClient
 from noveum_trace.guard.decision import PolicyDecision
+from noveum_trace.guard.engine import PolicyEngine
+from noveum_trace.guard.policies.base import AbstractPolicy
 from noveum_trace.guard.transport.async_transport import NoveumAsyncTransport
 from noveum_trace.guard.transport.sync_transport import NoveumTransport
 from noveum_trace.guard.types import ParsedRequest, ParsedResponse, Phase, PolicyContext
@@ -118,6 +121,28 @@ def _streaming_parsed_req() -> ParsedRequest:
     )
 
 
+def _openai_sse_body() -> bytes:
+    events = [
+        {"choices": [{"delta": {"content": "Hello"}}]},
+        {"choices": [{"delta": {"content": " world"}}]},
+        {
+            "choices": [],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        },
+    ]
+    lines = [f"data: {json.dumps(e)}\n\n" for e in events]
+    lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode()
+
+
+def _unread_sse_response() -> httpx.Response:
+    return httpx.Response(
+        200,
+        stream=httpx.ByteStream(_openai_sse_body()),
+        headers={"content-type": "text/event-stream"},
+    )
+
+
 def _content_reading_adapter():
     """Stub adapter whose parse_response actually touches resp.content.
 
@@ -168,19 +193,27 @@ class _MockAsyncInner(httpx.AsyncBaseTransport):
         return self._response
 
 
-def _make_transport(engine, inner, adapter=None):
+def _make_transport(engine, inner, adapter=None, on_unmatched_request="passthrough"):
     registry = MagicMock()
     if adapter is None:
         registry.for_request.return_value = None
     else:
         registry.for_request.return_value = adapter
     return (
-        NoveumTransport(engine=engine, context=_ctx(), inner=inner, registry=registry),
+        NoveumTransport(
+            engine=engine,
+            context=_ctx(),
+            inner=inner,
+            registry=registry,
+            on_unmatched_request=on_unmatched_request,
+        ),
         registry,
     )
 
 
-def _make_async_transport(engine, inner, adapter=None):
+def _make_async_transport(
+    engine, inner, adapter=None, on_unmatched_request="passthrough"
+):
     registry = MagicMock()
     if adapter is None:
         registry.for_request.return_value = None
@@ -188,7 +221,11 @@ def _make_async_transport(engine, inner, adapter=None):
         registry.for_request.return_value = adapter
     return (
         NoveumAsyncTransport(
-            engine=engine, context=_ctx(), inner=inner, registry=registry
+            engine=engine,
+            context=_ctx(),
+            inner=inner,
+            registry=registry,
+            on_unmatched_request=on_unmatched_request,
         ),
         registry,
     )
@@ -385,6 +422,40 @@ class TestErrorDuringForward:
 
 
 # ---------------------------------------------------------------------------
+# Sync/async transport — backend unavailable (real PolicyEngine, P1b)
+# ---------------------------------------------------------------------------
+
+
+class TestBackendUnavailableEndToEnd:
+    def test_sync_transport_returns_403_without_calling_inner(self):
+        engine = PolicyEngine(api_client=GuardAPIClient())
+        engine.set_backend_unavailable(True)
+
+        adapter = _stub_adapter()
+        inner = _MockInner(_real_response())
+        transport, _ = _make_transport(engine, inner, adapter)
+
+        result = transport.handle_request(_real_request())
+
+        assert result.status_code == 403
+        assert inner.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_async_transport_returns_403_without_calling_inner(self):
+        engine = PolicyEngine(api_client=GuardAPIClient())
+        engine.set_backend_unavailable(True)
+
+        adapter = _stub_adapter()
+        inner = _MockAsyncInner(_real_response())
+        transport, _ = _make_async_transport(engine, inner, adapter)
+
+        result = await transport.handle_async_request(_real_request())
+
+        assert result.status_code == 403
+        assert inner.call_count == 0
+
+
+# ---------------------------------------------------------------------------
 # Sync transport — no adapter (unknown provider)
 # ---------------------------------------------------------------------------
 
@@ -411,6 +482,30 @@ class TestNoAdapter:
 
         engine.pre_call.assert_not_called()
         engine.post_call.assert_not_called()
+
+    def test_on_unmatched_request_block_returns_403_without_calling_inner(self):
+        engine = MagicMock()
+        inner = _MockInner(_real_response())
+        transport, _ = _make_transport(
+            engine, inner, adapter=None, on_unmatched_request="block"
+        )
+
+        result = transport.handle_request(_real_request())
+
+        assert result.status_code == 403
+        assert inner.call_count == 0
+        engine.pre_call.assert_not_called()
+
+    def test_on_unmatched_request_default_is_passthrough(self):
+        """Default behavior must remain exactly today's: forward unguarded."""
+        engine = MagicMock()
+        inner = _MockInner(_real_response())
+        transport, _ = _make_transport(engine, inner, adapter=None)
+
+        result = transport.handle_request(_real_request())
+
+        assert result.status_code == 200
+        assert inner.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -443,6 +538,7 @@ class TestResponseReading:
         engine = MagicMock()
         engine.pre_call.return_value = (None, [])
         engine.post_call.return_value = None
+        engine.has_post_blocking_policies.return_value = False
 
         adapter = _content_reading_adapter()
         adapter.parse_request.return_value = _streaming_parsed_req()
@@ -456,6 +552,114 @@ class TestResponseReading:
         engine.post_call.assert_not_called()
         # The unread stream is intact for the caller to consume.
         assert json.loads(result.read())["model"] == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Streaming + a post-blocking-capable policy (P1a) — buffered enforcement
+# ---------------------------------------------------------------------------
+
+
+class _PostBlockingPolicy(AbstractPolicy):
+    """Stub policy that can block post(); records the resp it saw."""
+
+    name = "post_blocking_stub"
+    can_block_post = True
+
+    def __init__(self, *, block: bool) -> None:
+        super().__init__()
+        self._block = block
+        self.seen_resp: ParsedResponse | None = None
+
+    def post(self, resp, ctx, decision, deps) -> PolicyDecision:
+        self.seen_resp = resp
+        if self._block:
+            return PolicyDecision.block(self.name, Phase.post, reason="blocked content")
+        return PolicyDecision.allow(self.name, Phase.post)
+
+
+def _engine_with_post_blocking(
+    *, block: bool
+) -> tuple[PolicyEngine, _PostBlockingPolicy]:
+    engine = PolicyEngine(api_client=GuardAPIClient())
+    policy = _PostBlockingPolicy(block=block)
+    engine.attach(policy)
+    return engine, policy
+
+
+class TestStreamingWithPostBlockingPolicy:
+    def test_blocked_response_never_reaches_caller(self):
+        engine, policy = _engine_with_post_blocking(block=True)
+        adapter = _stub_adapter(_block_response())
+        adapter.parse_request.return_value = _streaming_parsed_req()
+        inner = _MockInner(_unread_sse_response())
+        transport, _ = _make_transport(engine, inner, adapter)
+
+        result = transport.handle_request(_real_request())
+
+        assert result.status_code == 403
+        assert policy.seen_resp is not None  # post() did run, with real content
+        assert policy.seen_resp.text == "Hello world"
+
+    def test_allowed_response_replays_original_sse_content(self):
+        engine, policy = _engine_with_post_blocking(block=False)
+        adapter = _stub_adapter()
+        adapter.parse_request.return_value = _streaming_parsed_req()
+        inner = _MockInner(_unread_sse_response())
+        transport, _ = _make_transport(engine, inner, adapter)
+
+        result = transport.handle_request(_real_request())
+
+        assert result.status_code == 200
+        assert result.content == _openai_sse_body()
+        assert policy.seen_resp.text == "Hello world"
+        assert policy.seen_resp.input_tokens == 10
+        assert policy.seen_resp.output_tokens == 5
+
+    def test_no_post_blocking_policy_uses_lazy_streaming_path(self):
+        """Regression: without a post-blocking policy, the response must NOT
+        be buffered — it stays a lazy stream (content unread until consumed)."""
+        engine = PolicyEngine(api_client=GuardAPIClient())  # no policies attached
+        adapter = _stub_adapter()
+        adapter.parse_request.return_value = _streaming_parsed_req()
+        inner = _MockInner(_unread_sse_response())
+        transport, _ = _make_transport(engine, inner, adapter)
+
+        result = transport.handle_request(_real_request())
+
+        # Real (unbuffered) streaming responses are lazy — content is not yet
+        # readable without consuming/closing the stream.
+        with pytest.raises(httpx.ResponseNotRead):
+            _ = result.content
+
+
+class TestAsyncStreamingWithPostBlockingPolicy:
+    @pytest.mark.asyncio
+    async def test_blocked_response_never_reaches_caller(self):
+        engine, policy = _engine_with_post_blocking(block=True)
+        adapter = _stub_adapter(_block_response())
+        adapter.parse_request.return_value = _streaming_parsed_req()
+        inner = _MockAsyncInner(_unread_sse_response())
+        transport, _ = _make_async_transport(engine, inner, adapter)
+
+        result = await transport.handle_async_request(_real_request())
+
+        assert result.status_code == 403
+        assert policy.seen_resp is not None
+        assert policy.seen_resp.text == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_allowed_response_replays_original_sse_content(self):
+        engine, policy = _engine_with_post_blocking(block=False)
+        adapter = _stub_adapter()
+        adapter.parse_request.return_value = _streaming_parsed_req()
+        inner = _MockAsyncInner(_unread_sse_response())
+        transport, _ = _make_async_transport(engine, inner, adapter)
+
+        result = await transport.handle_async_request(_real_request())
+
+        assert result.status_code == 200
+        assert await result.aread() == _openai_sse_body()
+        assert policy.seen_resp.text == "Hello world"
 
 
 # ---------------------------------------------------------------------------
@@ -521,6 +725,20 @@ class TestAsyncTransport:
         engine.pre_call.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_on_unmatched_request_block_returns_403_without_calling_inner(self):
+        engine = MagicMock()
+        inner = _MockAsyncInner(_real_response())
+        transport, _ = _make_async_transport(
+            engine, inner, adapter=None, on_unmatched_request="block"
+        )
+
+        result = await transport.handle_async_request(_real_request())
+
+        assert result.status_code == 403
+        assert inner.call_count == 0
+        engine.pre_call.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unread_stream_body_is_materialized_before_parse(self):
         engine = MagicMock()
         engine.pre_call.return_value = (None, [])
@@ -541,6 +759,7 @@ class TestAsyncTransport:
         engine = MagicMock()
         engine.pre_call.return_value = (None, [])
         engine.post_call.return_value = None
+        engine.has_post_blocking_policies.return_value = False
 
         adapter = _content_reading_adapter()
         adapter.parse_request.return_value = _streaming_parsed_req()

--- a/tests/unit/guard/test_transport_helper.py
+++ b/tests/unit/guard/test_transport_helper.py
@@ -1,0 +1,296 @@
+"""Unit tests for noveum_trace.guard.transport.helper.
+
+Covers:
+  - _parse_sse_event_data: usage + assembled text extraction (OpenAI, Anthropic)
+  - reconcile_stream: lazy-streaming reconciliation, including gzip bodies
+  - build_generic_block_response
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import uuid
+
+import httpx
+
+from noveum_trace.guard.api_client import GuardAPIClient
+from noveum_trace.guard.decision import PolicyDecision
+from noveum_trace.guard.engine import PolicyEngine
+from noveum_trace.guard.policies.base import AbstractPolicy
+from noveum_trace.guard.transport.adapters.openai_adapter import OpenAIAdapter
+from noveum_trace.guard.transport.helper import (
+    _parse_sse_event_data,
+    build_buffered_stream_response,
+    build_generic_block_response,
+    reconcile_stream,
+)
+from noveum_trace.guard.types import ParsedRequest, Phase, PolicyContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx() -> PolicyContext:
+    return PolicyContext(
+        project_id="proj",
+        organization_id=None,
+        environment="test",
+        trace_id=None,
+        span_id=None,
+        call_id=str(uuid.uuid4()),
+    )
+
+
+def _streaming_req(provider: str = "openai", model: str = "gpt-4o") -> ParsedRequest:
+    return ParsedRequest(
+        provider=provider,
+        model=model,
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+        max_tokens=100,
+        estimated_input_tokens=10,
+        raw_body=b"{}",
+    )
+
+
+def _openai_sse(*, include_usage: bool = True) -> bytes:
+    events = [
+        {"choices": [{"delta": {"content": "Hello"}}]},
+        {"choices": [{"delta": {"content": " world"}}]},
+    ]
+    if include_usage:
+        events.append(
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                },
+            }
+        )
+    lines = [f"data: {json.dumps(e)}\n\n" for e in events]
+    lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode()
+
+
+def _anthropic_sse() -> bytes:
+    events = [
+        {
+            "type": "message_start",
+            "message": {"usage": {"input_tokens": 8}},
+        },
+        {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": "Hi"},
+        },
+        {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": " there"},
+        },
+        {
+            "type": "message_delta",
+            "usage": {"output_tokens": 4},
+        },
+    ]
+    lines = [f"data: {json.dumps(e)}\n\n" for e in events]
+    return "".join(lines).encode()
+
+
+# ---------------------------------------------------------------------------
+# _parse_sse_event_data
+# ---------------------------------------------------------------------------
+
+
+class TestParseSSEEventData:
+    def test_openai_assembles_text_across_chunks(self):
+        result = _parse_sse_event_data(_openai_sse(), "openai")
+        assert result.text == "Hello world"
+
+    def test_openai_extracts_usage(self):
+        result = _parse_sse_event_data(_openai_sse(), "openai")
+        assert result.has_usage is True
+        assert result.input_tokens == 10
+        assert result.output_tokens == 5
+
+    def test_openai_no_usage_event_has_usage_false(self):
+        result = _parse_sse_event_data(_openai_sse(include_usage=False), "openai")
+        assert result.has_usage is False
+        # Text is still assembled even without a usage event.
+        assert result.text == "Hello world"
+
+    def test_anthropic_assembles_text_across_content_block_deltas(self):
+        result = _parse_sse_event_data(_anthropic_sse(), "anthropic")
+        assert result.text == "Hi there"
+
+    def test_anthropic_extracts_usage_from_start_and_delta_events(self):
+        result = _parse_sse_event_data(_anthropic_sse(), "anthropic")
+        assert result.has_usage is True
+        assert result.input_tokens == 8
+        assert result.output_tokens == 4
+
+    def test_empty_body_has_no_usage_and_no_text(self):
+        result = _parse_sse_event_data(b"", "openai")
+        assert result.has_usage is False
+        assert result.text is None
+
+
+# ---------------------------------------------------------------------------
+# reconcile_stream
+# ---------------------------------------------------------------------------
+
+
+class _AllowAllPolicy(AbstractPolicy):
+    name = "allow_all"
+
+    def pre(self, parsed, ctx, deps):
+        from noveum_trace.guard.decision import PolicyDecision
+
+        return PolicyDecision.allow(self.name, Phase.pre)
+
+
+class TestReconcileStream:
+    def _engine_and_ran(self):
+        engine = PolicyEngine(api_client=GuardAPIClient())
+        policy = _AllowAllPolicy()
+        engine.attach(policy)
+        ctx = _ctx()
+        _, ran = engine.pre_call(_streaming_req(), ctx)
+        return engine, ctx, ran
+
+    def test_reconcile_with_usage_calls_post_call(self):
+        engine, ctx, ran = self._engine_and_ran()
+        chunks = [_openai_sse()]
+
+        # Should not raise; post_call() runs to completion with real usage.
+        reconcile_stream(chunks, engine, ctx, ran, _streaming_req())
+
+    def test_reconcile_without_usage_releases_all(self):
+        engine, ctx, ran = self._engine_and_ran()
+        chunks = [_openai_sse(include_usage=False)]
+
+        # No usage event → falls back to release_all(), must not raise.
+        reconcile_stream(chunks, engine, ctx, ran, _streaming_req())
+
+    def test_reconcile_handles_gzip_compressed_body(self):
+        engine, ctx, ran = self._engine_and_ran()
+        compressed = gzip.compress(_openai_sse())
+
+        # Must decompress before SSE parsing; must not raise.
+        reconcile_stream([compressed], engine, ctx, ran, _streaming_req())
+
+    def test_reconcile_swallows_unexpected_exceptions_via_release_all(self):
+        engine, ctx, ran = self._engine_and_ran()
+        # Malformed bytes that will fail to decode/parse meaningfully.
+        chunks = [b"\xff\xfe not valid sse at all"]
+
+        # Must not raise even on garbage input.
+        reconcile_stream(chunks, engine, ctx, ran, _streaming_req())
+
+
+# ---------------------------------------------------------------------------
+# build_generic_block_response
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGenericBlockResponse:
+    def test_returns_403(self):
+        resp = build_generic_block_response("no adapter matched")
+        assert resp.status_code == 403
+
+    def test_body_contains_reason(self):
+        resp = build_generic_block_response("no adapter matched")
+        body = json.loads(resp.content)
+        assert body["error"]["message"] == "no adapter matched"
+        assert body["error"]["type"] == "policy_blocked"
+
+
+# ---------------------------------------------------------------------------
+# build_buffered_stream_response
+# ---------------------------------------------------------------------------
+
+
+class _BlockInPostPolicy(AbstractPolicy):
+    name = "block_post"
+    can_block_post = True
+
+    def post(self, resp, ctx, decision, deps):
+        return PolicyDecision.block(self.name, Phase.post, reason="blocked in post")
+
+
+def _read_inner_response(sse_bytes: bytes, *, gzip_encoded: bool = False):
+    """Build a response as the inner transport would return it, then read()
+    it — mirroring what NoveumTransport does before build_buffered_stream_response.
+
+    read() applies content-decoding, so response.content ends up decoded while
+    the original Content-Encoding/Content-Length headers still describe the
+    compressed body.
+    """
+    headers = {"content-type": "text/event-stream"}
+    if gzip_encoded:
+        body = gzip.compress(sse_bytes)
+        headers["content-encoding"] = "gzip"
+    else:
+        body = sse_bytes
+    headers["content-length"] = str(len(body))
+    resp = httpx.Response(200, headers=headers, content=body)
+    resp.read()
+    return resp
+
+
+class TestBuildBufferedStreamResponse:
+    def _engine_ctx_ran(self, policy: AbstractPolicy):
+        engine = PolicyEngine(api_client=GuardAPIClient())
+        engine.attach(policy)
+        ctx = _ctx()
+        _, ran = engine.pre_call(_streaming_req(), ctx)
+        return engine, ctx, ran
+
+    def test_allow_path_replays_decoded_sse(self):
+        engine, ctx, ran = self._engine_ctx_ran(_AllowAllPolicy())
+        sse = _openai_sse()
+        inner = _read_inner_response(sse)
+        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+
+        out = build_buffered_stream_response(
+            inner, request, OpenAIAdapter(), engine, ctx, ran, _streaming_req()
+        )
+        out.read()
+        assert out.status_code == 200
+        assert out.content == sse
+
+    def test_gzip_body_replays_without_double_decode(self):
+        """Regression (Finding 2): response.content is already decoded, so the
+        replay must drop Content-Encoding — otherwise the caller's httpx read
+        attempts a second gunzip and raises DecodingError.
+        """
+        engine, ctx, ran = self._engine_ctx_ran(_AllowAllPolicy())
+        sse = _openai_sse()
+        inner = _read_inner_response(sse, gzip_encoded=True)
+        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+
+        out = build_buffered_stream_response(
+            inner, request, OpenAIAdapter(), engine, ctx, ran, _streaming_req()
+        )
+        # Must not raise DecodingError, and must yield the decoded SSE bytes.
+        out.read()
+        assert out.content == sse
+        # The stale gzip encoding header must be gone.
+        assert "content-encoding" not in out.headers
+        # httpx regenerates Content-Length from the (decoded) replay body, so
+        # it now matches the real content instead of the compressed length.
+        assert out.headers["content-length"] == str(len(sse))
+
+    def test_post_block_returns_synthetic_block(self):
+        engine, ctx, ran = self._engine_ctx_ran(_BlockInPostPolicy())
+        inner = _read_inner_response(_openai_sse())
+        request = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+
+        out = build_buffered_stream_response(
+            inner, request, OpenAIAdapter(), engine, ctx, ran, _streaming_req()
+        )
+        assert out.status_code == 403
+        body = json.loads(out.content)
+        assert body["error"]["type"] == "policy_blocked"

--- a/tests/unit/utils/test_llm_utils.py
+++ b/tests/unit/utils/test_llm_utils.py
@@ -8,6 +8,8 @@ cost estimation, and model validation functionality.
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from noveum_trace.utils.llm_utils import (
     MODEL_ALIASES,
     MODEL_REGISTRY,
@@ -77,6 +79,70 @@ class TestModelRegistry:
         normalized = normalize_model_name("claude-3.5-sonnet-20241022")
         # Should normalize to the canonical form
         assert normalized in ["claude-3.5-sonnet", "claude-3.5-sonnet-20241022"]
+
+    def test_normalize_bedrock_model_ids(self):
+        """Bedrock IDs put the date in the middle (``...-YYYYMMDD-vN:M``).
+
+        Regression: the ``:N`` and ``-vN`` suffixes must be stripped before the
+        trailing-date regex, otherwise the date is left in and the name never
+        matches its registry key (silently falling back to default pricing).
+        """
+        assert (
+            normalize_model_name("anthropic.claude-3-5-sonnet-20240620-v1:0")
+            == "anthropic.claude-3-5-sonnet"
+        )
+        assert (
+            normalize_model_name("anthropic.claude-3-5-sonnet-20241022-v2:0")
+            == "anthropic.claude-3-5-sonnet"
+        )
+        assert (
+            normalize_model_name("anthropic.claude-3-haiku-20240307-v1:0")
+            == "anthropic.claude-3-haiku"
+        )
+        assert (
+            normalize_model_name("anthropic.claude-3-opus-20240229-v1:0")
+            == "anthropic.claude-3-opus"
+        )
+        assert (
+            normalize_model_name("meta.llama3-70b-instruct-v1:0")
+            == "meta.llama3-70b-instruct"
+        )
+        assert (
+            normalize_model_name("amazon.titan-embed-text-v2:0")
+            == "amazon.titan-embed-text"
+        )
+
+    def test_estimate_cost_bedrock_claude_uses_registry_pricing(self):
+        """Regression (Finding 1): Bedrock Claude IDs must resolve to their
+        registry entry, not the generic default fallback.
+
+        With 1k input + 1k output tokens, claude-3-5-sonnet on Bedrock
+        ($3/$15 per 1M) costs $0.018; the default fallback would return a much
+        lower figure and let ~6x the intended spend through a cost cap.
+        """
+        info = get_model_info("anthropic.claude-3-5-sonnet-20240620-v1:0")
+        assert info is not None
+        assert info.provider == "bedrock"
+
+        cost = estimate_cost(
+            "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            input_tokens=1000,
+            output_tokens=1000,
+        )
+        # 1000/1e6 * 3.00 + 1000/1e6 * 15.00 = 0.018
+        assert cost["total_cost"] == pytest.approx(0.018)
+
+    def test_estimate_cost_bedrock_mistral_large_both_snapshots(self):
+        """Both the 2402 and 2407 Mistral Large snapshots ship on Bedrock and
+        must resolve (the 4-digit snapshot is not stripped by normalization)."""
+        for model_id in (
+            "mistral.mistral-large-2402-v1:0",
+            "mistral.mistral-large-2407-v1:0",
+        ):
+            assert get_model_info(model_id) is not None, model_id
+            cost = estimate_cost(model_id, input_tokens=1000, output_tokens=1000)
+            # 1000/1e6 * 4.00 + 1000/1e6 * 12.00 = 0.016
+            assert cost["total_cost"] == pytest.approx(0.016), model_id
 
 
 class TestModelValidation:


### PR DESCRIPTION
# Pull Request

## Description

Closes three gaps in NovaGuard (`src/noveum_trace/guard/`) found during review of `novaguard-v1`:

- **P1 — post-phase policies couldn't be enforced on streams.** A blocking `post()` decision on a streaming response was only logged, never enforced, because bytes were already flushed to the caller. Cost-cap policies never block post so this was harmless today, but a PII/content-filter policy would have been silently bypassed by `stream=True`. Fixed by adding `AbstractPolicy.can_block_post` — when a policy that can block post is attached, the sync/async transports (and the Bedrock integration) now fully buffer the streamed response, run `post_call()`, and either replay the buffered bytes or return a synthetic 403 — before anything reaches the caller. Streams with no such policy attached keep the original zero-buffering, true-streaming path unchanged.
- **P1 — backend down meant silent no-enforcement.** `GuardAPIClient.fetch_remote_policies()` used to swallow all network/HTTP/parse errors and return `[]`, indistinguishable from "no policies configured." Added a `GuardBackendUnavailable` exception for real backend failures (as opposed to legitimate stub/no-API-key mode); `PolicyPoller` now sets a `PolicyEngine.set_backend_unavailable(True)` flag on that exception, and `pre_call()` fails closed (blocks every call with a clear reason) while the control plane is unreachable, recovering automatically once polling succeeds again.
- **P2 — provider coverage gaps.** Added AWS Bedrock coverage (`guard.instrument_bedrock()`) and embeddings-endpoint coverage (`ParsedRequest.kind="embeddings"`, cost-cap reserves input-only cost instead of guessing a chat-style output budget). Also added an `on_unmatched_request="block"` mode for `http_client()`/`async_http_client()` for defense-in-depth deployments. Vertex/Gemini remain uncovered (documented via `guard.supported_providers()`).

Bedrock coverage went through a design iteration: the first pass required calling `instrument_bedrock(client)` on every individual boto3 client instance (via `client.meta.events.register(...)`), which silently misses any client an application builds without remembering to wrap it. This was replaced with a single idempotent, process-wide monkeypatch of `botocore.client.BaseClient._make_api_call` (the same technique OpenTelemetry/Sentry/Datadog use for botocore instrumentation) — `instrument_bedrock()` called once, with no client argument, now covers every bedrock-runtime client the app builds afterward, from any `boto3.Session()`, not just one instance. The per-instance form (`instrument_bedrock(client, engine=, context=)`) is kept for advanced per-client policy overrides.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [x] Test improvements

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing
- [ ] Performance testing

Ran the full guard unit suite (`tests/unit/guard/`), the rewritten Bedrock integration suite (`tests/integration/guard/test_bedrock.py`), and the full unit suite (`pytest tests/unit/ -n auto --dist loadscope`) — all green. `mypy`, `black`, `isort`, `ruff` clean on all touched files.

Manual sanity check: called `instrument_bedrock()` once (no client arg), then constructed two independent bedrock-runtime clients — one via `boto3.client(...)`, one via `boto3.Session().client(...)` — and confirmed a blocking test policy stopped calls on **both**, even though neither was passed to `instrument_bedrock` individually. This is the exact scenario the old per-client design couldn't cover.

Also added test coverage for:
- A second, never-explicitly-instrumented client (independent session) being guarded by the same global patch.
- A non-Bedrock botocore client (STS) passing through the patched `_make_api_call` completely untouched.
- The blocking-policy test no longer needs the `connect_timeout` workaround previously required to dodge `Stubber`'s `register_first` event-ordering conflict — patching `_make_api_call` directly sidesteps that fragility entirely.

## Test Configuration

* Python version: 3.11
* Operating System: Windows 11
* Dependencies: `boto3`/`botocore` (new optional `bedrock` extra)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock guard support, including Bedrock integration and expanded model coverage.
  * Added `guard_fail_open_on_backend_unavailable` option to choose fail-open vs fail-closed when the guard control plane is unreachable.
  * Added configurable behavior for unknown/unmatched providers: passthrough or block.

* **Bug Fixes**
  * Improved embeddings request/response parsing and cost handling so embeddings aren’t mis-costed as chat.
  * Enhanced streaming reconciliation and post-call enforcement so blocking decisions behave more predictably.

* **Chores / Tests**
  * Added Bedrock-related dependency support for development and testing.
  * Expanded Bedrock and guard transport/unit test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->