### PR TITLE
made sync pipecat observer for dograh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.x] — Current (2026)
 
+### 1.5.21
+
+- **Pipecat**: Added a public synchronous `NoveumTraceObserver.attach_to_task_sync(task)` method for hosts that wire the observer OUTSIDE an event loop. It registers all observers, the `on_pipeline_finished` safety net, STT detection, and the `AudioBufferProcessor` `on_audio_data` handler synchronously, but does NOT start audio recording — the host calls `AudioBufferProcessor.start_recording()` itself (or uses the async `attach_to_task()`, which now delegates its synchronous wiring to `attach_to_task_sync` and only awaits the recording-start step).
+
 ### Current Public API (v1.x)
 
 The SDK has evolved significantly from the decorator-based 0.3.x era. The current public interface is **context-manager first**:

--- a/docs/examples/agent_cleanup_example.py
+++ b/docs/examples/agent_cleanup_example.py
@@ -147,12 +147,14 @@ def main():
     print(f"  MAX_AGENT_GRAPHS: {os.getenv('NOVEUM_MAX_AGENT_GRAPHS', '100')}")
     print(f"  MAX_AGENT_WORKFLOWS: {os.getenv('NOVEUM_MAX_AGENT_WORKFLOWS', '100')}")
 
-    print("""
+    print(
+        """
     💡 Tip: You can configure registry limits via environment variables:
     - NOVEUM_MAX_AGENTS=500
     - NOVEUM_MAX_AGENT_GRAPHS=50
     - NOVEUM_MAX_AGENT_WORKFLOWS=50
-    """)
+    """
+    )
 
     # Flush any pending traces
     noveum_trace.flush()
@@ -165,7 +167,8 @@ def demonstrate_production_usage():
     print("\n🏭 Production Usage Patterns")
     print("=" * 50)
 
-    print("""
+    print(
+        """
     1. **Periodic TTL Cleanup** (recommended for most applications):
        ```python
        import threading
@@ -213,7 +216,8 @@ def demonstrate_production_usage():
            # Take action: cleanup, alerting, etc.
            cleanup_by_ttl(ttl_seconds=1800)  # More aggressive cleanup
        ```
-    """)
+    """
+    )
 
 
 if __name__ == "__main__":

--- a/docs/examples/crewai_e2e_test.py
+++ b/docs/examples/crewai_e2e_test.py
@@ -378,10 +378,12 @@ def run_a2a_remote_delegation_crew(agent_card_url: str) -> str:
     a2a_coordinator = Agent(
         role="E2E A2A Coordinator",
         goal="Delegate specialist work through the configured remote A2A connection.",
-        backstory=textwrap.dedent("""\
+        backstory=textwrap.dedent(
+            """\
             When the task requires A2A delegation, use your remote A2A agent
             (agent card). Return the remote agent's substantive reply.
-        """),
+        """
+        ),
         tools=[],
         llm=coordinator_llm,
         a2a=A2AClientConfig(

--- a/docs/examples/streaming_example.py
+++ b/docs/examples/streaming_example.py
@@ -175,7 +175,8 @@ def example_real_openai():
 
     # Simulate the OpenAI integration
     print("To use with real OpenAI:")
-    print("""
+    print(
+        """
     from openai import OpenAI
 
     # Initialize OpenAI client
@@ -199,7 +200,8 @@ def example_real_openai():
         content = chunk.choices[0].delta.content
         if content:
             print(content, end="")
-    """)
+    """
+    )
     print("\n")
 
 

--- a/src/noveum_trace/integrations/pipecat/pipecat_observer.py
+++ b/src/noveum_trace/integrations/pipecat/pipecat_observer.py
@@ -753,8 +753,7 @@ class NoveumTraceObserver(
         the full stereo conversation WAV is captured on session end.
 
         Does NOT start recording — ``start_recording()`` is asynchronous and is
-        handled by :meth:`_attach_audio_buffer_from_pipeline` /
-        :meth:`_ensure_audio_buffer_recording`. When the same ABP is already
+        handled by :meth:`_ensure_audio_buffer_recording`. When the same ABP is already
         attached, this is a no-op (``self._audio_buffer_processor`` is left
         unchanged so the async caller can ensure recording).
 
@@ -819,47 +818,6 @@ class NoveumTraceObserver(
             # If the new ABP couldn't be wired, prefer keeping the previous one.
             self._audio_buffer_processor = prev_proc
             return
-
-    async def _attach_audio_buffer_from_pipeline(self, task: Any) -> None:
-        """
-        Walk the task's pipeline processors looking for an ``AudioBufferProcessor``.
-
-        If found, register ``_on_conversation_audio`` on its ``on_audio_data``
-        event so the full stereo conversation WAV is captured on session end and
-        start recording (the one async step).
-
-        If ``record_audio=True`` but no ``AudioBufferProcessor`` is present, logs
-        a warning so the user knows conversation-level audio won't be captured.
-        """
-        prev_proc = self._audio_buffer_processor
-        # Synchronous walk + handler registration (sets _audio_buffer_processor
-        # when a new proc is found; leaves it unchanged for same/absent proc).
-        self._attach_audio_buffer_handler_sync(task)
-
-        proc = self._audio_buffer_processor
-        if proc is None:
-            return
-
-        # Same ABP already attached (or none newly found): ensure recording.
-        if proc is prev_proc:
-            await self._ensure_audio_buffer_recording()
-            return
-
-        # Newly-attached proc: start recording directly. ABP drops
-        # InputAudio/OutputAudio until start_recording(); observer on_push_frame
-        # runs after process_frame, so start here before run().
-        try:
-            await proc.start_recording()
-            self._abp_is_recording = True
-            logger.debug(
-                "Attached to AudioBufferProcessor; start_recording() completed"
-            )
-        except Exception as e:
-            logger.warning(
-                "Failed to start AudioBufferProcessor recording: %s",
-                e,
-                exc_info=True,
-            )
 
     async def _ensure_audio_buffer_recording(self) -> None:
         """

--- a/src/noveum_trace/integrations/pipecat/pipecat_observer.py
+++ b/src/noveum_trace/integrations/pipecat/pipecat_observer.py
@@ -593,6 +593,42 @@ class NoveumTraceObserver(
         before ``runner.run(task)``, so conversation audio recording can start
         before the pipeline processes PCM.
 
+        This delegates all synchronous wiring to :meth:`attach_to_task_sync` and
+        then performs the one genuinely-async step — starting
+        ``AudioBufferProcessor`` recording — so hosts running inside an event
+        loop can attach everything with a single ``await``.
+
+        Safe to call multiple times; repeated calls with the same observers are
+        no-ops.
+        """
+        # attach_to_task_sync registers all observers, the safety net, and the
+        # audio on_audio_data handler (setting self._audio_buffer_processor).
+        self.attach_to_task_sync(task)
+
+        # The only genuinely-async step: start AudioBufferProcessor recording.
+        # _ensure_audio_buffer_recording is idempotent and a no-op when no ABP
+        # was attached, so this safely covers the fresh/same/absent-proc cases.
+        if self._record_audio:
+            await self._ensure_audio_buffer_recording()
+
+    def attach_to_task_sync(self, task: Any) -> None:
+        """
+        Synchronous variant of :meth:`attach_to_task` for hosts wiring the
+        observer OUTSIDE an event loop.
+
+        Registers everything that does not require ``await``: it resets the
+        transport's captured trace, subscribes to the turn-tracking and latency
+        observers, installs the ``on_pipeline_finished`` safety-net handler,
+        detects whether the pipeline has an STT service, and — when
+        ``record_audio=True`` — registers ``_on_conversation_audio`` on the
+        ``AudioBufferProcessor``'s ``on_audio_data`` event.
+
+        It does NOT start ``AudioBufferProcessor`` recording, because
+        ``start_recording()`` is asynchronous. The HOST is responsible for
+        calling ``AudioBufferProcessor.start_recording()`` before conversation
+        audio flows, OR use the async :meth:`attach_to_task` which starts
+        recording for you.
+
         Safe to call multiple times; repeated calls with the same observers are
         no-ops.
         """
@@ -614,6 +650,23 @@ class NoveumTraceObserver(
         if lto is not None:
             self.attach_latency_observer(lto)
 
+        self._register_finish_safety_net_handler(task)
+
+        self._detect_pipeline_has_stt(task)
+
+        # Auto-detect AudioBufferProcessor and register the on_audio_data handler
+        # (synchronous). Recording is started separately (async).
+        if self._record_audio:
+            self._attach_audio_buffer_handler_sync(task)
+
+    def _register_finish_safety_net_handler(self, task: Any) -> None:
+        """
+        Register the ``on_pipeline_finished`` safety-net handler on ``task``.
+
+        The safety net guarantees ``_finish_conversation`` runs even when
+        Pipecat cancels the ``TaskObserver`` proxy queue before it drains.
+        Synchronous: ``task.event_handler`` registration is not awaited.
+        """
         # ---------------------------------------------------------------------- #
         # Safety net: on_pipeline_finished fires inline in the main pipeline      #
         # coroutine, before _cancel_tasks() kills the TaskObserver proxy tasks.   #
@@ -678,12 +731,6 @@ class NoveumTraceObserver(
                 "trace cleanup relies on on_push_frame CancelFrame/EndFrame path only"
             )
 
-        self._detect_pipeline_has_stt(task)
-
-        # Auto-detect AudioBufferProcessor for full-conversation recording
-        if self._record_audio:
-            await self._attach_audio_buffer_from_pipeline(task)
-
     def _iter_nested_processors(self, node: Any) -> Iterator[Any]:
         """Depth-first walk of Pipecat compound processors (Pipeline inside Pipeline)."""
         procs = (
@@ -695,12 +742,21 @@ class NoveumTraceObserver(
             yield proc
             yield from self._iter_nested_processors(proc)
 
-    async def _attach_audio_buffer_from_pipeline(self, task: Any) -> None:
+    def _attach_audio_buffer_handler_sync(self, task: Any) -> None:
         """
-        Walk the task's pipeline processors looking for an ``AudioBufferProcessor``.
+        Synchronous part of AudioBufferProcessor wiring.
 
-        If found, register ``_on_conversation_audio`` on its ``on_audio_data``
-        event so the full stereo conversation WAV is captured on session end.
+        Walks the task's pipeline processors looking for an
+        ``AudioBufferProcessor``. If a NEW one is found, registers
+        ``_on_conversation_audio`` on its ``on_audio_data`` event, resets the
+        conversation-audio buffers, and sets ``self._audio_buffer_processor`` so
+        the full stereo conversation WAV is captured on session end.
+
+        Does NOT start recording — ``start_recording()`` is asynchronous and is
+        handled by :meth:`_attach_audio_buffer_from_pipeline` /
+        :meth:`_ensure_audio_buffer_recording`. When the same ABP is already
+        attached, this is a no-op (``self._audio_buffer_processor`` is left
+        unchanged so the async caller can ensure recording).
 
         If ``record_audio=True`` but no ``AudioBufferProcessor`` is present, logs
         a warning so the user knows conversation-level audio won't be captured.
@@ -734,9 +790,10 @@ class NoveumTraceObserver(
                 )
             return
 
-        # If the same ABP is still active for this observer, don't re-register the handler.
+        # If the same ABP is still active for this observer, don't re-register the
+        # handler. Leave self._audio_buffer_processor unchanged so the async
+        # caller detects "same proc" and ensures recording instead.
         if found_proc is self._audio_buffer_processor:
-            await self._ensure_audio_buffer_recording()
             return
 
         # Swap ABP when a new PipelineTask (or changed pipeline) is attached.
@@ -752,22 +809,8 @@ class NoveumTraceObserver(
             self._audio_buffer_processor.add_event_handler(
                 "on_audio_data", self._on_conversation_audio
             )
-            # ABP drops InputAudio/OutputAudio until start_recording(); observer
-            # on_push_frame runs after process_frame, so start here before run().
-            try:
-                await self._audio_buffer_processor.start_recording()
-                self._abp_is_recording = True
-            except Exception as e:
-                logger.warning(
-                    "Failed to start AudioBufferProcessor recording: %s",
-                    e,
-                    exc_info=True,
-                )
             logger.info(
                 "Noveum trace: full-conversation audio attached (nested pipeline OK)"
-            )
-            logger.debug(
-                "Attached to AudioBufferProcessor; start_recording() completed"
             )
         except Exception as e:
             logger.warning(
@@ -776,7 +819,47 @@ class NoveumTraceObserver(
             # If the new ABP couldn't be wired, prefer keeping the previous one.
             self._audio_buffer_processor = prev_proc
             return
-        return
+
+    async def _attach_audio_buffer_from_pipeline(self, task: Any) -> None:
+        """
+        Walk the task's pipeline processors looking for an ``AudioBufferProcessor``.
+
+        If found, register ``_on_conversation_audio`` on its ``on_audio_data``
+        event so the full stereo conversation WAV is captured on session end and
+        start recording (the one async step).
+
+        If ``record_audio=True`` but no ``AudioBufferProcessor`` is present, logs
+        a warning so the user knows conversation-level audio won't be captured.
+        """
+        prev_proc = self._audio_buffer_processor
+        # Synchronous walk + handler registration (sets _audio_buffer_processor
+        # when a new proc is found; leaves it unchanged for same/absent proc).
+        self._attach_audio_buffer_handler_sync(task)
+
+        proc = self._audio_buffer_processor
+        if proc is None:
+            return
+
+        # Same ABP already attached (or none newly found): ensure recording.
+        if proc is prev_proc:
+            await self._ensure_audio_buffer_recording()
+            return
+
+        # Newly-attached proc: start recording directly. ABP drops
+        # InputAudio/OutputAudio until start_recording(); observer on_push_frame
+        # runs after process_frame, so start here before run().
+        try:
+            await proc.start_recording()
+            self._abp_is_recording = True
+            logger.debug(
+                "Attached to AudioBufferProcessor; start_recording() completed"
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to start AudioBufferProcessor recording: %s",
+                e,
+                exc_info=True,
+            )
 
     async def _ensure_audio_buffer_recording(self) -> None:
         """

--- a/src/noveum_trace/integrations/pipecat/tracer.py
+++ b/src/noveum_trace/integrations/pipecat/tracer.py
@@ -151,7 +151,7 @@ class NoveumPipecatTracer:
             # we only operate on the customer's processors; Pipeline(inner) re-adds them.
             inner = list(pipeline._processors[1:-1])
 
-            # Same MRO check used by _attach_audio_buffer_from_pipeline in pipecat_observer.py
+            # Same MRO check used by _attach_audio_buffer_handler_sync in pipecat_observer.py
             has_abp = any(
                 any(base.__name__ == "AudioBufferProcessor" for base in type(p).__mro__)
                 for p in inner

--- a/tests/integration/pipecat/test_observer_lifecycle_behavior.py
+++ b/tests/integration/pipecat/test_observer_lifecycle_behavior.py
@@ -312,10 +312,7 @@ async def test_attach_to_task_wires_real_observer_event_names() -> None:
 
             return deco
 
-    with patch.object(
-        obs, "_attach_audio_buffer_from_pipeline", new_callable=AsyncMock
-    ):
-        await obs.attach_to_task(FakeTask())
+    await obs.attach_to_task(FakeTask())
 
     # Real TurnTrackingObserver records subscriptions in _event_handlers.
     assert "on_turn_started" in tto._event_handlers
@@ -348,11 +345,8 @@ async def test_attach_to_task_idempotent_pipeline_finished_registration() -> Non
             return deco
 
     task = FakeTask()
-    with patch.object(
-        obs, "_attach_audio_buffer_from_pipeline", new_callable=AsyncMock
-    ):
-        await obs.attach_to_task(task)
-        await obs.attach_to_task(task)
+    await obs.attach_to_task(task)
+    await obs.attach_to_task(task)
 
     assert registrations["n"] == 1
     assert task in obs._registered_pipeline_tasks

--- a/tests/integration/pipecat/test_pipecat_observer.py
+++ b/tests/integration/pipecat/test_pipecat_observer.py
@@ -262,9 +262,7 @@ async def test_attach_to_task_wires_observers() -> None:
     task._pipeline = None
     task.pipeline = None
 
-    with patch.object(
-        obs, "_attach_audio_buffer_from_pipeline", new_callable=AsyncMock
-    ):
+    with patch.object(obs, "_ensure_audio_buffer_recording", new_callable=AsyncMock):
         await obs.attach_to_task(task)
 
     task.turn_tracking_observer.add_event_handler.assert_called()
@@ -295,6 +293,7 @@ async def test_attach_audio_buffer_registers_processor() -> None:
 
     abp = MagicMock()
     abp.__class__.__name__ = "AudioBufferProcessor"
+    abp._recording = False
     abp.start_recording = AsyncMock()
 
     pipeline = MagicMock()
@@ -303,7 +302,7 @@ async def test_attach_audio_buffer_registers_processor() -> None:
     task._pipeline = pipeline
 
     obs = NoveumTraceObserver(record_audio=True)
-    await obs._attach_audio_buffer_from_pipeline(task)
+    await obs.attach_to_task(task)
 
     assert obs._audio_buffer_processor is abp
     abp.add_event_handler.assert_called()

--- a/tests/integration/pipecat/test_pipecat_observer.py
+++ b/tests/integration/pipecat/test_pipecat_observer.py
@@ -380,9 +380,12 @@ async def test_attach_to_task_delegates_to_sync_then_starts_recording() -> None:
     obs = NoveumTraceObserver(record_audio=True)
     task = MagicMock()
 
-    with patch.object(obs, "attach_to_task_sync") as sync_mock, patch.object(
-        obs, "_ensure_audio_buffer_recording", new_callable=AsyncMock
-    ) as rec_mock:
+    with (
+        patch.object(obs, "attach_to_task_sync") as sync_mock,
+        patch.object(
+            obs, "_ensure_audio_buffer_recording", new_callable=AsyncMock
+        ) as rec_mock,
+    ):
         await obs.attach_to_task(task)
 
     sync_mock.assert_called_once_with(task)

--- a/tests/integration/pipecat/test_pipecat_observer.py
+++ b/tests/integration/pipecat/test_pipecat_observer.py
@@ -312,6 +312,83 @@ async def test_attach_audio_buffer_registers_processor() -> None:
     assert call_args[0] == "on_audio_data"
 
 
+def test_attach_to_task_sync_registers_audio_handler_without_start_recording() -> None:
+    """attach_to_task_sync (the public sync path) registers the on_audio_data
+    handler + wires the ABP synchronously, but must NOT start recording — the
+    host owns AudioBufferProcessor.start_recording() (a coroutine). No event
+    loop / await is required to call it."""
+    pytest.importorskip("pipecat.observers.base_observer")
+
+    from noveum_trace.integrations.pipecat.pipecat_observer import NoveumTraceObserver
+
+    abp = MagicMock()
+    abp.__class__.__name__ = "AudioBufferProcessor"
+    abp.start_recording = AsyncMock()
+
+    pipeline = MagicMock()
+    pipeline.processors = [abp]
+    task = MagicMock()
+    task._pipeline = pipeline
+
+    obs = NoveumTraceObserver(record_audio=True)
+    # Synchronous call — no `await`.
+    obs.attach_to_task_sync(task)
+
+    assert obs._audio_buffer_processor is abp
+    abp.add_event_handler.assert_called()
+    assert abp.add_event_handler.call_args[0][0] == "on_audio_data"
+    # The whole point of the sync path: recording is deferred to the host.
+    abp.start_recording.assert_not_called()
+
+
+def test_attach_to_task_sync_skips_audio_when_record_audio_false() -> None:
+    """With record_audio=False the sync path still wires observers but never
+    walks the pipeline for an ABP nor registers the audio handler."""
+    pytest.importorskip("pipecat.observers.base_observer")
+
+    from noveum_trace.integrations.pipecat.pipecat_observer import NoveumTraceObserver
+
+    abp = MagicMock()
+    abp.__class__.__name__ = "AudioBufferProcessor"
+
+    pipeline = MagicMock()
+    pipeline.processors = [abp]
+    task = MagicMock()
+    task._pipeline = pipeline
+    task.turn_tracking_observer = MagicMock()
+    task._user_bot_latency_observer = MagicMock()
+
+    obs = NoveumTraceObserver(record_audio=False)
+    obs.attach_to_task_sync(task)
+
+    assert obs._audio_buffer_processor is None
+    abp.add_event_handler.assert_not_called()
+    # Observers are still wired regardless of audio recording.
+    task.turn_tracking_observer.add_event_handler.assert_called()
+    task._user_bot_latency_observer.add_event_handler.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_attach_to_task_delegates_to_sync_then_starts_recording() -> None:
+    """The async attach_to_task must DELEGATE to attach_to_task_sync (no
+    duplicated wiring) and then perform the single async step — starting ABP
+    recording via _ensure_audio_buffer_recording."""
+    pytest.importorskip("pipecat.observers.base_observer")
+
+    from noveum_trace.integrations.pipecat.pipecat_observer import NoveumTraceObserver
+
+    obs = NoveumTraceObserver(record_audio=True)
+    task = MagicMock()
+
+    with patch.object(obs, "attach_to_task_sync") as sync_mock, patch.object(
+        obs, "_ensure_audio_buffer_recording", new_callable=AsyncMock
+    ) as rec_mock:
+        await obs.attach_to_task(task)
+
+    sync_mock.assert_called_once_with(task)
+    rec_mock.assert_awaited_once()
+
+
 @pytest.mark.asyncio
 async def test_on_conversation_audio_concatenates_chunks() -> None:
     pytest.importorskip("pipecat.observers.base_observer")


### PR DESCRIPTION
# Pull Request

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Performance testing

## Test Configuration

* Python version:
* Operating System:
* Dependencies:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

## Additional Notes

Add any other context about the pull request here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous Pipecat task attachment for observer, speech-to-text, pipeline completion, and audio handler setup.
  * Audio recording now starts separately, giving hosts control over when recording begins.
* **Documentation**
  * Updated the changelog and examples to explain the integration behavior and improve formatted output.
* **Tests**
  * Expanded coverage for synchronous attachment, recording control, disabled audio capture, and asynchronous delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a public synchronous `attach_to_task_sync` method on `NoveumTraceObserver` for hosts (like dograh) that wire the observer outside an event loop. The existing async `attach_to_task` is refactored to delegate all synchronous wiring to the new method and only await the single genuinely-async step — starting `AudioBufferProcessor` recording.

- `attach_to_task` now calls `attach_to_task_sync` (registers observers, safety-net handler, STT detection, and the `on_audio_data` handler) then separately awaits `_ensure_audio_buffer_recording`, cleanly separating sync and async responsibilities.
- `_attach_audio_buffer_from_pipeline` (async) is replaced by `_attach_audio_buffer_handler_sync` (sync), which wires the handler but deliberately omits `start_recording()` — the host calls it directly when using the sync path, or `attach_to_task` calls `_ensure_audio_buffer_recording` in the async path.
- Three new test cases cover: the sync path not starting recording, audio disabled in sync mode, and the async path delegating to sync then starting recording.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core sync/async split is correct and well-tested, with one small omission in the ABP swap path that matters only in an already-broken teardown scenario.

The refactoring is structurally sound and the new test coverage directly validates the sync path, the delegation chain, and the recording-not-started contract. The only gap is that `_abp_is_recording` is not reset when `_attach_audio_buffer_handler_sync` swaps to a fresh `AudioBufferProcessor`; in the fallback branch of `_ensure_audio_buffer_recording` (processors that don't expose `_recording`), a stale `True` value would suppress `start_recording()` on the new processor. This only triggers if `_finish_conversation` was never called before the swap, which the safety-net handler is specifically designed to prevent — so the issue is latent rather than immediately reachable.

**Files Needing Attention:** src/noveum_trace/integrations/pipecat/pipecat_observer.py — specifically the ABP swap block in `_attach_audio_buffer_handler_sync` and the constructor comment on `_abp_is_recording`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/noveum_trace/integrations/pipecat/pipecat_observer.py | Core refactor: `attach_to_task` delegates to new public `attach_to_task_sync`; audio handler wiring moved to sync `_attach_audio_buffer_handler_sync` with `start_recording()` deferred to `_ensure_audio_buffer_recording`. `_abp_is_recording` is not reset on ABP swap, a latent edge-case issue. |
| tests/integration/pipecat/test_pipecat_observer.py | Tests updated to reflect new public API: patches changed from `_attach_audio_buffer_from_pipeline` to `_ensure_audio_buffer_recording`, and three new test cases added for `attach_to_task_sync` (sync wiring without recording, audio disabled path, and delegation-to-sync verification). |
| tests/integration/pipecat/test_observer_lifecycle_behavior.py | Removed now-unnecessary `AsyncMock` patches for the deleted `_attach_audio_buffer_from_pipeline` method in two lifecycle tests; both use `record_audio=False` so no audio wiring occurs. |
| src/noveum_trace/integrations/pipecat/tracer.py | Single-line comment update: renamed `_attach_audio_buffer_from_pipeline` reference to `_attach_audio_buffer_handler_sync` to match the refactored method name. |
| CHANGELOG.md | Added entry for version 1.5.21 documenting the new synchronous `attach_to_task_sync` API and the changed behaviour of `attach_to_task` (delegating to the sync path). |
| docs/examples/agent_cleanup_example.py | Cosmetic formatting only: multi-line string literals inside `print()` calls reformatted for PEP 8 compliance. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Host
    participant attach_to_task
    participant attach_to_task_sync
    participant _attach_audio_buffer_handler_sync
    participant _ensure_audio_buffer_recording
    participant ABP as AudioBufferProcessor

    Note over Host: Async host (event loop available)
    Host->>attach_to_task: await attach_to_task(task)
    attach_to_task->>attach_to_task_sync: attach_to_task_sync(task)
    attach_to_task_sync->>attach_to_task_sync: register TTO/LTO observers
    attach_to_task_sync->>attach_to_task_sync: _register_finish_safety_net_handler
    attach_to_task_sync->>attach_to_task_sync: _detect_pipeline_has_stt
    attach_to_task_sync->>_attach_audio_buffer_handler_sync: _attach_audio_buffer_handler_sync(task)
    _attach_audio_buffer_handler_sync->>ABP: add_event_handler(on_audio_data)
    _attach_audio_buffer_handler_sync-->>attach_to_task_sync: done (no recording started)
    attach_to_task_sync-->>attach_to_task: done
    attach_to_task->>_ensure_audio_buffer_recording: await _ensure_audio_buffer_recording()
    _ensure_audio_buffer_recording->>ABP: await start_recording()
    ABP-->>_ensure_audio_buffer_recording: ok
    _ensure_audio_buffer_recording-->>attach_to_task: done
    attach_to_task-->>Host: done

    Note over Host: Sync host (no event loop)
    Host->>attach_to_task_sync: attach_to_task_sync(task)
    attach_to_task_sync->>_attach_audio_buffer_handler_sync: _attach_audio_buffer_handler_sync(task)
    _attach_audio_buffer_handler_sync->>ABP: add_event_handler(on_audio_data)
    _attach_audio_buffer_handler_sync-->>attach_to_task_sync: done
    attach_to_task_sync-->>Host: done (recording NOT started)
    Host->>ABP: await ABP.start_recording()
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/noveum_trace/integrations/pipecat/pipecat_observer.py`, line 801-805 ([link](https://github.com/noveum/noveum-trace/blob/e9820611da7254289ff3e268f3375e31b7d63334/src/noveum_trace/integrations/pipecat/pipecat_observer.py#L801-L805)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `_abp_is_recording` is not reset when swapping to a new `AudioBufferProcessor`. `_ensure_audio_buffer_recording` falls back to `_abp_is_recording` only when the processor does not expose `_recording`; if that flag is stale-`True` from the previous ABP, `start_recording()` will be silently skipped for the newly attached processor, preventing any conversation audio from being captured for that session.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/noveum_trace/integrations/pipecat/pipecat_observer.py
   Line: 801-805

   Comment:
   `_abp_is_recording` is not reset when swapping to a new `AudioBufferProcessor`. `_ensure_audio_buffer_recording` falls back to `_abp_is_recording` only when the processor does not expose `_recording`; if that flag is stale-`True` from the previous ABP, `start_recording()` will be silently skipped for the newly attached processor, preventing any conversation audio from being captured for that session.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fnoveum_trace%2Fintegrations%2Fpipecat%2Fpipecat_observer.py%0ALine%3A%20801-805%0A%0AComment%3A%0A%60_abp_is_recording%60%20is%20not%20reset%20when%20swapping%20to%20a%20new%20%60AudioBufferProcessor%60.%20%60_ensure_audio_buffer_recording%60%20falls%20back%20to%20%60_abp_is_recording%60%20only%20when%20the%20processor%20does%20not%20expose%20%60_recording%60%3B%20if%20that%20flag%20is%20stale-%60True%60%20from%20the%20previous%20ABP%2C%20%60start_recording%28%29%60%20will%20be%20silently%20skipped%20for%20the%20newly%20attached%20processor%2C%20preventing%20any%20conversation%20audio%20from%20being%20captured%20for%20that%20session.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20prev_proc%20%3D%20self._audio_buffer_processor%0A%20%20%20%20%20%20%20%20self._audio_buffer_processor%20%3D%20found_proc%0A%20%20%20%20%20%20%20%20self._abp_is_recording%20%3D%20False%20%20%23%20new%20ABP%20%E2%80%94%20recording%20must%20be%20started%20fresh%0A%20%20%20%20%20%20%20%20self._conversation_audio_chunks%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20self._conversation_audio_sample_rate%20%3D%20None%0A%20%20%20%20%20%20%20%20self._conversation_audio_num_channels%20%3D%20None%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Fnoveum-trace&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>


2. `src/noveum_trace/integrations/pipecat/pipecat_observer.py`, line 364-366 ([link](https://github.com/noveum/noveum-trace/blob/e9820611da7254289ff3e268f3375e31b7d63334/src/noveum_trace/integrations/pipecat/pipecat_observer.py#L364-L366)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The constructor comment says "track internally, don't probe private `_recording`", but `_ensure_audio_buffer_recording` actively prefers Pipecat's `_recording` attribute when present. The comment contradicts the implementation and may mislead anyone trying to understand the fallback ordering.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/noveum_trace/integrations/pipecat/pipecat_observer.py
   Line: 364-366

   Comment:
   The constructor comment says "track internally, don't probe private `_recording`", but `_ensure_audio_buffer_recording` actively prefers Pipecat's `_recording` attribute when present. The comment contradicts the implementation and may mislead anyone trying to understand the fallback ordering.

   

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fnoveum_trace%2Fintegrations%2Fpipecat%2Fpipecat_observer.py%0ALine%3A%20364-366%0A%0AComment%3A%0AThe%20constructor%20comment%20says%20%22track%20internally%2C%20don't%20probe%20private%20%60_recording%60%22%2C%20but%20%60_ensure_audio_buffer_recording%60%20actively%20prefers%20Pipecat's%20%60_recording%60%20attribute%20when%20present.%20The%20comment%20contradicts%20the%20implementation%20and%20may%20mislead%20anyone%20trying%20to%20understand%20the%20fallback%20ordering.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20self._abp_is_recording%3A%20bool%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20False%20%20%23%20fallback%20when%20Pipecat's%20private%20_recording%20is%20absent%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Fnoveum-trace&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fnoveum_trace%2Fintegrations%2Fpipecat%2Fpipecat_observer.py%3A801-805%0A%60_abp_is_recording%60%20is%20not%20reset%20when%20swapping%20to%20a%20new%20%60AudioBufferProcessor%60.%20%60_ensure_audio_buffer_recording%60%20falls%20back%20to%20%60_abp_is_recording%60%20only%20when%20the%20processor%20does%20not%20expose%20%60_recording%60%3B%20if%20that%20flag%20is%20stale-%60True%60%20from%20the%20previous%20ABP%2C%20%60start_recording%28%29%60%20will%20be%20silently%20skipped%20for%20the%20newly%20attached%20processor%2C%20preventing%20any%20conversation%20audio%20from%20being%20captured%20for%20that%20session.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20prev_proc%20%3D%20self._audio_buffer_processor%0A%20%20%20%20%20%20%20%20self._audio_buffer_processor%20%3D%20found_proc%0A%20%20%20%20%20%20%20%20self._abp_is_recording%20%3D%20False%20%20%23%20new%20ABP%20%E2%80%94%20recording%20must%20be%20started%20fresh%0A%20%20%20%20%20%20%20%20self._conversation_audio_chunks%20%3D%20%5B%5D%0A%20%20%20%20%20%20%20%20self._conversation_audio_sample_rate%20%3D%20None%0A%20%20%20%20%20%20%20%20self._conversation_audio_num_channels%20%3D%20None%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2Fnoveum_trace%2Fintegrations%2Fpipecat%2Fpipecat_observer.py%3A364-366%0AThe%20constructor%20comment%20says%20%22track%20internally%2C%20don't%20probe%20private%20%60_recording%60%22%2C%20but%20%60_ensure_audio_buffer_recording%60%20actively%20prefers%20Pipecat's%20%60_recording%60%20attribute%20when%20present.%20The%20comment%20contradicts%20the%20implementation%20and%20may%20mislead%20anyone%20trying%20to%20understand%20the%20fallback%20ordering.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20self._abp_is_recording%3A%20bool%20%3D%20%28%0A%20%20%20%20%20%20%20%20%20%20%20%20False%20%20%23%20fallback%20when%20Pipecat's%20private%20_recording%20is%20absent%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=noveum%2Fnoveum-trace&pr=78&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/noveum_trace/integrations/pipecat/pipecat_observer.py:801-805
`_abp_is_recording` is not reset when swapping to a new `AudioBufferProcessor`. `_ensure_audio_buffer_recording` falls back to `_abp_is_recording` only when the processor does not expose `_recording`; if that flag is stale-`True` from the previous ABP, `start_recording()` will be silently skipped for the newly attached processor, preventing any conversation audio from being captured for that session.

```suggestion
        prev_proc = self._audio_buffer_processor
        self._audio_buffer_processor = found_proc
        self._abp_is_recording = False  # new ABP — recording must be started fresh
        self._conversation_audio_chunks = []
        self._conversation_audio_sample_rate = None
        self._conversation_audio_num_channels = None
```

### Issue 2
src/noveum_trace/integrations/pipecat/pipecat_observer.py:364-366
The constructor comment says "track internally, don't probe private `_recording`", but `_ensure_audio_buffer_recording` actively prefers Pipecat's `_recording` attribute when present. The comment contradicts the implementation and may mislead anyone trying to understand the fallback ordering.

```suggestion
        self._abp_is_recording: bool = (
            False  # fallback when Pipecat's private _recording is absent
        )
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: remove dead \_attach\_audio\_buff..."](https://github.com/noveum/noveum-trace/commit/e9820611da7254289ff3e268f3375e31b7d63334) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46727533)</sub>

<!-- /greptile_comment -->