### PR TITLE
feat/guard-shared-spend-backend

### DIFF
--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -246,8 +246,10 @@ def init(
 
                 # A real API key selects the HTTP backend (spend is shared across
                 # processes via /policies/state + /policies/usage). No key keeps
-                # the in-memory stub for local dev / tests.
-                _resolved_key = api_key or ""
+                # the in-memory stub for local dev / tests. Read from the
+                # resolved SDK config so NOVEUM_API_KEY (not just the explicit
+                # api_key argument) is honored.
+                _resolved_key = get_config().api_key or ""
                 if _resolved_key:
                     from noveum_trace.guard.api_client_http import HttpGuardAPIClient
 

--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -130,6 +130,7 @@ def init(
     endpoint: Optional[str] = None,
     environment: Optional[str] = None,
     service_version: Optional[str] = None,
+    organization: Optional[str] = None,
     policies: Optional[list[Any]] = None,
     guard_enabled: bool = False,
     guard_fail_open_on_backend_unavailable: bool = False,
@@ -239,15 +240,29 @@ def init(
 
             try:
                 from noveum_trace.guard._state import set_guard
-                from noveum_trace.guard.api_client import GuardAPIClient
                 from noveum_trace.guard.engine import PolicyEngine
                 from noveum_trace.guard.poller import PolicyPoller
                 from noveum_trace.guard.types import PolicyContext
 
-                _api_client = GuardAPIClient(
-                    api_key=api_key or "",
-                    base_url=endpoint or DEFAULT_ENDPOINT,
-                )
+                # A real API key selects the HTTP backend (spend is shared across
+                # processes via /policies/state + /policies/usage). No key keeps
+                # the in-memory stub for local dev / tests.
+                _resolved_key = api_key or ""
+                if _resolved_key:
+                    from noveum_trace.guard.api_client_http import HttpGuardAPIClient
+
+                    _api_client: Any = HttpGuardAPIClient(
+                        api_key=_resolved_key,
+                        base_url=endpoint or DEFAULT_ENDPOINT,
+                        organization_slug=organization,
+                    )
+                else:
+                    from noveum_trace.guard.api_client import GuardAPIClient
+
+                    _api_client = GuardAPIClient(
+                        api_key="",
+                        base_url=endpoint or DEFAULT_ENDPOINT,
+                    )
                 _engine = PolicyEngine(
                     _api_client,
                     fail_open_on_backend_unavailable=(
@@ -308,6 +323,12 @@ def shutdown() -> None:
         _guard_poller = _guard_state.get_poller()
         if _guard_poller is not None:
             _guard_poller.stop()
+        # Drain any queued usage pushes before dropping the engine.
+        _guard_engine = _guard_state.get_engine()
+        if _guard_engine is not None:
+            _close = getattr(_guard_engine._api_client, "close", None)
+            if callable(_close):
+                _close()
         _guard_state.clear()
 
         if _client:

--- a/src/noveum_trace/guard/__init__.py
+++ b/src/noveum_trace/guard/__init__.py
@@ -1,5 +1,6 @@
 from noveum_trace.guard._state import attach_policy, detach_policy, refresh
 from noveum_trace.guard.api_client import GuardAPIClient
+from noveum_trace.guard.api_client_http import HttpGuardAPIClient
 from noveum_trace.guard.decision import PolicyDecision
 from noveum_trace.guard.engine import PolicyEngine
 from noveum_trace.guard.exceptions import GuardBackendUnavailable, NoveumGuardBlocked
@@ -54,6 +55,7 @@ def supported_providers() -> list[str]:
 __all__ = [
     # Core
     "GuardAPIClient",
+    "HttpGuardAPIClient",
     "PolicyDecision",
     "PolicyEngine",
     "NoveumGuardBlocked",

--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -14,10 +14,12 @@ class ReservationResult:
 
 
 class GuardAPIClient:
-    """In-memory stub for the Noveum Guard backend.
+    """In-memory backend for the Noveum Guard, and base class for HttpGuardAPIClient.
 
-    All state is per-process. Correct for single-process use and tests;
-    multi-process deployments need the real HTTP backend (swap this file only).
+    All state is per-process. Correct for single-process use and tests, and is
+    the only backend that supports atomic reserve/reconcile — multi-process
+    deployments should use ``HttpGuardAPIClient`` (guard/api_client_http.py),
+    which subclasses this and overrides the network-backed methods.
 
     Thread-safety: a single Lock guards every mutation. The lock is held only
     for the minimal critical section so high-concurrency callers are not

--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -24,6 +24,10 @@ class GuardAPIClient:
     serialised longer than necessary.
     """
 
+    # In-memory reservations are atomic within this process, so strict-mode
+    # reserve/reconcile are supported. The HTTP client sets this False.
+    supports_reservation: bool = True
+
     def __init__(
         self, api_key: str = "", base_url: str = "https://api.noveum.ai"
     ) -> None:
@@ -101,11 +105,14 @@ class GuardAPIClient:
         project_id: str,
         actual_usd: float,
         model: str,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
     ) -> None:
         """Record actual cost (non-strict post only).
 
         Non-strict never calls reserve(), so there is nothing to reconcile —
-        we simply add the actual spend.
+        we simply add the actual spend. Token counts are accepted for interface
+        parity with the HTTP client (which forwards them) but unused here.
         """
         if actual_usd < 0:
             raise ValueError(f"actual_usd must be non-negative, got {actual_usd}")
@@ -114,8 +121,14 @@ class GuardAPIClient:
 
     # Policy config / polling
 
-    def get_state(self, project_id: str) -> dict[str, Any]:
-        """Spend snapshot for poll(). Returns a copy to avoid lock-holding in caller."""
+    def get_state(
+        self, project_id: str, window: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Spend snapshot for poll(). Returns a copy to avoid lock-holding in caller.
+
+        ``window`` is accepted for interface parity with the HTTP client (which
+        selects a per-window counter); the in-memory stub tracks one bucket.
+        """
         with self._lock:
             return {"spend": self._spend.get(project_id, 0.0)}
 

--- a/src/noveum_trace/guard/api_client_http.py
+++ b/src/noveum_trace/guard/api_client_http.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from noveum_trace.guard.api_client import GuardAPIClient, ReservationResult
+from noveum_trace.guard.exceptions import GuardBackendUnavailable
+
+_log = logging.getLogger(__name__)
+
+# Backend cost windows (packages/api/.../guardrails/schemas.ts).
+_DEFAULT_WINDOW = "30d_rolling"
+
+# Map backend PolicyType enum (uppercase) → SDK policy registry key (lowercase).
+_TYPE_MAP = {"COST_CAP": "cost_cap", "RATE_LIMIT": "rate_limit"}
+
+
+class HttpGuardAPIClient(GuardAPIClient):
+    """Real HTTP client for the Noveum Guard backend.
+
+    Spend is server-authoritative: every worker pushes each call's cost to the
+    shared ``/policies/usage`` endpoint and reads accumulated spend back from
+    ``/policies/state``. This is what makes a cost cap hold across processes —
+    the in-memory ``GuardAPIClient`` only shares state within one process.
+
+    There is no atomic reserve endpoint, so ``reserve``/``reconcile`` are not
+    supported; ``supports_reservation`` is False and CostCapPolicy degrades to
+    the shared read-then-check model (bounded overshoot ≈ one poll window).
+
+    Usage pushes are batched on a background daemon thread so the hot path never
+    blocks on the network. Retries are safe because the backend dedups on
+    ``eventId`` (we send the per-call ``call_id``).
+    """
+
+    supports_reservation = False
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.noveum.ai",
+        organization_slug: Optional[str] = None,
+        flush_interval: float = 5.0,
+        batch_max: int = 100,
+        timeout: float = 10.0,
+    ) -> None:
+        super().__init__(api_key=api_key, base_url=base_url)
+        self._organization_slug = organization_slug
+        self._flush_interval = flush_interval
+        self._batch_max = batch_max
+        self._timeout = timeout
+        # (scope_id, event dict) pairs awaiting push, guarded by _queue_lock.
+        self._queue: list[tuple[str, dict[str, Any]]] = []
+        self._queue_lock = threading.Lock()
+        self._stop = threading.Event()
+        self._flush_thread: Optional[threading.Thread] = None
+
+    # HTTP helpers
+
+    def _query(self) -> dict[str, str]:
+        return (
+            {"organizationSlug": self._organization_slug}
+            if self._organization_slug
+            else {}
+        )
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    # Spend read — GET /policies/state
+
+    def get_state(
+        self, project_id: str, window: Optional[str] = None
+    ) -> dict[str, Any]:
+        """Read shared spend for ``window`` from the backend live-state endpoint."""
+        window = window or _DEFAULT_WINDOW
+        url = f"{self.base_url}/v1/projects/{project_id}/policies/state"
+        try:
+            import httpx
+
+            with httpx.Client(timeout=self._timeout, follow_redirects=True) as client:
+                resp = client.get(url, headers=self._headers(), params=self._query())
+            if resp.status_code == 200:
+                cost = resp.json().get("cost", {}) or {}
+                return {"spend": float(cost.get(window, 0.0) or 0.0)}
+            raise GuardBackendUnavailable(
+                f"get_state: backend returned {resp.status_code} "
+                f"for project {project_id!r}"
+            )
+        except GuardBackendUnavailable:
+            raise
+        except Exception as exc:
+            raise GuardBackendUnavailable(
+                f"get_state: request failed for project {project_id!r} — {exc}"
+            ) from exc
+
+    # Spend write — enqueue for batched POST /policies/usage
+
+    def report_usage(
+        self,
+        call_id: str,
+        project_id: str,
+        actual_usd: float,
+        model: str,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ) -> None:
+        """Queue this call's actual usage for a batched push to the backend."""
+        if actual_usd < 0:
+            return
+        event = {
+            "model": model or "unknown",
+            "inputTokens": max(0, int(input_tokens)),
+            "outputTokens": max(0, int(output_tokens)),
+            "costUsd": float(actual_usd),
+            "requestCount": 1,
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "eventId": call_id,  # idempotency key — backend dedups on retry
+        }
+        with self._queue_lock:
+            self._queue.append((project_id, event))
+            full = len(self._queue) >= self._batch_max
+        self._ensure_thread()
+        if full:
+            self._flush_once()
+
+    # reserve/reconcile have no backend equivalent; CostCapPolicy must not call
+    # them (it checks supports_reservation first). Guard against wiring bugs.
+
+    def reserve(
+        self,
+        call_id: str,
+        project_id: str,
+        reserved_usd: float,
+        max_usd: float,
+        window: str = _DEFAULT_WINDOW,
+    ) -> ReservationResult:
+        raise NotImplementedError(
+            "HttpGuardAPIClient does not support reserve(); the backend has no "
+            "atomic reserve endpoint. Use the shared read-then-check path."
+        )
+
+    def reconcile(self, call_id: str, project_id: str, unconsumed_usd: float) -> None:
+        raise NotImplementedError("HttpGuardAPIClient does not support reconcile().")
+
+    # Policy definitions — GET /policies/effective (merged org + project set)
+
+    def fetch_remote_policies(self, project_id: str) -> list[dict[str, Any]]:
+        """Fetch the merged, enabled policy set and map it to the SDK's shape."""
+        url = f"{self.base_url}/v1/projects/{project_id}/policies/effective"
+        try:
+            import httpx
+
+            with httpx.Client(timeout=self._timeout, follow_redirects=True) as client:
+                resp = client.get(url, headers=self._headers(), params=self._query())
+            if resp.status_code == 200:
+                raw = resp.json()
+                policies = raw if isinstance(raw, list) else raw.get("policies", [])
+                return [
+                    mapped
+                    for p in policies
+                    if (mapped := _normalize_policy(p)) is not None
+                ]
+            raise GuardBackendUnavailable(
+                f"fetch_remote_policies: backend returned {resp.status_code} "
+                f"for project {project_id!r}"
+            )
+        except GuardBackendUnavailable:
+            raise
+        except Exception as exc:
+            raise GuardBackendUnavailable(
+                f"fetch_remote_policies: request failed for project "
+                f"{project_id!r} — {exc}"
+            ) from exc
+
+    # Background flush
+
+    def _ensure_thread(self) -> None:
+        if self._flush_thread and self._flush_thread.is_alive():
+            return
+        with self._queue_lock:
+            if self._flush_thread and self._flush_thread.is_alive():
+                return
+            self._stop.clear()
+            self._flush_thread = threading.Thread(
+                target=self._run, daemon=True, name="noveum-guard-usage-flush"
+            )
+            self._flush_thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.wait(timeout=self._flush_interval):
+            try:
+                self._flush_once()
+            except Exception:  # never let the flush thread die
+                pass
+
+    def _flush_once(self) -> None:
+        with self._queue_lock:
+            if not self._queue:
+                return
+            batch = self._queue[: self._batch_max]
+            del self._queue[: len(batch)]
+
+        # Group events by scope so each POST targets one project.
+        by_scope: dict[str, list[dict[str, Any]]] = {}
+        for scope_id, event in batch:
+            by_scope.setdefault(scope_id, []).append(event)
+
+        for scope_id, events in by_scope.items():
+            self._post_usage(scope_id, events)
+
+    def _post_usage(self, scope_id: str, events: list[dict[str, Any]]) -> None:
+        url = f"{self.base_url}/v1/projects/{scope_id}/policies/usage"
+        try:
+            import httpx
+
+            with httpx.Client(timeout=self._timeout, follow_redirects=True) as client:
+                client.post(
+                    url,
+                    headers=self._headers(),
+                    params=self._query(),
+                    json=events,
+                )
+        except Exception as exc:
+            # Best-effort: a dropped batch under-counts spend slightly; it never
+            # over-counts (idempotent) and the backend stays authoritative.
+            _log.debug(
+                "usage push failed for project %r (%d events) — %s",
+                scope_id,
+                len(events),
+                exc,
+            )
+
+    def close(self) -> None:
+        """Stop the flush thread and drain any queued usage events."""
+        self._stop.set()
+        if self._flush_thread:
+            self._flush_thread.join(timeout=self._flush_interval * 2)
+        self._flush_once()
+
+
+def _normalize_policy(raw: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Map a backend policy row to the flat, snake_case dict the poller expects.
+
+    Backend shape: ``{type: "COST_CAP", name, enabled, failClosed,
+    config: {window, maxUsd, softUsd, action}}``. The poller wants a flat dict
+    keyed by ``type`` (lowercase) plus constructor params (``max_usd`` …).
+    Returns None for disabled or unmappable rows so they are skipped.
+    """
+    if not isinstance(raw, dict) or not raw.get("enabled", True):
+        return None
+    sdk_type = _TYPE_MAP.get(raw.get("type", ""))
+    if sdk_type is None:
+        return None
+    config = raw.get("config") or {}
+    mapped: dict[str, Any] = {
+        "type": sdk_type,
+        "name": raw.get("name", sdk_type),
+        "fail_closed": raw.get("failClosed", True),
+    }
+    if "maxUsd" in config:
+        mapped["max_usd"] = config["maxUsd"]
+    if "window" in config:
+        mapped["window"] = config["window"]
+    return mapped

--- a/src/noveum_trace/guard/api_client_http.py
+++ b/src/noveum_trace/guard/api_client_http.py
@@ -54,6 +54,9 @@ class HttpGuardAPIClient(GuardAPIClient):
         self._queue: list[tuple[str, dict[str, Any]]] = []
         self._queue_lock = threading.Lock()
         self._stop = threading.Event()
+        # Set to wake the worker for an early flush (batch full / shutdown) so the
+        # caller never blocks on the HTTP request itself.
+        self._wake = threading.Event()
         self._flush_thread: Optional[threading.Thread] = None
 
     # HTTP helpers
@@ -123,7 +126,9 @@ class HttpGuardAPIClient(GuardAPIClient):
             full = len(self._queue) >= self._batch_max
         self._ensure_thread()
         if full:
-            self._flush_once()
+            # Wake the worker for a prompt flush; the POST runs on its thread so
+            # the caller returns without waiting on the network.
+            self._wake.set()
 
     # reserve/reconcile have no backend equivalent; CostCapPolicy must not call
     # them (it checks supports_reservation first). Guard against wiring bugs.
@@ -189,7 +194,12 @@ class HttpGuardAPIClient(GuardAPIClient):
             self._flush_thread.start()
 
     def _run(self) -> None:
-        while not self._stop.wait(timeout=self._flush_interval):
+        # Flush on the interval, or earlier when woken by a full batch / shutdown.
+        while not self._stop.is_set():
+            self._wake.wait(timeout=self._flush_interval)
+            self._wake.clear()
+            if self._stop.is_set():
+                break
             try:
                 self._flush_once()
             except Exception:  # never let the flush thread die
@@ -235,6 +245,7 @@ class HttpGuardAPIClient(GuardAPIClient):
     def close(self) -> None:
         """Stop the flush thread and drain any queued usage events."""
         self._stop.set()
+        self._wake.set()  # wake the worker so it exits without waiting the interval
         if self._flush_thread:
             self._flush_thread.join(timeout=self._flush_interval * 2)
         self._flush_once()

--- a/src/noveum_trace/guard/policies/cost_cap.py
+++ b/src/noveum_trace/guard/policies/cost_cap.py
@@ -22,12 +22,15 @@ _log = logging.getLogger(__name__)
 class CostCapPolicy(AbstractPolicy):
     """Block calls that would exceed a per-project or per-org USD spend cap.
 
-    strict mode: reserves worst-case cost atomically in GuardAPIClient before
-    forwarding; reconciles after. Prevents any overshoot under concurrency.
+    strict mode: reserves worst-case cost before forwarding and reconciles after.
+    Prevents overshoot only when the backend supports atomic reservation — i.e.
+    the in-memory GuardAPIClient, which is single-process. With the HTTP backend
+    (no reserve endpoint) strict degrades to the shared model below.
 
-    non_strict mode: checks a local counter; allows all calls that look under-cap
-    at the moment of pre(). Reports actual cost in post(). May overshoot slightly
-    under high concurrency — advisory only.
+    shared / non_strict mode: reads accumulated spend (process-local for the
+    in-memory client, server-shared via /policies/state for the HTTP client) and
+    blocks when spend + estimate would exceed the cap; pushes actual cost in
+    post(). Overshoot is bounded by the poll interval, not the worker count.
 
     Scoping precedence (highest → lowest):
       1. explicit ``organization_id`` constructor arg → org-level cap
@@ -120,7 +123,14 @@ class CostCapPolicy(AbstractPolicy):
         with self._lock:
             mode = self.mode
 
-        if mode == EnforcementMode.strict:
+        # Strict reservation only holds when the backend can reserve atomically.
+        # The HTTP backend has no reserve endpoint, so strict degrades to the
+        # shared read-then-check path below.
+        use_reserve = mode == EnforcementMode.strict and getattr(
+            deps.api, "supports_reservation", True
+        )
+
+        if use_reserve:
             try:
                 result = deps.api.reserve(
                     call_id=ctx.call_id,
@@ -228,8 +238,11 @@ class CostCapPolicy(AbstractPolicy):
                 self.data_map.get(self.window, 0.0) + actual_usd
             )
 
+        use_reserve = mode == EnforcementMode.strict and getattr(
+            deps.api, "supports_reservation", True
+        )
         try:
-            if mode == EnforcementMode.strict:
+            if use_reserve:
                 if actual_usd <= reserved_usd:
                     # Return the unused headroom so the budget stays accurate.
                     deps.api.reconcile(ctx.call_id, scope_id, reserved_usd - actual_usd)
@@ -244,7 +257,15 @@ class CostCapPolicy(AbstractPolicy):
                         resp.model,
                     )
             else:
-                deps.api.report_usage(ctx.call_id, scope_id, actual_usd, resp.model)
+                # Shared model: push the full actual usage (idempotent by call_id).
+                deps.api.report_usage(
+                    ctx.call_id,
+                    scope_id,
+                    actual_usd,
+                    resp.model,
+                    resp.input_tokens,
+                    resp.output_tokens,
+                )
         except Exception:
             pass  # reporting failure is non-blocking; local counter already updated
 
@@ -260,7 +281,10 @@ class CostCapPolicy(AbstractPolicy):
             if "mode" in decision.state
             else self.mode
         )
-        if mode == EnforcementMode.strict:
+        use_reserve = mode == EnforcementMode.strict and getattr(
+            deps.api, "supports_reservation", True
+        )
+        if use_reserve:
             reserved_usd = decision.state.get("reserved_usd", 0.0)
             try:
                 # Always reconcile in strict mode — even with reserved_usd=0 this
@@ -309,7 +333,7 @@ class CostCapPolicy(AbstractPolicy):
         if not scope_id:
             return
         try:
-            state = deps.api.get_state(scope_id)
+            state = deps.api.get_state(scope_id, self.window)
             with self._lock:
                 self.data_map[self.window] = state.get("spend", 0.0)
         except Exception:

--- a/tests/unit/guard/test_api_client_http.py
+++ b/tests/unit/guard/test_api_client_http.py
@@ -1,0 +1,309 @@
+"""Unit tests for HttpGuardAPIClient — the server-authoritative Guard backend.
+
+The backend is exercised through a fake ``httpx.Client`` injected via
+monkeypatch, so these tests assert the exact HTTP contract (URLs, request
+bodies, response mapping) without a network.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pytest
+
+from noveum_trace.guard.api_client_http import HttpGuardAPIClient
+from noveum_trace.guard.exceptions import GuardBackendUnavailable
+
+
+def _call_id() -> str:
+    return str(uuid.uuid4())
+
+
+class _Resp:
+    def __init__(self, status_code: int, json_data=None):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {}
+
+    def json(self):
+        return self._json
+
+
+class _FakeClient:
+    """Records every get/post so tests can assert the HTTP contract."""
+
+    calls: list[dict] = []
+
+    def __init__(self, *, get_resp=None, get_exc=None, post_exc=None):
+        self._get_resp = get_resp
+        self._get_exc = get_exc
+        self._post_exc = post_exc
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def get(self, url, headers=None, params=None):
+        _FakeClient.calls.append(
+            {"method": "GET", "url": url, "headers": headers, "params": params}
+        )
+        if self._get_exc is not None:
+            raise self._get_exc
+        return self._get_resp
+
+    def post(self, url, headers=None, params=None, json=None):
+        _FakeClient.calls.append(
+            {
+                "method": "POST",
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "json": json,
+            }
+        )
+        if self._post_exc is not None:
+            raise self._post_exc
+        return _Resp(202, {"success": True})
+
+
+def _patch(monkeypatch, **kwargs) -> None:
+    _FakeClient.calls = []
+    monkeypatch.setattr(httpx, "Client", lambda **kw: _FakeClient(**kwargs))
+
+
+# ---------------------------------------------------------------------------
+# get_state — GET /policies/state
+# ---------------------------------------------------------------------------
+
+
+class TestGetState:
+    def test_reads_the_requested_window(self, monkeypatch):
+        _patch(
+            monkeypatch,
+            get_resp=_Resp(200, {"cost": {"30d_rolling": 1247.81, "1d_rolling": 12.0}}),
+        )
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        assert api.get_state("proj", "30d_rolling") == {"spend": 1247.81}
+
+    def test_missing_window_reads_zero(self, monkeypatch):
+        _patch(monkeypatch, get_resp=_Resp(200, {"cost": {}}))
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        assert api.get_state("proj", "7d_rolling") == {"spend": 0.0}
+
+    def test_hits_project_state_url(self, monkeypatch):
+        _patch(monkeypatch, get_resp=_Resp(200, {"cost": {}}))
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        api.get_state("proj-1")
+        call = _FakeClient.calls[0]
+        assert call["url"] == "https://api.noveum.ai/v1/projects/proj-1/policies/state"
+        assert call["headers"]["Authorization"] == "Bearer k"
+
+    def test_org_slug_sent_as_query_param(self, monkeypatch):
+        _patch(monkeypatch, get_resp=_Resp(200, {"cost": {}}))
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", organization_slug="acme"
+        )
+        api.get_state("proj")
+        assert _FakeClient.calls[0]["params"] == {"organizationSlug": "acme"}
+
+    def test_non_200_raises(self, monkeypatch):
+        _patch(monkeypatch, get_resp=_Resp(500))
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        with pytest.raises(GuardBackendUnavailable):
+            api.get_state("proj")
+
+    def test_network_error_raises(self, monkeypatch):
+        _patch(monkeypatch, get_exc=httpx.ConnectError("boom"))
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        with pytest.raises(GuardBackendUnavailable):
+            api.get_state("proj")
+
+    def test_strips_api_suffix_from_base_url(self, monkeypatch):
+        _patch(monkeypatch, get_resp=_Resp(200, {"cost": {}}))
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai/api")
+        api.get_state("proj")
+        assert _FakeClient.calls[0]["url"].startswith(
+            "https://api.noveum.ai/v1/projects/proj"
+        )
+
+
+# ---------------------------------------------------------------------------
+# report_usage — batched POST /policies/usage
+# ---------------------------------------------------------------------------
+
+
+class TestReportUsage:
+    def test_event_has_backend_shape(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        cid = _call_id()
+        api.report_usage(cid, "proj", 0.0123, "gpt-4o", 800, 200)
+        api.close()  # drains
+
+        post = [c for c in _FakeClient.calls if c["method"] == "POST"][0]
+        assert post["url"] == "https://api.noveum.ai/v1/projects/proj/policies/usage"
+        event = post["json"][0]
+        assert event["model"] == "gpt-4o"
+        assert event["inputTokens"] == 800
+        assert event["outputTokens"] == 200
+        assert event["costUsd"] == 0.0123
+        assert event["requestCount"] == 1
+        assert event["eventId"] == cid  # idempotency key = call_id
+        assert event["timestamp"].endswith("Z")
+
+    def test_auto_flush_when_batch_full(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k",
+            base_url="https://api.noveum.ai",
+            flush_interval=3600,
+            batch_max=2,
+        )
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        assert [c for c in _FakeClient.calls if c["method"] == "POST"] == []
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")  # hits batch_max → flush
+        posts = [c for c in _FakeClient.calls if c["method"] == "POST"]
+        assert len(posts) == 1
+        assert len(posts[0]["json"]) == 2
+        api.close()
+
+    def test_events_grouped_by_scope(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        api.report_usage(_call_id(), "proj-a", 1.0, "gpt-4o")
+        api.report_usage(_call_id(), "proj-b", 1.0, "gpt-4o")
+        api.close()
+        posts = [c for c in _FakeClient.calls if c["method"] == "POST"]
+        urls = {c["url"] for c in posts}
+        assert urls == {
+            "https://api.noveum.ai/v1/projects/proj-a/policies/usage",
+            "https://api.noveum.ai/v1/projects/proj-b/policies/usage",
+        }
+
+    def test_negative_cost_is_dropped(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        api.report_usage(_call_id(), "proj", -1.0, "gpt-4o")
+        api.close()
+        assert [c for c in _FakeClient.calls if c["method"] == "POST"] == []
+
+    def test_push_failure_is_swallowed(self, monkeypatch):
+        _patch(monkeypatch, post_exc=httpx.ConnectError("down"))
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        api.close()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# reserve / reconcile — unsupported by the HTTP backend
+# ---------------------------------------------------------------------------
+
+
+class TestReservationUnsupported:
+    def test_supports_reservation_is_false(self):
+        api = HttpGuardAPIClient(api_key="k")
+        assert api.supports_reservation is False
+
+    def test_reserve_raises(self):
+        api = HttpGuardAPIClient(api_key="k")
+        with pytest.raises(NotImplementedError):
+            api.reserve(_call_id(), "proj", 1.0, 100.0)
+
+    def test_reconcile_raises(self):
+        api = HttpGuardAPIClient(api_key="k")
+        with pytest.raises(NotImplementedError):
+            api.reconcile(_call_id(), "proj", 1.0)
+
+
+# ---------------------------------------------------------------------------
+# fetch_remote_policies — GET /policies/effective + shape mapping
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRemotePolicies:
+    def test_maps_cost_cap_shape(self, monkeypatch):
+        _patch(
+            monkeypatch,
+            get_resp=_Resp(
+                200,
+                [
+                    {
+                        "policyId": "p1",
+                        "name": "Monthly budget",
+                        "type": "COST_CAP",
+                        "enabled": True,
+                        "failClosed": True,
+                        "config": {
+                            "window": "30d_rolling",
+                            "maxUsd": 1500,
+                            "action": "BLOCK",
+                        },
+                    }
+                ],
+            ),
+        )
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        result = api.fetch_remote_policies("proj")
+        assert result == [
+            {
+                "type": "cost_cap",
+                "name": "Monthly budget",
+                "fail_closed": True,
+                "max_usd": 1500,
+                "window": "30d_rolling",
+            }
+        ]
+
+    def test_hits_effective_url(self, monkeypatch):
+        _patch(monkeypatch, get_resp=_Resp(200, []))
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        api.fetch_remote_policies("proj")
+        assert (
+            _FakeClient.calls[0]["url"]
+            == "https://api.noveum.ai/v1/projects/proj/policies/effective"
+        )
+
+    def test_disabled_policy_skipped(self, monkeypatch):
+        _patch(
+            monkeypatch,
+            get_resp=_Resp(
+                200,
+                [
+                    {
+                        "name": "off",
+                        "type": "COST_CAP",
+                        "enabled": False,
+                        "config": {"maxUsd": 10, "window": "1d_rolling"},
+                    }
+                ],
+            ),
+        )
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        assert api.fetch_remote_policies("proj") == []
+
+    def test_unknown_type_skipped(self, monkeypatch):
+        _patch(
+            monkeypatch,
+            get_resp=_Resp(
+                200,
+                [{"name": "x", "type": "SOMETHING_NEW", "enabled": True, "config": {}}],
+            ),
+        )
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        assert api.fetch_remote_policies("proj") == []
+
+    def test_non_200_raises(self, monkeypatch):
+        _patch(monkeypatch, get_resp=_Resp(403))
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        with pytest.raises(GuardBackendUnavailable):
+            api.fetch_remote_policies("proj")

--- a/tests/unit/guard/test_api_client_http.py
+++ b/tests/unit/guard/test_api_client_http.py
@@ -7,6 +7,7 @@ bodies, response mapping) without a network.
 
 from __future__ import annotations
 
+import time
 import uuid
 
 import httpx
@@ -165,8 +166,17 @@ class TestReportUsage:
         )
         api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
         assert [c for c in _FakeClient.calls if c["method"] == "POST"] == []
-        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")  # hits batch_max → flush
-        posts = [c for c in _FakeClient.calls if c["method"] == "POST"]
+        # Filling the batch wakes the worker; the flush runs on its thread (never
+        # inline on the caller). With flush_interval=3600 only the wake can fire
+        # it, so a POST appearing means the batch-full signal worked.
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        deadline = time.time() + 5.0
+        posts: list = []
+        while time.time() < deadline:
+            posts = [c for c in _FakeClient.calls if c["method"] == "POST"]
+            if posts:
+                break
+            time.sleep(0.01)
         assert len(posts) == 1
         assert len(posts[0]["json"]) == 2
         api.close()

--- a/tests/unit/guard/test_cost_cap_shared.py
+++ b/tests/unit/guard/test_cost_cap_shared.py
@@ -1,0 +1,127 @@
+"""CostCapPolicy against a non-reserving (HTTP-style) backend.
+
+When the backend cannot reserve atomically (``supports_reservation = False``),
+strict mode must degrade to the shared read-then-check model: never call
+``reserve``/``reconcile``, block off polled shared spend, and push the full
+actual usage in post().
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from noveum_trace.guard.policies.cost_cap import CostCapPolicy
+from noveum_trace.guard.types import (
+    EnforcementMode,
+    ParsedRequest,
+    ParsedResponse,
+    PolicyContext,
+    PolicyDeps,
+)
+
+
+class _FakeSharedClient:
+    """Server-authoritative client stub: reserve/reconcile are hard errors."""
+
+    supports_reservation = False
+
+    def __init__(self, spend: float = 0.0):
+        self._spend = spend
+        self.usage_calls: list[tuple] = []
+
+    def get_state(self, project_id, window=None):
+        return {"spend": self._spend}
+
+    def report_usage(
+        self, call_id, project_id, actual_usd, model, input_tokens=0, output_tokens=0
+    ):
+        self.usage_calls.append(
+            (call_id, project_id, actual_usd, model, input_tokens, output_tokens)
+        )
+
+    def reserve(self, *a, **k):  # must never be called in shared mode
+        raise AssertionError("reserve() called against a non-reserving backend")
+
+    def reconcile(self, *a, **k):
+        raise AssertionError("reconcile() called against a non-reserving backend")
+
+
+def _ctx() -> PolicyContext:
+    return PolicyContext(
+        project_id="proj",
+        organization_id=None,
+        environment="test",
+        trace_id=None,
+        span_id=None,
+        call_id=str(uuid.uuid4()),
+    )
+
+
+def _req() -> ParsedRequest:
+    return ParsedRequest(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        max_tokens=100,
+        estimated_input_tokens=50,
+        raw_body=b"{}",
+    )
+
+
+def _resp(cost_usd: float) -> ParsedResponse:
+    return ParsedResponse(
+        model="gpt-4o-mini",
+        text="ok",
+        input_tokens=50,
+        output_tokens=100,
+        cost_usd=cost_usd,
+    )
+
+
+def _policy() -> CostCapPolicy:
+    # strict is requested but must degrade because the backend can't reserve.
+    return CostCapPolicy(max_usd=100.0, mode=EnforcementMode.strict, project_id="proj")
+
+
+def test_strict_degrades_and_allows_under_shared_spend():
+    api = _FakeSharedClient(spend=0.0)
+    deps = PolicyDeps(api=api)
+    policy = _policy()
+    policy.poll(deps)  # load shared spend into data_map
+    decision = policy.pre(_req(), _ctx(), deps)
+    assert not decision.is_blocking  # and reserve() was never called
+
+
+def test_strict_degrades_and_blocks_over_shared_spend():
+    api = _FakeSharedClient(spend=100.0)  # cap exhausted per shared counter
+    deps = PolicyDeps(api=api)
+    policy = _policy()
+    policy.poll(deps)
+    decision = policy.pre(_req(), _ctx(), deps)
+    assert decision.is_blocking
+
+
+def test_post_pushes_full_actual_usage_with_tokens():
+    api = _FakeSharedClient(spend=0.0)
+    deps = PolicyDeps(api=api)
+    policy = _policy()
+    policy.poll(deps)
+    ctx = _ctx()
+    decision = policy.pre(_req(), ctx, deps)
+    policy.post(_resp(cost_usd=0.5), ctx, decision, deps)
+
+    assert len(api.usage_calls) == 1
+    call_id, project_id, actual_usd, model, in_tok, out_tok = api.usage_calls[0]
+    assert actual_usd == 0.5  # full actual, not an over-estimate excess
+    assert (in_tok, out_tok) == (50, 100)
+
+
+def test_release_does_not_reconcile_when_backend_cannot_reserve():
+    api = _FakeSharedClient(spend=0.0)
+    deps = PolicyDeps(api=api)
+    policy = _policy()
+    policy.poll(deps)
+    ctx = _ctx()
+    decision = policy.pre(_req(), ctx, deps)
+    policy.release(decision, ctx, deps)  # must not raise AssertionError


### PR DESCRIPTION
# Pull Request

## Description

Fix the Guard cost cap so it works correctly across multiple processes.

Previously, `GuardAPIClient` stored spend in a process-local dictionary. In multi-worker deployments (gunicorn, Kubernetes, ECS, etc.), each worker tracked its own spend, effectively multiplying the configured budget and resetting usage after restarts.

This PR introduces a shared backend implementation:

* Adds `HttpGuardAPIClient` (automatically used when an API key is present).
* Reads shared spend from the backend (`/policies/state`).
* Reports usage asynchronously in batched, idempotent requests (`/policies/usage`).
* Fetches effective policies from the backend and maps them to the SDK format.
* Falls back from local "strict" reservations to shared read/check mode since the backend has no atomic `/reserve` endpoint.

The in-memory client remains unchanged for local development and tests.

**Result:** spend is shared across all workers and survives restarts. Overshoot is now bounded by the polling interval instead of the number of workers.

Fixes: **P0 – Guard cost cap is per-process in-memory**

---

## Type of change

* [x] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Performance improvement
* [ ] Refactoring
* [ ] Test improvements

> **Release note:** This should not be released until the backend endpoints are deployed.

---

## Testing

* [x] Unit tests
* [x] Manual testing

### Verified

* Added unit tests for the new HTTP client.
* Added unit tests covering shared cost-cap behavior.
* Guard test suite: **203 passed**
* Full unit suite: **1603 passed**
* `mypy`, `ruff`, `black`, and `isort` all clean.

### Manual validation

Verified with 4 separate OS processes:

* **HTTP client:** all processes shared one backend counter (total = **$100**).
* **In-memory client:** each process maintained its own **$25** counter.

---

## Files Changed

* Added `HttpGuardAPIClient`
* Updated Guard client selection
* Updated `CostCapPolicy`
* Exported HTTP client
* Added HTTP client and shared-cost-cap tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `organization` parameter to Guard SDK initialization for HTTP backend bootstrapping.
  * Introduced an HTTP Guard backend client with effective policy fetching and background-batched usage reporting (including input/output token counts).
  * Exposed the HTTP Guard client for direct use.
* **Bug Fixes**
  * Cost cap strict mode now automatically falls back to shared read-then-check when the backend doesn’t support reservations.
  * Cost cap spend polling is now window-specific.
  * Shutdown now best-effort flushes any queued usage events before clearing state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->