### PR TITLE
feat/guard-rate-limit-policy

### DIFF
--- a/src/noveum_trace/guard/__init__.py
+++ b/src/noveum_trace/guard/__init__.py
@@ -6,7 +6,7 @@ from noveum_trace.guard.engine import PolicyEngine
 from noveum_trace.guard.exceptions import GuardBackendUnavailable, NoveumGuardBlocked
 from noveum_trace.guard.integrations.bedrock import instrument_bedrock
 from noveum_trace.guard.integrations.crewai import NoveumCrewAIInterceptor
-from noveum_trace.guard.policies import AbstractPolicy, CostCapPolicy
+from noveum_trace.guard.policies import AbstractPolicy, CostCapPolicy, RateLimitPolicy
 from noveum_trace.guard.poller import PolicyPoller
 from noveum_trace.guard.transport import (
     NoveumAsyncTransport,
@@ -64,6 +64,7 @@ __all__ = [
     # Policies
     "AbstractPolicy",
     "CostCapPolicy",
+    "RateLimitPolicy",
     # Transport
     "NoveumTransport",
     "NoveumAsyncTransport",

--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -34,11 +34,10 @@ class GuardAPIClient:
         self, api_key: str = "", base_url: str = "https://api.noveum.ai"
     ) -> None:
         self.api_key = api_key
-        # The tracing SDK uses DEFAULT_ENDPOINT which includes a trailing /api path
-        # component, but the guard API paths start at /v1/ from the domain root.
-        # Strip /api so fetch_remote_policies() produces the correct URL.
-        stripped = base_url.rstrip("/")
-        self.base_url = stripped[:-4] if stripped.endswith("/api") else stripped
+        # Guard endpoints live under the same /api prefix as the tracing API
+        # (e.g. https://api.noveum.ai/api/v1/projects/{id}/policies/effective).
+        # DEFAULT_ENDPOINT already includes /api, so just trim trailing slashes.
+        self.base_url = base_url.rstrip("/")
         self._lock = threading.Lock()
         # project_id → accumulated spend (USD)
         self._spend: dict[str, float] = {}
@@ -46,6 +45,12 @@ class GuardAPIClient:
         self._inflight: dict[str, float] = {}
         # project_id → arbitrary policy config dict (refreshed by poll)
         self._policy_configs: dict[str, dict[str, Any]] = {}
+        # project_id → {"requests_1m": int, "tokens_1m": int, ...} for RateLimitPolicy
+        self._rate: dict[str, dict[str, int]] = {}
+        # call_ids already folded into _spend/_rate via report_usage — guards
+        # against double counting when more than one policy (e.g. CostCapPolicy
+        # in shared mode + RateLimitPolicy) reports the same call's usage.
+        self._reported_event_ids: set[str] = set()
 
     # Core accounting
 
@@ -110,29 +115,45 @@ class GuardAPIClient:
         input_tokens: int = 0,
         output_tokens: int = 0,
     ) -> None:
-        """Record actual cost (non-strict post only).
+        """Record actual cost and rate-limit counters for a completed call.
 
-        Non-strict never calls reserve(), so there is nothing to reconcile —
-        we simply add the actual spend. Token counts are accepted for interface
-        parity with the HTTP client (which forwards them) but unused here.
+        Non-strict cost accounting never calls reserve(), so there is nothing
+        to reconcile — we simply add the actual spend. Also bumps the
+        request/token counters RateLimitPolicy reads back via get_state().
+        Deduped by ``call_id`` so CostCapPolicy (shared mode) and
+        RateLimitPolicy reporting the same call don't double count.
         """
         if actual_usd < 0:
             raise ValueError(f"actual_usd must be non-negative, got {actual_usd}")
         with self._lock:
+            if call_id in self._reported_event_ids:
+                return
+            self._reported_event_ids.add(call_id)
             self._spend[project_id] = self._spend.get(project_id, 0.0) + actual_usd
+            rate = self._rate.setdefault(project_id, {})
+            for period in ("1m", "1h", "1d"):
+                rate[f"requests_{period}"] = rate.get(f"requests_{period}", 0) + 1
+                rate[f"tokens_{period}"] = (
+                    rate.get(f"tokens_{period}", 0) + input_tokens + output_tokens
+                )
 
     # Policy config / polling
 
     def get_state(
         self, project_id: str, window: Optional[str] = None
     ) -> dict[str, Any]:
-        """Spend snapshot for poll(). Returns a copy to avoid lock-holding in caller.
+        """Spend + rate snapshot for poll(). Returns a copy to avoid lock-holding
+        in the caller.
 
         ``window`` is accepted for interface parity with the HTTP client (which
-        selects a per-window counter); the in-memory stub tracks one bucket.
+        selects a per-window cost counter); the in-memory stub tracks one
+        bucket. ``rate`` mirrors the backend's requests_*/tokens_* shape.
         """
         with self._lock:
-            return {"spend": self._spend.get(project_id, 0.0)}
+            return {
+                "spend": self._spend.get(project_id, 0.0),
+                "rate": dict(self._rate.get(project_id, {})),
+            }
 
     def get_policy_config(self, project_id: str) -> Optional[dict[str, Any]]:
         with self._lock:
@@ -203,6 +224,10 @@ class GuardAPIClient:
         with self._lock:
             return self._spend.get(project_id, 0.0)
 
+    def current_rate(self, project_id: str) -> dict[str, int]:
+        with self._lock:
+            return dict(self._rate.get(project_id, {}))
+
     def inflight_count(self) -> int:
         with self._lock:
             return len(self._inflight)
@@ -213,3 +238,5 @@ class GuardAPIClient:
             self._spend.clear()
             self._inflight.clear()
             self._policy_configs.clear()
+            self._rate.clear()
+            self._reported_event_ids.clear()

--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from noveum_trace.guard.exceptions import GuardBackendUnavailable
+
+# In-memory rate windows (seconds). Mirrors the backend periods in
+# guardrails/schemas.ts; the HTTP backend does its own windowing server-side.
+_PERIODS = ("1m", "1h", "1d")
+_WINDOW_SECONDS = {"1m": 60.0, "1h": 3600.0, "1d": 86400.0}
+_MAX_WINDOW_SECONDS = 86400.0  # 1d — the longest window bounds retention
 
 
 @dataclass
@@ -45,12 +52,15 @@ class GuardAPIClient:
         self._inflight: dict[str, float] = {}
         # project_id → arbitrary policy config dict (refreshed by poll)
         self._policy_configs: dict[str, dict[str, Any]] = {}
-        # project_id → {"requests_1m": int, "tokens_1m": int, ...} for RateLimitPolicy
-        self._rate: dict[str, dict[str, int]] = {}
-        # call_ids already folded into _spend/_rate via report_usage — guards
-        # against double counting when more than one policy (e.g. CostCapPolicy
-        # in shared mode + RateLimitPolicy) reports the same call's usage.
-        self._reported_event_ids: set[str] = set()
+        # project_id → list of (monotonic_ts, tokens) per reported call, so the
+        # windowed request/token counts RateLimitPolicy reads only include events
+        # still inside their 1m/1h/1d window. Events past 1d are evicted.
+        self._rate_events: dict[str, list[tuple[float, int]]] = {}
+        # call_id → monotonic_ts of the report already folded into _spend/_rate —
+        # guards against double counting when more than one policy (e.g.
+        # CostCapPolicy in shared mode + RateLimitPolicy) reports the same call.
+        # Timestamped so stale ids can be evicted rather than growing unbounded.
+        self._reported_event_ids: dict[str, float] = {}
 
     # Core accounting
 
@@ -125,17 +135,16 @@ class GuardAPIClient:
         """
         if actual_usd < 0:
             raise ValueError(f"actual_usd must be non-negative, got {actual_usd}")
+        now = time.monotonic()
         with self._lock:
+            self._evict_expired(now)
             if call_id in self._reported_event_ids:
                 return
-            self._reported_event_ids.add(call_id)
+            self._reported_event_ids[call_id] = now
             self._spend[project_id] = self._spend.get(project_id, 0.0) + actual_usd
-            rate = self._rate.setdefault(project_id, {})
-            for period in ("1m", "1h", "1d"):
-                rate[f"requests_{period}"] = rate.get(f"requests_{period}", 0) + 1
-                rate[f"tokens_{period}"] = (
-                    rate.get(f"tokens_{period}", 0) + input_tokens + output_tokens
-                )
+            self._rate_events.setdefault(project_id, []).append(
+                (now, input_tokens + output_tokens)
+            )
 
     # Policy config / polling
 
@@ -149,11 +158,52 @@ class GuardAPIClient:
         selects a per-window cost counter); the in-memory stub tracks one
         bucket. ``rate`` mirrors the backend's requests_*/tokens_* shape.
         """
+        now = time.monotonic()
         with self._lock:
+            self._evict_expired(now)
             return {
                 "spend": self._spend.get(project_id, 0.0),
-                "rate": dict(self._rate.get(project_id, {})),
+                "rate": self._windowed_rate(project_id, now),
             }
+
+    def _evict_expired(self, now: float) -> None:
+        """Drop rate events and reported call_ids older than the largest window.
+
+        Caller must hold ``self._lock``. Bounds memory and keeps the windowed
+        counts accurate as events age out. Duplicate protection only needs to
+        outlive the longest window — a genuine retry always lands far sooner.
+        """
+        cutoff = now - _MAX_WINDOW_SECONDS
+        for pid in list(self._rate_events):
+            kept = [e for e in self._rate_events[pid] if e[0] >= cutoff]
+            if kept:
+                self._rate_events[pid] = kept
+            else:
+                del self._rate_events[pid]
+        for cid in [c for c, ts in self._reported_event_ids.items() if ts < cutoff]:
+            del self._reported_event_ids[cid]
+
+    def _windowed_rate(self, project_id: str, now: float) -> dict[str, int]:
+        """Request/token counts per window, counting only events inside each.
+
+        Caller must hold ``self._lock``. Returns ``{}`` when the project has no
+        live events, matching get_state()'s zero-state for a fresh project.
+        """
+        events = self._rate_events.get(project_id)
+        if not events:
+            return {}
+        result: dict[str, int] = {}
+        for period in _PERIODS:
+            cutoff = now - _WINDOW_SECONDS[period]
+            requests = 0
+            tokens = 0
+            for ts, tok in events:
+                if ts >= cutoff:
+                    requests += 1
+                    tokens += tok
+            result[f"requests_{period}"] = requests
+            result[f"tokens_{period}"] = tokens
+        return result
 
     def get_policy_config(self, project_id: str) -> Optional[dict[str, Any]]:
         with self._lock:
@@ -225,8 +275,10 @@ class GuardAPIClient:
             return self._spend.get(project_id, 0.0)
 
     def current_rate(self, project_id: str) -> dict[str, int]:
+        now = time.monotonic()
         with self._lock:
-            return dict(self._rate.get(project_id, {}))
+            self._evict_expired(now)
+            return self._windowed_rate(project_id, now)
 
     def inflight_count(self) -> int:
         with self._lock:
@@ -238,5 +290,5 @@ class GuardAPIClient:
             self._spend.clear()
             self._inflight.clear()
             self._policy_configs.clear()
-            self._rate.clear()
+            self._rate_events.clear()
             self._reported_event_ids.clear()

--- a/src/noveum_trace/guard/api_client_http.py
+++ b/src/noveum_trace/guard/api_client_http.py
@@ -76,7 +76,11 @@ class HttpGuardAPIClient(GuardAPIClient):
     def get_state(
         self, project_id: str, window: Optional[str] = None
     ) -> dict[str, Any]:
-        """Read shared spend for ``window`` from the backend live-state endpoint."""
+        """Read shared spend + rate counters from the backend live-state endpoint.
+
+        ``spend`` is the ``cost[window]`` bucket CostCapPolicy polls; ``rate``
+        is the ``requests_*``/``tokens_*`` counter map RateLimitPolicy polls.
+        """
         window = window or _DEFAULT_WINDOW
         url = f"{self.base_url}/v1/projects/{project_id}/policies/state"
         try:
@@ -85,8 +89,13 @@ class HttpGuardAPIClient(GuardAPIClient):
             with httpx.Client(timeout=self._timeout, follow_redirects=True) as client:
                 resp = client.get(url, headers=self._headers(), params=self._query())
             if resp.status_code == 200:
-                cost = resp.json().get("cost", {}) or {}
-                return {"spend": float(cost.get(window, 0.0) or 0.0)}
+                body = resp.json()
+                cost = body.get("cost", {}) or {}
+                rate = body.get("rate", {}) or {}
+                return {
+                    "spend": float(cost.get(window, 0.0) or 0.0),
+                    "rate": dict(rate),
+                }
             raise GuardBackendUnavailable(
                 f"get_state: backend returned {resp.status_code} "
                 f"for project {project_id!r}"
@@ -274,4 +283,6 @@ def _normalize_policy(raw: dict[str, Any]) -> Optional[dict[str, Any]]:
         mapped["max_usd"] = config["maxUsd"]
     if "window" in config:
         mapped["window"] = config["window"]
+    if "windows" in config:
+        mapped["windows"] = config["windows"]
     return mapped

--- a/src/noveum_trace/guard/policies/__init__.py
+++ b/src/noveum_trace/guard/policies/__init__.py
@@ -1,4 +1,5 @@
 from noveum_trace.guard.policies.base import AbstractPolicy
 from noveum_trace.guard.policies.cost_cap import CostCapPolicy
+from noveum_trace.guard.policies.rate_limit import RateLimitPolicy
 
-__all__ = ["AbstractPolicy", "CostCapPolicy"]
+__all__ = ["AbstractPolicy", "CostCapPolicy", "RateLimitPolicy"]

--- a/src/noveum_trace/guard/policies/rate_limit.py
+++ b/src/noveum_trace/guard/policies/rate_limit.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from noveum_trace.guard.decision import PolicyDecision
+from noveum_trace.guard.policies.base import AbstractPolicy
+from noveum_trace.guard.poller import register_policy_type
+from noveum_trace.guard.types import (
+    ParsedRequest,
+    ParsedResponse,
+    Phase,
+    PolicyContext,
+    PolicyDeps,
+)
+
+_log = logging.getLogger(__name__)
+
+# Backend rate-limit periods (packages/api/.../guardrails/schemas.ts).
+_PERIODS = ("1m", "1h", "1d")
+
+
+class RateLimitPolicy(AbstractPolicy):
+    """Block calls once a per-window request or token count is reached.
+
+    Unlike CostCapPolicy there is no strict/reserve mode here: the backend has
+    no atomic reserve endpoint for request or token counts (same gap
+    documented on ``HttpGuardAPIClient`` for cost), so this policy always
+    follows the shared read-then-check model — pre() compares against counts
+    last read from GET /policies/state (refreshed every ``poll_interval``
+    seconds), and post() pushes the call's actual usage via
+    ``deps.api.report_usage`` so the backend's next snapshot reflects it.
+    Overshoot within one process is bounded by the poll interval, matching
+    CostCapPolicy's shared/non-strict tradeoff.
+
+    ``windows`` mirrors the backend RATE_LIMIT config shape: a list of
+    ``{"period": "1m"|"1h"|"1d", "maxRequests": int|None, "maxTokens": int|None}``.
+    Either threshold may be omitted/None to leave that dimension unenforced.
+    """
+
+    name = "rate_limit"
+    poll_interval: float = 30.0
+
+    def __init__(
+        self,
+        windows: Optional[list[dict[str, Any]]] = None,
+        fail_closed: bool = True,
+        project_id: Optional[str] = None,
+        organization_id: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.windows = list(windows) if windows else []
+        self.fail_closed = fail_closed
+        self._project_id = project_id
+        self._organization_id = organization_id
+
+    def bind_context(self, ctx: PolicyContext) -> None:
+        # Adopt the ambient org/project so the background poller can scope
+        # get_state() when the policy was constructed without explicit IDs.
+        if not self._organization_id and not self._project_id:
+            self._organization_id = ctx.organization_id
+            self._project_id = ctx.project_id
+        if not self._project_id:
+            self._project_id = ctx.project_id
+
+    def _scope_id(self, ctx: PolicyContext) -> str:
+        """Return the scope key to use for API calls: org > project."""
+        with self._lock:
+            org = self._organization_id
+            proj = self._project_id
+        if org:
+            return org
+        if proj:
+            return proj
+        return ctx.organization_id or ctx.project_id
+
+    def _stored_scope_id(self) -> str:
+        """Scope key for poll(), which has no per-call ctx."""
+        with self._lock:
+            return self._organization_id or self._project_id or ""
+
+    def pre(
+        self, parsed: ParsedRequest, ctx: PolicyContext, deps: PolicyDeps
+    ) -> PolicyDecision:
+        scope_id = self._scope_id(ctx)
+        with self._lock:
+            windows = list(self.windows)
+            counts = dict(self.data_map)
+
+        for w in windows:
+            period = w.get("period")
+            if period not in _PERIODS:
+                continue
+            max_requests = w.get("maxRequests")
+            max_tokens = w.get("maxTokens")
+            requests = counts.get(f"requests_{period}", 0)
+            tokens = counts.get(f"tokens_{period}", 0)
+            if max_requests and requests >= max_requests:
+                return PolicyDecision.block(
+                    self.name,
+                    Phase.pre,
+                    reason=(
+                        f"Rate limit reached: {requests}/{max_requests} "
+                        f"requests per {period}"
+                    ),
+                    state={"scope_id": scope_id},
+                )
+            if max_tokens and tokens >= max_tokens:
+                return PolicyDecision.block(
+                    self.name,
+                    Phase.pre,
+                    reason=(
+                        f"Rate limit reached: {tokens}/{max_tokens} tokens per {period}"
+                    ),
+                    state={"scope_id": scope_id},
+                )
+
+        return PolicyDecision.allow(self.name, Phase.pre, state={"scope_id": scope_id})
+
+    def post(
+        self,
+        resp: ParsedResponse,
+        ctx: PolicyContext,
+        decision: PolicyDecision,
+        deps: PolicyDeps,
+    ) -> PolicyDecision:
+        scope_id: str = decision.state.get("scope_id") or self._scope_id(ctx)
+        total_tokens = resp.input_tokens + resp.output_tokens
+
+        # Update local counters immediately so concurrent calls in this same
+        # process see this call's impact before the next poll() re-syncs from
+        # the backend (mirrors CostCapPolicy's non-strict post()).
+        with self._lock:
+            for period in _PERIODS:
+                self.data_map[f"requests_{period}"] = (
+                    self.data_map.get(f"requests_{period}", 0) + 1
+                )
+                self.data_map[f"tokens_{period}"] = (
+                    self.data_map.get(f"tokens_{period}", 0) + total_tokens
+                )
+
+        try:
+            # Idempotent by call_id on the backend (and on the in-memory stub),
+            # so this is safe even when a CostCapPolicy on the same call also
+            # reports the identical usage.
+            deps.api.report_usage(
+                ctx.call_id,
+                scope_id,
+                resp.cost_usd,
+                resp.model,
+                resp.input_tokens,
+                resp.output_tokens,
+            )
+        except Exception:
+            pass  # reporting failure is non-blocking; local counters already updated
+
+        return PolicyDecision.allow(self.name, Phase.post)  # rate post never blocks
+
+    def update_params(self, config: dict[str, Any]) -> None:
+        """Apply parameter updates received from the backend.
+
+        Recognised keys (all optional):
+            ``windows``         — list of {period, maxRequests, maxTokens}
+            ``fail_closed``     — bool; whether to block on unexpected exception
+            ``organization_id`` — switch or set org-level scoping
+            ``project_id``      — switch or set project-level scoping
+        """
+        with self._lock:
+            if "windows" in config:
+                self.windows = list(config["windows"] or [])
+            if "fail_closed" in config:
+                self.fail_closed = bool(config["fail_closed"])
+            if "organization_id" in config:
+                self._organization_id = config["organization_id"] or None
+            if "project_id" in config:
+                self._project_id = config["project_id"] or None
+
+    def poll(self, deps: PolicyDeps) -> None:
+        scope_id = self._stored_scope_id()
+        if not scope_id:
+            return
+        try:
+            state = deps.api.get_state(scope_id)
+            rate = state.get("rate") or {}
+            with self._lock:
+                self.data_map.update(rate)
+        except Exception:
+            pass
+
+
+# Register so the backend poller can instantiate this policy by type name.
+register_policy_type("rate_limit", RateLimitPolicy)

--- a/src/noveum_trace/guard/policies/rate_limit.py
+++ b/src/noveum_trace/guard/policies/rate_limit.py
@@ -95,7 +95,9 @@ class RateLimitPolicy(AbstractPolicy):
             max_tokens = w.get("maxTokens")
             requests = counts.get(f"requests_{period}", 0)
             tokens = counts.get(f"tokens_{period}", 0)
-            if max_requests and requests >= max_requests:
+            # ``is not None`` so a configured limit of 0 (block everything) is
+            # enforced; only an omitted/None threshold is left unenforced.
+            if max_requests is not None and requests >= max_requests:
                 return PolicyDecision.block(
                     self.name,
                     Phase.pre,
@@ -105,7 +107,7 @@ class RateLimitPolicy(AbstractPolicy):
                     ),
                     state={"scope_id": scope_id},
                 )
-            if max_tokens and tokens >= max_tokens:
+            if max_tokens is not None and tokens >= max_tokens:
                 return PolicyDecision.block(
                     self.name,
                     Phase.pre,

--- a/tests/integration/guard/test_rate_limit_real_calls.py
+++ b/tests/integration/guard/test_rate_limit_real_calls.py
@@ -211,7 +211,7 @@ class TestMultipleWindowsRealCalls:
             project_id,
             windows=[
                 {"period": "1m", "maxRequests": 100},
-                {"period": "1m", "maxTokens": 10},
+                {"period": "1h", "maxTokens": 10},
             ],
         )
         client = anthropic.Anthropic(

--- a/tests/integration/guard/test_rate_limit_real_calls.py
+++ b/tests/integration/guard/test_rate_limit_real_calls.py
@@ -1,0 +1,228 @@
+"""Real-call ("real time") integration tests for RateLimitPolicy.
+
+Mirrors test_real_calls.py's pattern (real Anthropic calls through the full
+Guard transport + PolicyEngine stack, backed by the in-memory GuardAPIClient)
+but exercises RateLimitPolicy's request-count and token-count enforcement
+instead of CostCapPolicy's spend cap.
+
+Every test skips unless a valid ``ANTHROPIC_API_KEY`` is present, so the suite
+is a no-op until keys are configured. Run explicitly with:
+
+    pytest tests/integration/guard/test_rate_limit_real_calls.py -m integration -v
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Optional
+
+import pytest
+
+# Load .env so locally-exported provider keys are picked up automatically.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # dotenv optional
+    pass
+
+import noveum_trace
+from noveum_trace.guard.api_client import GuardAPIClient
+from noveum_trace.guard.engine import PolicyEngine
+from noveum_trace.guard.policies.rate_limit import RateLimitPolicy
+from noveum_trace.guard.types import PolicyContext
+
+try:
+    import anthropic
+
+    ANTHROPIC_AVAILABLE = True
+except ImportError:  # provider SDK optional
+    anthropic = None  # type: ignore[assignment]
+    ANTHROPIC_AVAILABLE = False
+
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+MODEL = os.environ.get("NOVEUM_GUARD_TEST_MODEL", "claude-haiku-4-5-20251001")
+
+
+def _is_valid_key(key: Optional[str]) -> bool:
+    invalid = {"", "your-anthropic-api-key-here", "test-key", "sk-test", "sk-fake"}
+    return bool(key) and key not in invalid and len(key) > 10
+
+
+def _should_test_anthropic() -> bool:
+    return ANTHROPIC_AVAILABLE and _is_valid_key(ANTHROPIC_API_KEY)
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _should_test_anthropic(),
+        reason="ANTHROPIC_API_KEY not set/valid or anthropic not installed",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(project_id: str) -> PolicyContext:
+    return PolicyContext(
+        project_id=project_id,
+        organization_id=None,
+        environment="real-test",
+        trace_id=None,
+        span_id=None,
+        call_id=str(uuid.uuid4()),
+    )
+
+
+def _messages() -> list[dict]:
+    return [{"role": "user", "content": "Reply with one word: done."}]
+
+
+def _build_stack(
+    project_id: str, windows: list[dict]
+) -> tuple[PolicyEngine, PolicyContext, GuardAPIClient]:
+    """A real-call Guard stack: fresh in-memory api + a single RateLimitPolicy."""
+    api = GuardAPIClient()
+    engine = PolicyEngine(api_client=api)
+    engine.attach(RateLimitPolicy(windows=windows, project_id=project_id))
+    return engine, _ctx(project_id), api
+
+
+# ---------------------------------------------------------------------------
+# Request-count enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestRequestCountLimit:
+    def test_calls_within_limit_are_allowed(self):
+        project_id = "guard-real-rate-requests-ok"
+        engine, ctx, api = _build_stack(
+            project_id, windows=[{"period": "1m", "maxRequests": 2}]
+        )
+        client = anthropic.Anthropic(
+            api_key=ANTHROPIC_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+
+        for _ in range(2):
+            resp = client.messages.create(
+                model=MODEL, messages=_messages(), max_tokens=16
+            )
+            assert resp.content[0].text  # real response came back
+
+        assert api.current_rate(project_id)["requests_1m"] == 2
+
+    def test_call_over_request_limit_is_blocked(self):
+        project_id = "guard-real-rate-requests-blocked"
+        engine, ctx, api = _build_stack(
+            project_id, windows=[{"period": "1m", "maxRequests": 2}]
+        )
+        client = anthropic.Anthropic(
+            api_key=ANTHROPIC_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+
+        # First two calls consume the request budget for this window.
+        for _ in range(2):
+            client.messages.create(model=MODEL, messages=_messages(), max_tokens=16)
+
+        # Third call is blocked in pre() — never reaches the network.
+        with pytest.raises(anthropic.PermissionDeniedError):
+            client.messages.create(model=MODEL, messages=_messages(), max_tokens=16)
+
+        # The blocked call must not have been counted.
+        assert api.current_rate(project_id)["requests_1m"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Token-count enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCountLimit:
+    def test_call_over_token_limit_is_blocked(self):
+        project_id = "guard-real-rate-tokens-blocked"
+        # One real call comfortably uses more than 10 combined input+output
+        # tokens, so the second call must be blocked.
+        engine, ctx, api = _build_stack(
+            project_id, windows=[{"period": "1m", "maxTokens": 10}]
+        )
+        client = anthropic.Anthropic(
+            api_key=ANTHROPIC_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+
+        resp = client.messages.create(model=MODEL, messages=_messages(), max_tokens=16)
+        assert resp.content[0].text
+        assert api.current_rate(project_id)["tokens_1m"] > 10
+
+        with pytest.raises(anthropic.PermissionDeniedError):
+            client.messages.create(model=MODEL, messages=_messages(), max_tokens=16)
+
+
+# ---------------------------------------------------------------------------
+# Async transport
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncRequestCountLimit:
+    async def test_async_call_over_request_limit_is_blocked(self):
+        project_id = "guard-real-rate-async-blocked"
+        engine, ctx, api = _build_stack(
+            project_id, windows=[{"period": "1m", "maxRequests": 1}]
+        )
+        client = anthropic.AsyncAnthropic(
+            api_key=ANTHROPIC_API_KEY,
+            http_client=noveum_trace.guard.async_http_client(engine, ctx),
+        )
+        try:
+            resp = await client.messages.create(
+                model=MODEL, messages=_messages(), max_tokens=16
+            )
+            assert resp.content[0].text
+
+            with pytest.raises(anthropic.PermissionDeniedError):
+                await client.messages.create(
+                    model=MODEL, messages=_messages(), max_tokens=16
+                )
+        finally:
+            await client.close()
+
+        assert api.current_rate(project_id)["requests_1m"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Multiple windows combined
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleWindowsRealCalls:
+    def test_tight_token_window_blocks_before_generous_request_window(self):
+        """A generous request limit but a tight token limit — the second call
+        should be blocked by the token dimension, not the request dimension.
+        """
+        project_id = "guard-real-rate-combined"
+        engine, ctx, api = _build_stack(
+            project_id,
+            windows=[
+                {"period": "1m", "maxRequests": 100},
+                {"period": "1m", "maxTokens": 10},
+            ],
+        )
+        client = anthropic.Anthropic(
+            api_key=ANTHROPIC_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+
+        client.messages.create(model=MODEL, messages=_messages(), max_tokens=16)
+
+        with pytest.raises(anthropic.PermissionDeniedError):
+            client.messages.create(model=MODEL, messages=_messages(), max_tokens=16)
+
+        # Well under the request cap — proves it was the token window that blocked.
+        assert api.current_rate(project_id)["requests_1m"] == 1

--- a/tests/unit/guard/test_api_client.py
+++ b/tests/unit/guard/test_api_client.py
@@ -136,6 +136,69 @@ class TestReportUsage:
         api.report_usage(_call_id(), "proj", actual_usd=5.0, model="gpt-4o")
         assert api.inflight_count() == 0
 
+    def test_report_usage_bumps_rate_counters(self):
+        api = GuardAPIClient()
+        api.report_usage(
+            _call_id(),
+            "proj",
+            actual_usd=1.0,
+            model="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        rate = api.current_rate("proj")
+        assert rate["requests_1m"] == 1
+        assert rate["requests_1h"] == 1
+        assert rate["requests_1d"] == 1
+        assert rate["tokens_1m"] == 150
+        assert rate["tokens_1h"] == 150
+        assert rate["tokens_1d"] == 150
+
+    def test_report_usage_accumulates_rate_counters_across_calls(self):
+        api = GuardAPIClient()
+        api.report_usage(
+            _call_id(),
+            "proj",
+            actual_usd=1.0,
+            model="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        api.report_usage(
+            _call_id(),
+            "proj",
+            actual_usd=1.0,
+            model="gpt-4o",
+            input_tokens=10,
+            output_tokens=5,
+        )
+        rate = api.current_rate("proj")
+        assert rate["requests_1m"] == 2
+        assert rate["tokens_1m"] == 165
+
+    def test_report_usage_dedups_by_call_id(self):
+        """Two policies reporting the same call must not double count."""
+        api = GuardAPIClient()
+        call_id = _call_id()
+        api.report_usage(
+            call_id,
+            "proj",
+            actual_usd=1.0,
+            model="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        api.report_usage(
+            call_id,
+            "proj",
+            actual_usd=1.0,
+            model="gpt-4o",
+            input_tokens=100,
+            output_tokens=50,
+        )
+        assert api.current_spend("proj") == pytest.approx(1.0)
+        assert api.current_rate("proj")["requests_1m"] == 1
+
 
 # ---------------------------------------------------------------------------
 # get_state()
@@ -146,7 +209,7 @@ class TestGetState:
     def test_get_state_returns_zero_for_new_project(self):
         api = GuardAPIClient()
         state = api.get_state("new-proj")
-        assert state == {"spend": 0.0}
+        assert state == {"spend": 0.0, "rate": {}}
 
     def test_get_state_reflects_current_spend(self):
         api = GuardAPIClient()

--- a/tests/unit/guard/test_api_client_http.py
+++ b/tests/unit/guard/test_api_client_http.py
@@ -86,12 +86,41 @@ class TestGetState:
             get_resp=_Resp(200, {"cost": {"30d_rolling": 1247.81, "1d_rolling": 12.0}}),
         )
         api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
-        assert api.get_state("proj", "30d_rolling") == {"spend": 1247.81}
+        assert api.get_state("proj", "30d_rolling") == {"spend": 1247.81, "rate": {}}
 
     def test_missing_window_reads_zero(self, monkeypatch):
         _patch(monkeypatch, get_resp=_Resp(200, {"cost": {}}))
         api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
-        assert api.get_state("proj", "7d_rolling") == {"spend": 0.0}
+        assert api.get_state("proj", "7d_rolling") == {"spend": 0.0, "rate": {}}
+
+    def test_reads_rate_counters(self, monkeypatch):
+        _patch(
+            monkeypatch,
+            get_resp=_Resp(
+                200,
+                {
+                    "cost": {"30d_rolling": 1.0},
+                    "rate": {
+                        "requests_1m": 3,
+                        "requests_1h": 3,
+                        "requests_1d": 3,
+                        "tokens_1m": 1900,
+                        "tokens_1h": 1900,
+                        "tokens_1d": 1900,
+                    },
+                },
+            ),
+        )
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        state = api.get_state("proj", "30d_rolling")
+        assert state["rate"] == {
+            "requests_1m": 3,
+            "requests_1h": 3,
+            "requests_1d": 3,
+            "tokens_1m": 1900,
+            "tokens_1h": 1900,
+            "tokens_1d": 1900,
+        }
 
     def test_hits_project_state_url(self, monkeypatch):
         _patch(monkeypatch, get_resp=_Resp(200, {"cost": {}}))
@@ -121,12 +150,16 @@ class TestGetState:
         with pytest.raises(GuardBackendUnavailable):
             api.get_state("proj")
 
-    def test_strips_api_suffix_from_base_url(self, monkeypatch):
+    def test_preserves_api_suffix_from_base_url(self, monkeypatch):
+        """Guard endpoints live under /api on the production backend (verified
+        against the live control plane); DEFAULT_ENDPOINT already includes it,
+        so it must be kept, not stripped.
+        """
         _patch(monkeypatch, get_resp=_Resp(200, {"cost": {}}))
         api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai/api")
         api.get_state("proj")
         assert _FakeClient.calls[0]["url"].startswith(
-            "https://api.noveum.ai/v1/projects/proj"
+            "https://api.noveum.ai/api/v1/projects/proj"
         )
 
 
@@ -271,6 +304,50 @@ class TestFetchRemotePolicies:
                 "fail_closed": True,
                 "max_usd": 1500,
                 "window": "30d_rolling",
+            }
+        ]
+
+    def test_maps_rate_limit_shape(self, monkeypatch):
+        _patch(
+            monkeypatch,
+            get_resp=_Resp(
+                200,
+                [
+                    {
+                        "policyId": "p2",
+                        "name": "Burst rate",
+                        "type": "RATE_LIMIT",
+                        "enabled": True,
+                        "failClosed": True,
+                        "config": {
+                            "windows": [
+                                {
+                                    "period": "1m",
+                                    "maxRequests": 100,
+                                    "maxTokens": 200000,
+                                    "action": "BLOCK",
+                                }
+                            ]
+                        },
+                    }
+                ],
+            ),
+        )
+        api = HttpGuardAPIClient(api_key="k", base_url="https://api.noveum.ai")
+        result = api.fetch_remote_policies("proj")
+        assert result == [
+            {
+                "type": "rate_limit",
+                "name": "Burst rate",
+                "fail_closed": True,
+                "windows": [
+                    {
+                        "period": "1m",
+                        "maxRequests": 100,
+                        "maxTokens": 200000,
+                        "action": "BLOCK",
+                    }
+                ],
             }
         ]
 

--- a/tests/unit/guard/test_rate_limit.py
+++ b/tests/unit/guard/test_rate_limit.py
@@ -1,0 +1,349 @@
+"""Unit tests for RateLimitPolicy — shared read-then-check model (no reserve)."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+from noveum_trace.guard.api_client import GuardAPIClient
+from noveum_trace.guard.policies.rate_limit import RateLimitPolicy
+from noveum_trace.guard.types import (
+    ParsedRequest,
+    ParsedResponse,
+    PolicyContext,
+    PolicyDeps,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _ctx(project_id: str = "proj") -> PolicyContext:
+    return PolicyContext(
+        project_id=project_id,
+        organization_id=None,
+        environment="test",
+        trace_id=None,
+        span_id=None,
+        call_id=str(uuid.uuid4()),
+    )
+
+
+def _req() -> ParsedRequest:
+    return ParsedRequest(
+        provider="openai",
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=False,
+        max_tokens=100,
+        estimated_input_tokens=50,
+        raw_body=b"{}",
+    )
+
+
+def _resp(
+    input_tokens: int = 50, output_tokens: int = 100, cost_usd: float = 0.001
+) -> ParsedResponse:
+    return ParsedResponse(
+        model="gpt-4o-mini",
+        text="Hello",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+    )
+
+
+def _policy(windows, **kwargs) -> RateLimitPolicy:
+    return RateLimitPolicy(windows=windows, project_id="proj", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# pre() — request-count enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestRequestCountEnforcement:
+    def test_allow_under_limit(self):
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        with policy._lock:
+            policy.data_map["requests_1m"] = 3
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert not decision.is_blocking
+
+    def test_block_when_at_limit(self):
+        """Guide's formula blocks when the polled count is already >= max."""
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        with policy._lock:
+            policy.data_map["requests_1m"] = 100
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert decision.is_blocking
+        assert "requests" in decision.reason
+
+    def test_allow_one_below_limit(self):
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        with policy._lock:
+            policy.data_map["requests_1m"] = 99
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert not decision.is_blocking
+
+
+# ---------------------------------------------------------------------------
+# pre() — token-count enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestTokenCountEnforcement:
+    def test_allow_under_token_limit(self):
+        policy = _policy([{"period": "1m", "maxTokens": 200_000}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        with policy._lock:
+            policy.data_map["tokens_1m"] = 1_900
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert not decision.is_blocking
+
+    def test_block_when_at_token_limit(self):
+        policy = _policy([{"period": "1m", "maxTokens": 200_000}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        with policy._lock:
+            policy.data_map["tokens_1m"] = 200_000
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert decision.is_blocking
+        assert "tokens" in decision.reason
+
+
+# ---------------------------------------------------------------------------
+# pre() — multiple windows / thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleWindows:
+    def test_blocks_if_any_window_exceeded(self):
+        policy = _policy(
+            [
+                {"period": "1m", "maxRequests": 100},
+                {"period": "1h", "maxRequests": 1000},
+            ]
+        )
+        deps = PolicyDeps(api=GuardAPIClient())
+        with policy._lock:
+            policy.data_map["requests_1m"] = 5
+            policy.data_map["requests_1h"] = 1000  # this one is exhausted
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert decision.is_blocking
+
+    def test_unconfigured_threshold_is_not_enforced(self):
+        """maxRequests omitted for a window → that dimension never blocks."""
+        policy = _policy([{"period": "1m", "maxTokens": 10}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        with policy._lock:
+            policy.data_map["requests_1m"] = 999_999  # would block if enforced
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert not decision.is_blocking
+
+    def test_no_windows_configured_always_allows(self):
+        policy = _policy([])
+        deps = PolicyDeps(api=GuardAPIClient())
+
+        decision = policy.pre(_req(), _ctx(), deps)
+
+        assert not decision.is_blocking
+
+
+# ---------------------------------------------------------------------------
+# post() — local counter update + usage push
+# ---------------------------------------------------------------------------
+
+
+class TestPost:
+    def test_post_never_blocks(self):
+        policy = _policy([{"period": "1m", "maxRequests": 1}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        ctx = _ctx()
+        pre_decision = policy.pre(_req(), ctx, deps)
+
+        post_decision = policy.post(_resp(), ctx, pre_decision, deps)
+
+        assert not post_decision.is_blocking
+
+    def test_post_increments_all_periods_locally(self):
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=GuardAPIClient())
+        ctx = _ctx()
+        pre_decision = policy.pre(_req(), ctx, deps)
+
+        policy.post(_resp(input_tokens=50, output_tokens=100), ctx, pre_decision, deps)
+
+        assert policy.data_map["requests_1m"] == 1
+        assert policy.data_map["requests_1h"] == 1
+        assert policy.data_map["requests_1d"] == 1
+        assert policy.data_map["tokens_1m"] == 150
+        assert policy.data_map["tokens_1h"] == 150
+        assert policy.data_map["tokens_1d"] == 150
+
+    def test_post_pushes_usage_to_backend(self):
+        api = MagicMock(spec=GuardAPIClient)
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=api)
+        ctx = _ctx()
+        pre_decision = policy.pre(_req(), ctx, deps)
+
+        policy.post(
+            _resp(input_tokens=50, output_tokens=100, cost_usd=0.02),
+            ctx,
+            pre_decision,
+            deps,
+        )
+
+        api.report_usage.assert_called_once_with(
+            ctx.call_id, "proj", 0.02, "gpt-4o-mini", 50, 100
+        )
+
+    def test_post_usage_push_failure_is_swallowed(self):
+        api = MagicMock(spec=GuardAPIClient)
+        api.report_usage.side_effect = RuntimeError("network down")
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=api)
+        ctx = _ctx()
+        pre_decision = policy.pre(_req(), ctx, deps)
+
+        policy.post(_resp(), ctx, pre_decision, deps)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# poll() — refresh data_map from backend state
+# ---------------------------------------------------------------------------
+
+
+class TestPoll:
+    def test_poll_loads_rate_counters(self):
+        api = GuardAPIClient()
+        api.report_usage(
+            str(uuid.uuid4()),
+            "proj",
+            0.01,
+            "gpt-4o-mini",
+            input_tokens=10,
+            output_tokens=20,
+        )
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=api)
+
+        policy.poll(deps)
+
+        assert policy.data_map["requests_1m"] == 1
+        assert policy.data_map["tokens_1m"] == 30
+
+    def test_poll_without_scope_is_noop(self):
+        policy = RateLimitPolicy(windows=[{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=GuardAPIClient())
+
+        policy.poll(deps)  # must not raise despite no project_id/organization_id
+
+        assert policy.data_map == {}
+
+    def test_poll_swallows_backend_errors(self):
+        api = MagicMock(spec=GuardAPIClient)
+        api.get_state.side_effect = RuntimeError("boom")
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+        deps = PolicyDeps(api=api)
+
+        policy.poll(deps)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# update_params() — backend-pushed config changes
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateParams:
+    def test_update_windows(self):
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+
+        policy.update_params({"windows": [{"period": "1h", "maxRequests": 5000}]})
+
+        assert policy.windows == [{"period": "1h", "maxRequests": 5000}]
+
+    def test_update_fail_closed(self):
+        policy = _policy([{"period": "1m", "maxRequests": 100}], fail_closed=True)
+
+        policy.update_params({"fail_closed": False})
+
+        assert policy.fail_closed is False
+
+    def test_unknown_keys_ignored(self):
+        policy = _policy([{"period": "1m", "maxRequests": 100}])
+
+        policy.update_params({"unrelated": "value"})  # must not raise
+
+        assert policy.windows == [{"period": "1m", "maxRequests": 100}]
+
+
+# ---------------------------------------------------------------------------
+# bind_context() / scoping precedence
+# ---------------------------------------------------------------------------
+
+
+class TestScoping:
+    def test_bind_context_adopts_ambient_project(self):
+        policy = RateLimitPolicy(windows=[])
+        ctx = PolicyContext(
+            project_id="ambient-proj",
+            organization_id=None,
+            environment="test",
+            trace_id=None,
+            span_id=None,
+            call_id=str(uuid.uuid4()),
+        )
+
+        policy.bind_context(ctx)
+
+        assert policy._stored_scope_id() == "ambient-proj"
+
+    def test_explicit_project_id_takes_precedence_over_ambient(self):
+        policy = RateLimitPolicy(windows=[], project_id="explicit-proj")
+        ctx = PolicyContext(
+            project_id="ambient-proj",
+            organization_id=None,
+            environment="test",
+            trace_id=None,
+            span_id=None,
+            call_id=str(uuid.uuid4()),
+        )
+
+        policy.bind_context(ctx)
+
+        assert policy._stored_scope_id() == "explicit-proj"
+
+    def test_organization_id_takes_precedence_over_project(self):
+        policy = RateLimitPolicy(windows=[], project_id="proj", organization_id="org")
+
+        assert policy._scope_id(_ctx()) == "org"
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_registered_under_rate_limit_type():
+    from noveum_trace.guard.poller import _POLICY_TYPE_REGISTRY
+
+    assert _POLICY_TYPE_REGISTRY["rate_limit"] is RateLimitPolicy


### PR DESCRIPTION
# Pull Request

## Description

Adds a new `RateLimitPolicy` to NovaGuard that blocks LLM calls once a
per-window request or token count is reached. Windows mirror the backend
`RATE_LIMIT` config shape — a list of
`{"period": "1m"|"1h"|"1d", "maxRequests": int|None, "maxTokens": int|None}` —
where either threshold may be omitted to leave that dimension unenforced.

Like `CostCapPolicy`, this policy uses the shared read-then-check model (the
backend has no atomic reserve endpoint for request/token counts): `pre()`
checks against counters last read from `GET /policies/state`, and `post()`
reports the call's actual usage so the next snapshot reflects it. Overshoot
within a process is bounded by the poll interval.

The in-memory and HTTP API clients (`api_client.py`, `api_client_http.py`)
were extended to track and return `requests_*`/`tokens_*` counters alongside
the existing cost/spend buckets, via `report_usage` and `get_state`. Usage
reporting is idempotent by `call_id`, so a `CostCapPolicy` and
`RateLimitPolicy` on the same call don't double count.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests

New unit tests cover the policy logic (`test_rate_limit.py`) and the client
counter/state changes (`test_api_client.py`, `test_api_client_http.py`).
Integration tests exercise real report/read cycles
(`test_rate_limit_real_calls.py`).

Run: `pytest tests/unit/guard/ -q` and
`pytest tests/integration/guard/test_rate_limit_real_calls.py -q`

## Test Configuration

* Python version: 3.9–3.12
* Operating System: Windows 11 / Linux
* Dependencies: no new runtime dependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rate limiting enforcement for requests and token usage across 1-minute, 1-hour, and 1-day windows.
  - Supports configurable thresholds, multiple windows, and organization/project scoping.
  - Introduced a new rate-limiting policy type and exposed it for configuration.

- **Bug Fixes**
  - Improved client base URL handling and more accurate usage accounting with call deduplication.
  - Enhanced state reporting to include windowed rate counters alongside spend.

- **Tests**
  - Added unit tests for rate limiting and usage-rate accounting, plus opt-in integration tests for real enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->