### PR TITLE
feat(guard): report BLOCKED usage events to /policies/usage

### DIFF
--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -14,7 +15,13 @@ _WINDOW_SECONDS = {"1m": 60.0, "1h": 3600.0, "1d": 86400.0}
 _MAX_WINDOW_SECONDS = 86400.0  # 1d — the longest window bounds retention
 
 # The only values /policies/usage accepts for blockedBy; anything else is a 400.
-_BLOCKED_BY_VALUES = ("COST_CAP", "RATE_LIMIT")
+# Public: HttpGuardAPIClient validates against it too, and policies map onto it.
+BLOCKED_BY_VALUES = ("COST_CAP", "RATE_LIMIT")
+
+# Per-project cap on the blocked-event inspection buffer. A hard bound rather
+# than time-based eviction: a sustained block storm would otherwise accumulate
+# millions of entries before the first window expiry.
+_MAX_BLOCKED_EVENTS = 1000
 
 
 @dataclass
@@ -64,9 +71,10 @@ class GuardAPIClient:
         # CostCapPolicy in shared mode + RateLimitPolicy) reports the same call.
         # Timestamped so stale ids can be evicted rather than growing unbounded.
         self._reported_event_ids: dict[str, float] = {}
-        # project_id → blocked events recorded for inspection. Never folded into
-        # _spend/_rate: a blocked call never ran, so it is not metered.
-        self._blocked_events: dict[str, list[dict[str, Any]]] = {}
+        # project_id → recent blocked events, for inspection only. Never folded
+        # into _spend/_rate: a blocked call never ran, so it is not metered.
+        # Bounded per project — oldest entries are dropped once full.
+        self._blocked_events: dict[str, deque[dict[str, Any]]] = {}
 
     # Core accounting
 
@@ -167,10 +175,13 @@ class GuardAPIClient:
         excluded from the counters policies check. ``blocked_by`` is the backend
         limit type ("COST_CAP" or "RATE_LIMIT") that tripped.
         """
-        if blocked_by not in _BLOCKED_BY_VALUES:
+        if blocked_by not in BLOCKED_BY_VALUES:
             return
         with self._lock:
-            self._blocked_events.setdefault(project_id, []).append(
+            events = self._blocked_events.setdefault(
+                project_id, deque(maxlen=_MAX_BLOCKED_EVENTS)
+            )
+            events.append(
                 {
                     "call_id": call_id,
                     "model": model,

--- a/src/noveum_trace/guard/api_client.py
+++ b/src/noveum_trace/guard/api_client.py
@@ -13,6 +13,9 @@ _PERIODS = ("1m", "1h", "1d")
 _WINDOW_SECONDS = {"1m": 60.0, "1h": 3600.0, "1d": 86400.0}
 _MAX_WINDOW_SECONDS = 86400.0  # 1d — the longest window bounds retention
 
+# The only values /policies/usage accepts for blockedBy; anything else is a 400.
+_BLOCKED_BY_VALUES = ("COST_CAP", "RATE_LIMIT")
+
 
 @dataclass
 class ReservationResult:
@@ -61,6 +64,9 @@ class GuardAPIClient:
         # CostCapPolicy in shared mode + RateLimitPolicy) reports the same call.
         # Timestamped so stale ids can be evicted rather than growing unbounded.
         self._reported_event_ids: dict[str, float] = {}
+        # project_id → blocked events recorded for inspection. Never folded into
+        # _spend/_rate: a blocked call never ran, so it is not metered.
+        self._blocked_events: dict[str, list[dict[str, Any]]] = {}
 
     # Core accounting
 
@@ -144,6 +150,34 @@ class GuardAPIClient:
             self._spend[project_id] = self._spend.get(project_id, 0.0) + actual_usd
             self._rate_events.setdefault(project_id, []).append(
                 (now, input_tokens + output_tokens)
+            )
+
+    def report_blocked(
+        self,
+        call_id: str,
+        project_id: str,
+        model: str,
+        blocked_by: str,
+        policy_id: Optional[str] = None,
+        reason: str = "",
+    ) -> None:
+        """Record a call the Guard stopped before it reached the provider.
+
+        Deliberately does not touch _spend/_rate — the call never ran, so it is
+        excluded from the counters policies check. ``blocked_by`` is the backend
+        limit type ("COST_CAP" or "RATE_LIMIT") that tripped.
+        """
+        if blocked_by not in _BLOCKED_BY_VALUES:
+            return
+        with self._lock:
+            self._blocked_events.setdefault(project_id, []).append(
+                {
+                    "call_id": call_id,
+                    "model": model,
+                    "blocked_by": blocked_by,
+                    "policy_id": policy_id,
+                    "reason": reason,
+                }
             )
 
     # Policy config / polling
@@ -284,6 +318,10 @@ class GuardAPIClient:
         with self._lock:
             return len(self._inflight)
 
+    def blocked_events(self, project_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            return [dict(e) for e in self._blocked_events.get(project_id, [])]
+
     def reset(self) -> None:
         """Wipe all state. Tests only."""
         with self._lock:
@@ -292,3 +330,4 @@ class GuardAPIClient:
             self._policy_configs.clear()
             self._rate_events.clear()
             self._reported_event_ids.clear()
+            self._blocked_events.clear()

--- a/src/noveum_trace/guard/api_client_http.py
+++ b/src/noveum_trace/guard/api_client_http.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 from noveum_trace.guard.api_client import (
-    _BLOCKED_BY_VALUES,
+    BLOCKED_BY_VALUES,
     GuardAPIClient,
     ReservationResult,
 )
@@ -165,7 +165,7 @@ class HttpGuardAPIClient(GuardAPIClient):
         Sent in place of the model call, so the backend can bill nothing, log the
         block, and email the owner. ``costUsd`` is 0 — the call never happened.
         """
-        if blocked_by not in _BLOCKED_BY_VALUES:
+        if blocked_by not in BLOCKED_BY_VALUES:
             # Would be a 400; drop it rather than poison a whole batch.
             _log.debug("blocked event dropped — invalid blockedBy %r", blocked_by)
             return

--- a/src/noveum_trace/guard/api_client_http.py
+++ b/src/noveum_trace/guard/api_client_http.py
@@ -5,7 +5,11 @@ import threading
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from noveum_trace.guard.api_client import GuardAPIClient, ReservationResult
+from noveum_trace.guard.api_client import (
+    _BLOCKED_BY_VALUES,
+    GuardAPIClient,
+    ReservationResult,
+)
 from noveum_trace.guard.exceptions import GuardBackendUnavailable
 
 _log = logging.getLogger(__name__)
@@ -15,6 +19,19 @@ _DEFAULT_WINDOW = "30d_rolling"
 
 # Map backend PolicyType enum (uppercase) → SDK policy registry key (lowercase).
 _TYPE_MAP = {"COST_CAP": "cost_cap", "RATE_LIMIT": "rate_limit"}
+
+# Usage-push retry budget. Only 5xx and 429 are retried; the backend dedups on
+# eventId so a resend can never double-count.
+_MAX_PUSH_ATTEMPTS = 3
+_RETRY_BASE_DELAY = 0.5  # seconds; doubles per attempt
+_MAX_RETRY_DELAY = 30.0  # ceiling for a server-supplied Retry-After
+
+# Backend caps reason at 500 chars; longer values are a 400.
+_MAX_REASON_LEN = 500
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 class HttpGuardAPIClient(GuardAPIClient):
@@ -127,9 +144,46 @@ class HttpGuardAPIClient(GuardAPIClient):
             "outputTokens": max(0, int(output_tokens)),
             "costUsd": float(actual_usd),
             "requestCount": 1,
-            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "timestamp": _now_iso(),
             "eventId": call_id,  # idempotency key — backend dedups on retry
         }
+        self._enqueue(project_id, event)
+
+    # Block write — enqueue for the same batched POST /policies/usage
+
+    def report_blocked(
+        self,
+        call_id: str,
+        project_id: str,
+        model: str,
+        blocked_by: str,
+        policy_id: Optional[str] = None,
+        reason: str = "",
+    ) -> None:
+        """Queue a BLOCKED event for a call the Guard stopped before it ran.
+
+        Sent in place of the model call, so the backend can bill nothing, log the
+        block, and email the owner. ``costUsd`` is 0 — the call never happened.
+        """
+        if blocked_by not in _BLOCKED_BY_VALUES:
+            # Would be a 400; drop it rather than poison a whole batch.
+            _log.debug("blocked event dropped — invalid blockedBy %r", blocked_by)
+            return
+        event: dict[str, Any] = {
+            "model": model or "unknown",
+            "outcome": "BLOCKED",
+            "blockedBy": blocked_by,
+            "costUsd": 0.0,
+            "timestamp": _now_iso(),
+            "eventId": call_id,  # idempotency key — backend dedups on retry
+        }
+        if policy_id:
+            event["policyId"] = policy_id
+        if reason:
+            event["reason"] = reason[:_MAX_REASON_LEN]
+        self._enqueue(project_id, event)
+
+    def _enqueue(self, project_id: str, event: dict[str, Any]) -> None:
         with self._queue_lock:
             self._queue.append((project_id, event))
             full = len(self._queue) >= self._batch_max
@@ -230,26 +284,78 @@ class HttpGuardAPIClient(GuardAPIClient):
             self._post_usage(scope_id, events)
 
     def _post_usage(self, scope_id: str, events: list[dict[str, Any]]) -> None:
-        url = f"{self.base_url}/v1/projects/{scope_id}/policies/usage"
-        try:
-            import httpx
+        """POST one batch, retrying only what a retry can fix.
 
-            with httpx.Client(timeout=self._timeout, follow_redirects=True) as client:
-                client.post(
-                    url,
-                    headers=self._headers(),
-                    params=self._query(),
-                    json=events,
+        5xx and 429 are transient, so they are resent with the same eventIds
+        (the backend dedups). A 4xx means the payload itself is wrong — logged
+        loudly and dropped, because resending it would fail identically.
+        Runs on the flush thread, so a backoff never delays the caller.
+        """
+        url = f"{self.base_url}/v1/projects/{scope_id}/policies/usage"
+        for attempt in range(1, _MAX_PUSH_ATTEMPTS + 1):
+            try:
+                import httpx
+
+                with httpx.Client(
+                    timeout=self._timeout, follow_redirects=True
+                ) as client:
+                    resp = client.post(
+                        url,
+                        headers=self._headers(),
+                        params=self._query(),
+                        json=events,
+                    )
+                status = resp.status_code
+                if status < 300:
+                    return
+                if status == 429 or status >= 500:
+                    if attempt == _MAX_PUSH_ATTEMPTS:
+                        _log.warning(
+                            "usage push gave up after %d attempts for project %r "
+                            "(%d events, last status %d)",
+                            attempt,
+                            scope_id,
+                            len(events),
+                            status,
+                        )
+                        return
+                    if self._stop.wait(self._retry_delay(resp, attempt)):
+                        return  # shutting down; drop rather than delay close()
+                    continue
+                _log.error(
+                    "usage push rejected for project %r (%d events): HTTP %d — "
+                    "payload is malformed, not retrying",
+                    scope_id,
+                    len(events),
+                    status,
                 )
-        except Exception as exc:
-            # Best-effort: a dropped batch under-counts spend slightly; it never
-            # over-counts (idempotent) and the backend stays authoritative.
-            _log.debug(
-                "usage push failed for project %r (%d events) — %s",
-                scope_id,
-                len(events),
-                exc,
-            )
+                return
+            except Exception as exc:
+                # Network-level failure: retry on the same schedule as a 5xx.
+                if attempt == _MAX_PUSH_ATTEMPTS:
+                    # Best-effort: a dropped batch under-counts spend slightly; it
+                    # never over-counts (idempotent) and the backend stays
+                    # authoritative.
+                    _log.debug(
+                        "usage push failed for project %r (%d events) — %s",
+                        scope_id,
+                        len(events),
+                        exc,
+                    )
+                    return
+                if self._stop.wait(_RETRY_BASE_DELAY * (2 ** (attempt - 1))):
+                    return
+
+    # resp is Any because httpx is imported lazily — no module-level Response type.
+    def _retry_delay(self, resp: Any, attempt: int) -> float:
+        """Seconds to wait before the next attempt; honors Retry-After on 429."""
+        retry_after = (getattr(resp, "headers", None) or {}).get("Retry-After")
+        if retry_after:
+            try:
+                return min(float(retry_after), _MAX_RETRY_DELAY)
+            except (TypeError, ValueError):
+                pass  # HTTP-date form — fall back to exponential backoff
+        return _RETRY_BASE_DELAY * (2 ** (attempt - 1))
 
     def close(self) -> None:
         """Stop the flush thread and drain any queued usage events."""
@@ -279,6 +385,9 @@ def _normalize_policy(raw: dict[str, Any]) -> Optional[dict[str, Any]]:
         "name": raw.get("name", sdk_type),
         "fail_closed": raw.get("failClosed", True),
     }
+    # Carried through so a BLOCKED event can name the policy that blocked.
+    if raw.get("policyId"):
+        mapped["policy_id"] = raw["policyId"]
     if "maxUsd" in config:
         mapped["max_usd"] = config["maxUsd"]
     if "window" in config:

--- a/src/noveum_trace/guard/engine.py
+++ b/src/noveum_trace/guard/engine.py
@@ -139,6 +139,7 @@ class PolicyEngine:
                 # entry must be cleaned up even though state may carry reserved_usd=0.
                 for p, prev_d in ran:
                     self._safe_invoke(p, p.release, prev_d, ctx, deps)
+                self._report_blocked(decision, parsed, ctx)
                 return decision, ran
 
         return None, ran
@@ -186,6 +187,35 @@ class PolicyEngine:
                 pass
 
     # Internal
+
+    def _report_blocked(
+        self,
+        decision: PolicyDecision,
+        parsed: ParsedRequest,
+        ctx: PolicyContext,
+    ) -> None:
+        """Push a BLOCKED usage event for a call a limit policy stopped.
+
+        Reported here rather than in each transport so all four call sites
+        (sync, async, bedrock, crewai) are covered once. Only decisions carrying
+        ``blocked_by`` are sent: a fail-closed or control-plane block is not a
+        limit event, and the backend rejects any other ``blockedBy`` value.
+        """
+        blocked_by = decision.state.get("blocked_by")
+        if not blocked_by:
+            return
+        try:
+            self._api_client.report_blocked(
+                call_id=ctx.call_id,
+                project_id=decision.state.get("scope_id") or ctx.project_id,
+                model=parsed.model,
+                blocked_by=blocked_by,
+                policy_id=decision.state.get("policy_id"),
+                reason=decision.reason,
+            )
+        except Exception as exc:
+            # Never let reporting turn a clean block into an error for the caller.
+            _log.debug("blocked-event report failed for %s — %s", ctx.call_id, exc)
 
     def _safe_invoke(
         self,

--- a/src/noveum_trace/guard/policies/base.py
+++ b/src/noveum_trace/guard/policies/base.py
@@ -29,6 +29,9 @@ class AbstractPolicy(ABC):
     mode: EnforcementMode = EnforcementMode.strict
     fail_closed: bool = True  # block on unexpected exception (safe default)
     priority: int = 100  # lower = runs first; ties broken by registration order
+    # Backend limit type sent as ``blockedBy`` when this policy blocks a call.
+    # None means this policy's blocks are not limit events and go unreported.
+    blocked_by: ClassVar[Optional[str]] = None
     poll_interval: Optional[float] = (
         None  # seconds; None means poller skips this policy
     )

--- a/src/noveum_trace/guard/policies/cost_cap.py
+++ b/src/noveum_trace/guard/policies/cost_cap.py
@@ -40,6 +40,7 @@ class CostCapPolicy(AbstractPolicy):
     """
 
     name = "cost_cap"
+    blocked_by = "COST_CAP"
     poll_interval: float = 30.0
 
     def __init__(
@@ -51,6 +52,7 @@ class CostCapPolicy(AbstractPolicy):
         scope_to_models: Optional[list[str]] = None,
         project_id: Optional[str] = None,
         organization_id: Optional[str] = None,
+        policy_id: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.max_usd = max_usd
@@ -65,6 +67,7 @@ class CostCapPolicy(AbstractPolicy):
         self.scope_to_models = scope_to_models
         self._project_id = project_id
         self._organization_id = organization_id
+        self._policy_id = policy_id
 
     def bind_context(self, ctx: PolicyContext) -> None:
         # Adopt the ambient org/project so the background poller can scope
@@ -122,6 +125,7 @@ class CostCapPolicy(AbstractPolicy):
         scope_id = self._scope_id(ctx)
         with self._lock:
             mode = self.mode
+            policy_id = self._policy_id
 
         # Strict reservation only holds when the backend can reserve atomically.
         # The HTTP backend has no reserve endpoint, so strict degrades to the
@@ -148,6 +152,8 @@ class CostCapPolicy(AbstractPolicy):
                             "reserved_usd": 0.0,
                             "scope_id": scope_id,
                             "mode": mode.value,
+                            "blocked_by": self.blocked_by,
+                            "policy_id": policy_id,
                         },  # nothing reserved; release is a no-op
                     )
                 return PolicyDecision.allow(
@@ -199,6 +205,8 @@ class CostCapPolicy(AbstractPolicy):
                         "reserved_usd": 0.0,
                         "scope_id": scope_id,
                         "mode": mode.value,
+                        "blocked_by": self.blocked_by,
+                        "policy_id": policy_id,
                     },
                 )
             return PolicyDecision.allow(
@@ -308,6 +316,7 @@ class CostCapPolicy(AbstractPolicy):
             ``fail_closed``     — bool; whether to block on unexpected exception
             ``organization_id`` — switch or set org-level scoping
             ``project_id``      — switch or set project-level scoping
+            ``policy_id``       — backend policy id, sent on BLOCKED events
         """
         with self._lock:
             if "max_usd" in config:
@@ -327,6 +336,8 @@ class CostCapPolicy(AbstractPolicy):
                 self._organization_id = config["organization_id"] or None
             if "project_id" in config:
                 self._project_id = config["project_id"] or None
+            if "policy_id" in config:
+                self._policy_id = config["policy_id"] or None
 
     def poll(self, deps: PolicyDeps) -> None:
         scope_id = self._stored_scope_id()

--- a/src/noveum_trace/guard/policies/rate_limit.py
+++ b/src/noveum_trace/guard/policies/rate_limit.py
@@ -39,6 +39,7 @@ class RateLimitPolicy(AbstractPolicy):
     """
 
     name = "rate_limit"
+    blocked_by = "RATE_LIMIT"
     poll_interval: float = 30.0
 
     def __init__(
@@ -47,12 +48,14 @@ class RateLimitPolicy(AbstractPolicy):
         fail_closed: bool = True,
         project_id: Optional[str] = None,
         organization_id: Optional[str] = None,
+        policy_id: Optional[str] = None,
     ) -> None:
         super().__init__()
         self.windows = list(windows) if windows else []
         self.fail_closed = fail_closed
         self._project_id = project_id
         self._organization_id = organization_id
+        self._policy_id = policy_id
 
     def bind_context(self, ctx: PolicyContext) -> None:
         # Adopt the ambient org/project so the background poller can scope
@@ -86,6 +89,12 @@ class RateLimitPolicy(AbstractPolicy):
         with self._lock:
             windows = list(self.windows)
             counts = dict(self.data_map)
+            policy_id = self._policy_id
+        block_state = {
+            "scope_id": scope_id,
+            "blocked_by": self.blocked_by,
+            "policy_id": policy_id,
+        }
 
         for w in windows:
             period = w.get("period")
@@ -105,7 +114,7 @@ class RateLimitPolicy(AbstractPolicy):
                         f"Rate limit reached: {requests}/{max_requests} "
                         f"requests per {period}"
                     ),
-                    state={"scope_id": scope_id},
+                    state=dict(block_state),
                 )
             if max_tokens is not None and tokens >= max_tokens:
                 return PolicyDecision.block(
@@ -114,7 +123,7 @@ class RateLimitPolicy(AbstractPolicy):
                     reason=(
                         f"Rate limit reached: {tokens}/{max_tokens} tokens per {period}"
                     ),
-                    state={"scope_id": scope_id},
+                    state=dict(block_state),
                 )
 
         return PolicyDecision.allow(self.name, Phase.pre, state={"scope_id": scope_id})
@@ -166,6 +175,7 @@ class RateLimitPolicy(AbstractPolicy):
             ``fail_closed``     — bool; whether to block on unexpected exception
             ``organization_id`` — switch or set org-level scoping
             ``project_id``      — switch or set project-level scoping
+            ``policy_id``       — backend policy id, sent on BLOCKED events
         """
         with self._lock:
             if "windows" in config:
@@ -176,6 +186,8 @@ class RateLimitPolicy(AbstractPolicy):
                 self._organization_id = config["organization_id"] or None
             if "project_id" in config:
                 self._project_id = config["project_id"] or None
+            if "policy_id" in config:
+                self._policy_id = config["policy_id"] or None
 
     def poll(self, deps: PolicyDeps) -> None:
         scope_id = self._stored_scope_id()

--- a/tests/integration/guard/test_usage_ingest_real.py
+++ b/tests/integration/guard/test_usage_ingest_real.py
@@ -224,6 +224,9 @@ class TestPolicySyncCarriesPolicyId:
 # ---------------------------------------------------------------------------
 
 
+# No API-key guard: both tests block before the provider is reached, so they
+# need the openai package but never a valid key.
+@pytest.mark.skipif(not OPENAI_AVAILABLE, reason="openai not installed")
 class TestBlockedEventIngest:
     def test_blocked_call_posts_blocked_event(self, usage_posts):
         """Exhausted cap → no provider call, one BLOCKED event accepted (202).
@@ -552,20 +555,29 @@ class TestRealBackendPolicies:
 class TestBackendRejectsMalformed:
     def test_blocked_without_blocked_by_is_rejected(self):
         """Confirms the 400 the SDK guards against is real, so the local
-        validation in report_blocked() is protecting something."""
+        validation in report_blocked() is protecting something.
+
+        Sent as a one-element array — the batched shape _post_usage always
+        uses — so this exercises the same validation path the SDK would hit.
+        """
         url = (
             f"{NOVEUM_ENDPOINT.rstrip('/')}/v1/projects/{NOVEUM_PROJECT}/policies/usage"
         )
         resp = httpx.post(
             url,
             headers={"Authorization": f"Bearer {NOVEUM_API_KEY}"},
-            json={
-                "model": MODEL,
-                "outcome": "BLOCKED",  # no blockedBy — malformed on purpose
-                "eventId": str(uuid.uuid4()),
-            },
+            json=[
+                {
+                    "model": MODEL,
+                    "outcome": "BLOCKED",  # no blockedBy — malformed on purpose
+                    "eventId": str(uuid.uuid4()),
+                }
+            ],
             timeout=15.0,
             follow_redirects=True,
         )
         print(f"\n[malformed] HTTP {resp.status_code} {resp.text[:300]}")
         assert resp.status_code == 400
+        # The array form itself is valid (every SDK push uses it), so pin the
+        # rejection to the missing field rather than the wrapper.
+        assert "blockedBy" in resp.text

--- a/tests/integration/guard/test_usage_ingest_real.py
+++ b/tests/integration/guard/test_usage_ingest_real.py
@@ -1,0 +1,571 @@
+"""End-to-end tests for Nova Guard usage ingest against the LIVE backend.
+
+These prove the whole loop the mocked unit tests can only approximate: the SDK
+builds an event, POSTs it to the real ``/policies/usage`` endpoint, and the real
+server accepts it. Both outcomes are covered — a call that ran (ALLOWED, with
+cost) and a call the Guard stopped (BLOCKED, with blockedBy/policyId).
+
+Requires real credentials in .env:
+    NOVEUM_API_KEY, NOVEUM_PROJECT   — always
+    OPENAI_API_KEY                   — only for the ALLOWED test (real LLM call)
+
+Run explicitly:
+
+    pytest tests/integration/guard/test_usage_ingest_real.py -m integration -v -s
+
+SIDE EFFECTS — these write to your real project:
+  * The ALLOWED test makes one small real OpenAI call and reports its cost, so
+    project spend increases by a fraction of a cent.
+  * BLOCKED events are not metered, but they DO write the audit log and trigger
+    the owner "limit hit" email (backend-throttled to one per org+project+limit
+    type per hour).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from typing import Any, Optional
+
+import httpx
+import pytest
+
+# Load .env so locally-exported keys are picked up automatically.
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:  # dotenv optional
+    pass
+
+import noveum_trace
+from noveum_trace.core.config import DEFAULT_ENDPOINT
+from noveum_trace.guard.api_client_http import HttpGuardAPIClient
+from noveum_trace.guard.engine import PolicyEngine
+from noveum_trace.guard.policies.cost_cap import CostCapPolicy
+from noveum_trace.guard.policies.rate_limit import RateLimitPolicy
+from noveum_trace.guard.poller import PolicyPoller
+from noveum_trace.guard.transport.adapters.openai_adapter import OpenAIAdapter
+from noveum_trace.guard.types import EnforcementMode, ParsedRequest, PolicyContext
+
+try:
+    import openai
+
+    OPENAI_AVAILABLE = True
+except ImportError:  # provider SDK optional
+    openai = None  # type: ignore[assignment]
+    OPENAI_AVAILABLE = False
+
+NOVEUM_API_KEY = os.environ.get("NOVEUM_API_KEY")
+NOVEUM_PROJECT = os.environ.get("NOVEUM_PROJECT")
+NOVEUM_ENDPOINT = os.environ.get("NOVEUM_ENDPOINT", DEFAULT_ENDPOINT)
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+MODEL = os.environ.get("NOVEUM_GUARD_TEST_MODEL", "gpt-4o-mini")
+
+# Upper bound on real calls used to trip a rate limit, so a misconfigured
+# window can never turn this test into an unbounded spend loop.
+_MAX_RATE_ATTEMPTS = 12
+
+
+def _is_valid_key(key: Optional[str]) -> bool:
+    placeholders = {"", "your-api-key-here", "test-key", "sk-test", "sk-fake", "sk-..."}
+    return bool(key) and key not in placeholders and len(key) > 10
+
+
+def _guard_configured() -> bool:
+    return _is_valid_key(NOVEUM_API_KEY) and bool(NOVEUM_PROJECT)
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not _guard_configured(),
+        reason="NOVEUM_API_KEY / NOVEUM_PROJECT not set — see .env.example",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def usage_posts(monkeypatch):
+    """Record every real POST to /policies/usage without changing behaviour.
+
+    Wraps httpx.Client.post so the request still goes out over the wire; we only
+    observe it. That keeps the test genuinely end-to-end while letting it assert
+    on the status code and body the live backend returned.
+    """
+    recorded: list[dict[str, Any]] = []
+    original = httpx.Client.post
+
+    def spy(self, url, *args, **kwargs):
+        resp = original(self, url, *args, **kwargs)
+        if "/policies/usage" in str(url):
+            try:
+                body = resp.json()
+            except Exception:
+                body = {"_raw": resp.text[:300]}
+            recorded.append(
+                {
+                    "url": str(url),
+                    "events": kwargs.get("json"),
+                    "status": resp.status_code,
+                    "body": body,
+                }
+            )
+        return resp
+
+    monkeypatch.setattr(httpx.Client, "post", spy)
+    return recorded
+
+
+def _ctx() -> PolicyContext:
+    return PolicyContext(
+        project_id=NOVEUM_PROJECT or "",
+        organization_id=None,
+        environment="usage-ingest-e2e",
+        trace_id=None,
+        span_id=None,
+        call_id=str(uuid.uuid4()),
+    )
+
+
+def _api() -> HttpGuardAPIClient:
+    # flush_interval is long so nothing fires until the test calls close(),
+    # which drains synchronously and makes the assertions deterministic.
+    return HttpGuardAPIClient(
+        api_key=NOVEUM_API_KEY or "",
+        base_url=NOVEUM_ENDPOINT,
+        flush_interval=3600,
+    )
+
+
+def _stack(api: HttpGuardAPIClient, max_usd: float, policy_id: Optional[str] = None):
+    engine = PolicyEngine(api_client=api)
+    engine.attach(
+        CostCapPolicy(
+            max_usd=max_usd,
+            mode=EnforcementMode.strict,  # degrades to shared: HTTP has no reserve
+            project_id=NOVEUM_PROJECT,
+            policy_id=policy_id,
+        )
+    )
+    engine.poll_all()  # real GET /policies/state — seeds spend from the backend
+    return engine, _ctx()
+
+
+def _rate_stack(
+    api: HttpGuardAPIClient, max_requests: int, policy_id: Optional[str] = None
+):
+    engine = PolicyEngine(api_client=api)
+    engine.attach(
+        RateLimitPolicy(
+            windows=[{"period": "1m", "maxRequests": max_requests}],
+            project_id=NOVEUM_PROJECT,
+            policy_id=policy_id,
+        )
+    )
+    engine.poll_all()  # real GET /policies/state — seeds live rate counters
+    return engine, _ctx()
+
+
+def _probe_request(model: str, max_tokens: int) -> ParsedRequest:
+    """A parsed request used only to price a call before making it."""
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [{"role": "user", "content": "Reply with one word: done."}],
+            "max_tokens": max_tokens,
+        }
+    ).encode()
+    request = httpx.Request(
+        "POST", "https://api.openai.com/v1/chat/completions", content=payload
+    )
+    return OpenAIAdapter().parse_request(request)
+
+
+def _events(recorded: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [e for post in recorded for e in (post["events"] or [])]
+
+
+def _dump(label: str, recorded: list[dict[str, Any]]) -> None:
+    """Print the exact wire payload and the backend's reply."""
+    for post in recorded:
+        print(f"\n[{label}] POST {post['url']}")
+        print(f"[{label}] -> HTTP {post['status']} {post['body']}")
+        for event in post["events"] or []:
+            print(f"[{label}]    {json.dumps(event, sort_keys=True)}")
+
+
+# ---------------------------------------------------------------------------
+# Policy sync — the real policyId reaches the SDK
+# ---------------------------------------------------------------------------
+
+
+class TestPolicySyncCarriesPolicyId:
+    def test_effective_policies_include_policy_id(self):
+        """A BLOCKED event can only name its policy if the id survives mapping."""
+        api = _api()
+        policies = api.fetch_remote_policies(NOVEUM_PROJECT or "")
+
+        assert policies, "no enabled policies on this project — configure one first"
+        for p in policies:
+            assert p["type"] in ("cost_cap", "rate_limit")
+            assert p.get("policy_id"), f"policy_id missing from mapped policy: {p}"
+        print(f"\n[effective] {policies}")
+
+
+# ---------------------------------------------------------------------------
+# BLOCKED — the call never runs, the event still reaches the backend
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedEventIngest:
+    def test_blocked_call_posts_blocked_event(self, usage_posts):
+        """Exhausted cap → no provider call, one BLOCKED event accepted (202).
+
+        The cap is derived from the project's REAL polled spend, so the block is
+        triggered by live state rather than a hand-set counter.
+        """
+        api = _api()
+        real_spend = api.get_state(NOVEUM_PROJECT or "")["spend"]
+        # Half of real spend is guaranteed to be already exceeded; when spend is
+        # 0 a cap of 0 still blocks, since any estimate is > 0.
+        cap = real_spend * 0.5
+        engine, ctx = _stack(api, max_usd=cap, policy_id="e2e-blocked-probe")
+
+        # A deliberately fake provider key: if the block leaks, OpenAI rejects it
+        # and the test fails loudly instead of silently spending money.
+        client = openai.OpenAI(
+            api_key="sk-must-never-be-used",
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+
+        with pytest.raises(openai.PermissionDeniedError):
+            client.chat.completions.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Reply with one word: done."}],
+                max_tokens=16,
+            )
+
+        api.close()  # drains the queue → real POST /policies/usage
+
+        assert usage_posts, "no POST reached /policies/usage"
+        post = usage_posts[0]
+        _dump("cost-cap", usage_posts)
+
+        assert post["status"] == 202, f"backend rejected the event: {post}"
+        assert post["url"].endswith(f"/v1/projects/{NOVEUM_PROJECT}/policies/usage")
+
+        blocked = [e for e in _events(usage_posts) if e.get("outcome") == "BLOCKED"]
+        assert len(blocked) == 1
+        event = blocked[0]
+        assert event["blockedBy"] == "COST_CAP"
+        assert event["policyId"] == "e2e-blocked-probe"
+        assert event["costUsd"] == 0.0  # the call never ran
+        assert event["model"] == MODEL
+        assert event["eventId"]
+        assert "Cost cap" in event["reason"]
+
+        # The server counts the blocks it took in this push.
+        assert post["body"].get("success") is True
+        assert post["body"].get("blocked") == 1
+
+    def test_blocked_call_is_not_metered(self, usage_posts):
+        """Spend must not move: a blocked call never reached the provider."""
+        api = _api()
+        before = api.get_state(NOVEUM_PROJECT or "")["spend"]
+
+        engine, ctx = _stack(api, max_usd=before * 0.5, policy_id="e2e-not-metered")
+        client = openai.OpenAI(
+            api_key="sk-must-never-be-used",
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+        with pytest.raises(openai.PermissionDeniedError):
+            client.chat.completions.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=8,
+            )
+        api.close()
+
+        after = api.get_state(NOVEUM_PROJECT or "")["spend"]
+        print(f"\n[not-metered] spend before={before} after={after}")
+        assert after == pytest.approx(before, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# ALLOWED — a real LLM call, reported with its real cost
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedEventIngest:
+    @pytest.mark.skipif(
+        not (OPENAI_AVAILABLE and _is_valid_key(OPENAI_API_KEY)),
+        reason="OPENAI_API_KEY not set/valid or openai not installed",
+    )
+    def test_successful_call_posts_allowed_event(self, usage_posts):
+        api = _api()
+        engine, ctx = _stack(api, max_usd=100.0)  # generous: must not block
+
+        client = openai.OpenAI(
+            api_key=OPENAI_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+        resp = client.chat.completions.create(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Reply with one word: done."}],
+            max_tokens=16,
+        )
+        assert resp.choices[0].message.content  # a real answer came back
+
+        api.close()
+
+        assert usage_posts, "no POST reached /policies/usage"
+        post = usage_posts[0]
+        _dump("cost-allowed", usage_posts)
+
+        assert post["status"] == 202, f"backend rejected the event: {post}"
+
+        allowed = [e for e in _events(usage_posts) if e.get("outcome") is None]
+        assert len(allowed) == 1
+        event = allowed[0]
+        # costUsd is required on the allowed path — omitting it is a 400.
+        assert event["costUsd"] > 0.0
+        assert event["inputTokens"] > 0
+        assert event["outputTokens"] > 0
+        # The allowed path reports the model the provider RESOLVED to
+        # (e.g. "gpt-4o-mini-2024-07-18"), not the alias that was requested.
+        assert event["model"].startswith(MODEL)
+        assert event["requestCount"] == 1
+        assert event["eventId"]
+
+        assert post["body"].get("success") is True
+        assert post["body"].get("accepted") == 1
+        assert post["body"].get("blocked") == 0
+
+
+# ---------------------------------------------------------------------------
+# RATE_LIMIT — the second limit type, tripped naturally by a real call
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitBlockedEventIngest:
+    @pytest.mark.skipif(
+        not (OPENAI_AVAILABLE and _is_valid_key(OPENAI_API_KEY)),
+        reason="OPENAI_API_KEY not set/valid or openai not installed",
+    )
+    def test_rate_limit_trips_after_a_real_call(self, usage_posts):
+        """One real call is admitted, the next is blocked by RATE_LIMIT.
+
+        The threshold is set one above the project's live ``requests_1m`` count,
+        so the first call fits and the second trips the limit — the limit is
+        reached by an actual call, not by pre-loading a counter. Both events ride
+        one POST, so the backend reply shows the ALLOWED and BLOCKED split.
+        """
+        api = _api()
+        live_requests = api.get_state(NOVEUM_PROJECT or "")["rate"].get(
+            "requests_1m", 0
+        )
+        engine, ctx = _rate_stack(
+            api,
+            max_requests=live_requests + 1,
+            policy_id="e2e-rate-limit-probe",
+        )
+
+        client = openai.OpenAI(
+            api_key=OPENAI_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+        messages = [{"role": "user", "content": "Reply with one word: done."}]
+
+        # Call 1 — under the limit, actually reaches OpenAI.
+        first = client.chat.completions.create(
+            model=MODEL, messages=messages, max_tokens=16
+        )
+        assert first.choices[0].message.content
+
+        # Call 2 — the limit is now reached, so the Guard stops it.
+        with pytest.raises(openai.PermissionDeniedError):
+            client.chat.completions.create(
+                model=MODEL, messages=messages, max_tokens=16
+            )
+
+        api.close()
+        _dump("rate-limit", usage_posts)
+
+        assert usage_posts, "no POST reached /policies/usage"
+        for post in usage_posts:
+            assert post["status"] == 202, f"backend rejected the event: {post}"
+
+        events = _events(usage_posts)
+        allowed = [e for e in events if e.get("outcome") is None]
+        blocked = [e for e in events if e.get("outcome") == "BLOCKED"]
+
+        assert len(allowed) == 1, f"expected one ALLOWED event, got {events}"
+        assert allowed[0]["costUsd"] > 0.0
+        assert allowed[0]["inputTokens"] > 0
+
+        assert len(blocked) == 1, f"expected one BLOCKED event, got {events}"
+        assert blocked[0]["blockedBy"] == "RATE_LIMIT"
+        assert blocked[0]["policyId"] == "e2e-rate-limit-probe"
+        assert blocked[0]["costUsd"] == 0.0
+        assert "Rate limit reached" in blocked[0]["reason"]
+
+        # Both outcomes in one push; only the block is counted as blocked.
+        assert sum(p["body"].get("blocked", 0) for p in usage_posts) == 1
+        assert sum(p["body"].get("accepted", 0) for p in usage_posts) == 2
+
+
+# ---------------------------------------------------------------------------
+# Real backend policies — blocks carry the project's actual policyId
+# ---------------------------------------------------------------------------
+
+
+def _real_stack(api: HttpGuardAPIClient, keep: type):
+    """Load this project's real policies from the backend, keep one type.
+
+    Only the policy under test is kept attached, so which limit trips is
+    deterministic; both are still instantiated from the live definitions, with
+    their real policyIds.
+    """
+    engine = PolicyEngine(api_client=api)
+    poller = PolicyPoller(engine, project_id=NOVEUM_PROJECT, context=_ctx())
+    poller.force_refresh()  # real GET /policies/effective → attach + poll
+
+    kept = [p for p in engine.policies if isinstance(p, keep)]
+    if not kept:
+        pytest.skip(f"no enabled {keep.__name__} on project {NOVEUM_PROJECT!r}")
+    for policy in engine.policies:
+        if not isinstance(policy, keep):
+            engine.detach(policy.name)
+    return engine, _ctx(), kept[0]
+
+
+class TestRealBackendPolicies:
+    @pytest.mark.skipif(
+        not (OPENAI_AVAILABLE and _is_valid_key(OPENAI_API_KEY)),
+        reason="OPENAI_API_KEY not set/valid or openai not installed",
+    )
+    def test_real_cost_cap_blocks_with_its_own_policy_id(self, usage_posts):
+        """The project's configured COST_CAP blocks a request whose worst-case
+        cost would breach the remaining headroom."""
+        api = _api()
+        engine, ctx, policy = _real_stack(api, CostCapPolicy)
+        real_policy_id = policy._policy_id
+        assert real_policy_id, "backend policy arrived without a policyId"
+
+        spend = api.get_state(NOVEUM_PROJECT or "")["spend"]
+        headroom = policy.max_usd - spend
+        print(
+            f"\n[real-cost-cap] policy={policy.name!r} id={real_policy_id} "
+            f"cap=${policy.max_usd} spend=${spend} headroom=${headroom:.6f}"
+        )
+
+        # Size the request so its worst-case reservation exceeds the headroom.
+        max_tokens = 16000
+        reserved = policy._estimate_reserved_usd(
+            _probe_request(model=MODEL, max_tokens=max_tokens)
+        )
+        if reserved <= headroom:
+            pytest.skip(
+                f"cap has too much headroom to trip: reserved={reserved} "
+                f"headroom={headroom}"
+            )
+
+        client = openai.OpenAI(
+            api_key=OPENAI_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+        with pytest.raises(openai.PermissionDeniedError):
+            client.chat.completions.create(
+                model=MODEL,
+                messages=[{"role": "user", "content": "Reply with one word: done."}],
+                max_tokens=max_tokens,
+            )
+
+        api.close()
+        _dump("real-cost-cap", usage_posts)
+
+        blocked = [e for e in _events(usage_posts) if e.get("outcome") == "BLOCKED"]
+        assert len(blocked) == 1
+        assert blocked[0]["blockedBy"] == "COST_CAP"
+        assert blocked[0]["policyId"] == real_policy_id
+        assert all(p["status"] == 202 for p in usage_posts)
+
+    @pytest.mark.skipif(
+        not (OPENAI_AVAILABLE and _is_valid_key(OPENAI_API_KEY)),
+        reason="OPENAI_API_KEY not set/valid or openai not installed",
+    )
+    def test_real_rate_limit_blocks_with_its_own_policy_id(self, usage_posts):
+        """The project's configured RATE_LIMIT trips after enough real calls."""
+        api = _api()
+        engine, ctx, policy = _real_stack(api, RateLimitPolicy)
+        real_policy_id = policy._policy_id
+        assert real_policy_id, "backend policy arrived without a policyId"
+        print(
+            f"\n[real-rate-limit] policy={policy.name!r} id={real_policy_id} "
+            f"windows={policy.windows}"
+        )
+
+        client = openai.OpenAI(
+            api_key=OPENAI_API_KEY,
+            http_client=noveum_trace.guard.http_client(engine, ctx),
+        )
+        messages = [{"role": "user", "content": "Reply with one word: done."}]
+
+        allowed_calls = 0
+        for _ in range(_MAX_RATE_ATTEMPTS):
+            try:
+                client.chat.completions.create(
+                    model=MODEL, messages=messages, max_tokens=16
+                )
+                allowed_calls += 1
+            except openai.PermissionDeniedError:
+                break
+        else:
+            pytest.fail(
+                f"rate limit never tripped in {_MAX_RATE_ATTEMPTS} calls "
+                f"(windows={policy.windows})"
+            )
+
+        api.close()
+        _dump("real-rate-limit", usage_posts)
+        print(f"[real-rate-limit] allowed {allowed_calls} call(s) before the block")
+
+        blocked = [e for e in _events(usage_posts) if e.get("outcome") == "BLOCKED"]
+        assert len(blocked) == 1
+        assert blocked[0]["blockedBy"] == "RATE_LIMIT"
+        assert blocked[0]["policyId"] == real_policy_id
+        assert all(p["status"] == 202 for p in usage_posts)
+
+
+# ---------------------------------------------------------------------------
+# Malformed payloads — the 400 path the checklist calls out
+# ---------------------------------------------------------------------------
+
+
+class TestBackendRejectsMalformed:
+    def test_blocked_without_blocked_by_is_rejected(self):
+        """Confirms the 400 the SDK guards against is real, so the local
+        validation in report_blocked() is protecting something."""
+        url = (
+            f"{NOVEUM_ENDPOINT.rstrip('/')}/v1/projects/{NOVEUM_PROJECT}/policies/usage"
+        )
+        resp = httpx.post(
+            url,
+            headers={"Authorization": f"Bearer {NOVEUM_API_KEY}"},
+            json={
+                "model": MODEL,
+                "outcome": "BLOCKED",  # no blockedBy — malformed on purpose
+                "eventId": str(uuid.uuid4()),
+            },
+            timeout=15.0,
+            follow_redirects=True,
+        )
+        print(f"\n[malformed] HTTP {resp.status_code} {resp.text[:300]}")
+        assert resp.status_code == 400

--- a/tests/unit/guard/test_api_client.py
+++ b/tests/unit/guard/test_api_client.py
@@ -6,7 +6,7 @@ import uuid
 import httpx
 import pytest
 
-from noveum_trace.guard.api_client import GuardAPIClient
+from noveum_trace.guard.api_client import _MAX_BLOCKED_EVENTS, GuardAPIClient
 from noveum_trace.guard.exceptions import GuardBackendUnavailable
 
 # ---------------------------------------------------------------------------
@@ -363,3 +363,60 @@ class TestConcurrency:
             t.join()
 
         assert api.current_spend("proj") <= cap
+
+
+# ---------------------------------------------------------------------------
+# report_blocked()
+# ---------------------------------------------------------------------------
+
+
+class TestReportBlocked:
+    def test_records_the_event(self):
+        api = GuardAPIClient()
+        cid = _call_id()
+        api.report_blocked(
+            cid, "proj", "gpt-4o", "COST_CAP", policy_id="pol_1", reason="cap hit"
+        )
+        events = api.blocked_events("proj")
+        assert len(events) == 1
+        assert events[0] == {
+            "call_id": cid,
+            "model": "gpt-4o",
+            "blocked_by": "COST_CAP",
+            "policy_id": "pol_1",
+            "reason": "cap hit",
+        }
+
+    def test_invalid_blocked_by_is_ignored(self):
+        api = GuardAPIClient()
+        api.report_blocked(_call_id(), "proj", "gpt-4o", "NOT_A_LIMIT")
+        assert api.blocked_events("proj") == []
+
+    def test_blocked_call_is_not_metered(self):
+        """The call never ran, so it must not count toward spend or rate."""
+        api = GuardAPIClient()
+        api.report_blocked(_call_id(), "proj", "gpt-4o", "RATE_LIMIT")
+        assert api.current_spend("proj") == 0.0
+        assert api.current_rate("proj") == {}
+
+    def test_buffer_is_bounded(self):
+        """A long-running process under sustained blocking must not grow the
+        inspection buffer without bound."""
+        api = GuardAPIClient()
+        for _ in range(_MAX_BLOCKED_EVENTS + 250):
+            api.report_blocked(_call_id(), "proj", "gpt-4o", "RATE_LIMIT")
+        assert len(api.blocked_events("proj")) == _MAX_BLOCKED_EVENTS
+
+    def test_bounded_buffer_drops_the_oldest(self):
+        api = GuardAPIClient()
+        for i in range(_MAX_BLOCKED_EVENTS + 1):
+            api.report_blocked(str(i), "proj", "gpt-4o", "RATE_LIMIT")
+        events = api.blocked_events("proj")
+        assert events[0]["call_id"] == "1"  # "0" was evicted
+        assert events[-1]["call_id"] == str(_MAX_BLOCKED_EVENTS)
+
+    def test_reset_clears_blocked_events(self):
+        api = GuardAPIClient()
+        api.report_blocked(_call_id(), "proj", "gpt-4o", "COST_CAP")
+        api.reset()
+        assert api.blocked_events("proj") == []

--- a/tests/unit/guard/test_api_client_http.py
+++ b/tests/unit/guard/test_api_client_http.py
@@ -13,6 +13,7 @@ import uuid
 import httpx
 import pytest
 
+from noveum_trace.guard import api_client_http
 from noveum_trace.guard.api_client_http import HttpGuardAPIClient
 from noveum_trace.guard.exceptions import GuardBackendUnavailable
 
@@ -22,9 +23,10 @@ def _call_id() -> str:
 
 
 class _Resp:
-    def __init__(self, status_code: int, json_data=None):
+    def __init__(self, status_code: int, json_data=None, headers=None):
         self.status_code = status_code
         self._json = json_data if json_data is not None else {}
+        self.headers = headers or {}
 
     def json(self):
         return self._json
@@ -34,6 +36,9 @@ class _FakeClient:
     """Records every get/post so tests can assert the HTTP contract."""
 
     calls: list[dict] = []
+    # Queued POST responses, consumed in order; the last one repeats so a retry
+    # loop keeps seeing the same status. Empty means "always 202".
+    post_resps: list = []
 
     def __init__(self, *, get_resp=None, get_exc=None, post_exc=None):
         self._get_resp = get_resp
@@ -66,12 +71,20 @@ class _FakeClient:
         )
         if self._post_exc is not None:
             raise self._post_exc
+        queued = _FakeClient.post_resps
+        if queued:
+            return queued.pop(0) if len(queued) > 1 else queued[0]
         return _Resp(202, {"success": True})
 
 
-def _patch(monkeypatch, **kwargs) -> None:
+def _patch(monkeypatch, post_resps=None, **kwargs) -> None:
     _FakeClient.calls = []
+    _FakeClient.post_resps = list(post_resps or [])
     monkeypatch.setattr(httpx, "Client", lambda **kw: _FakeClient(**kwargs))
+
+
+def _posts() -> list[dict]:
+    return [c for c in _FakeClient.calls if c["method"] == "POST"]
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +261,173 @@ class TestReportUsage:
 
 
 # ---------------------------------------------------------------------------
+# report_blocked — BLOCKED events on the same POST /policies/usage
+# ---------------------------------------------------------------------------
+
+
+class TestReportBlocked:
+    def test_event_has_backend_shape(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        cid = _call_id()
+        api.report_blocked(
+            cid,
+            "proj",
+            "gpt-4o",
+            "COST_CAP",
+            policy_id="pol_abc123",
+            reason="30d cost cap exceeded",
+        )
+        api.close()
+
+        post = _posts()[0]
+        assert post["url"] == "https://api.noveum.ai/v1/projects/proj/policies/usage"
+        event = post["json"][0]
+        assert event["outcome"] == "BLOCKED"
+        assert event["blockedBy"] == "COST_CAP"
+        assert event["model"] == "gpt-4o"
+        assert event["costUsd"] == 0.0  # the call never ran
+        assert event["policyId"] == "pol_abc123"
+        assert event["reason"] == "30d cost cap exceeded"
+        assert event["eventId"] == cid
+        assert event["timestamp"].endswith("Z")
+
+    def test_optional_fields_omitted_when_absent(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        api.report_blocked(_call_id(), "proj", "gpt-4o", "RATE_LIMIT")
+        api.close()
+
+        event = _posts()[0]["json"][0]
+        assert "policyId" not in event
+        assert "reason" not in event
+        assert event["blockedBy"] == "RATE_LIMIT"
+
+    def test_reason_truncated_to_backend_limit(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        api.report_blocked(_call_id(), "proj", "gpt-4o", "COST_CAP", reason="x" * 900)
+        api.close()
+        assert len(_posts()[0]["json"][0]["reason"]) == 500
+
+    def test_invalid_blocked_by_is_dropped(self, monkeypatch):
+        """An unknown blockedBy is a guaranteed 400 — never let it poison a batch."""
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        api.report_blocked(_call_id(), "proj", "gpt-4o", "SOMETHING_ELSE")
+        api.close()
+        assert _posts() == []
+
+    def test_blocked_and_allowed_share_one_batch(self, monkeypatch):
+        _patch(monkeypatch)
+        api = HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+        api.report_usage(_call_id(), "proj", 0.01, "gpt-4o", 10, 5)
+        api.report_blocked(_call_id(), "proj", "gpt-4o", "COST_CAP")
+        api.close()
+
+        posts = _posts()
+        assert len(posts) == 1
+        outcomes = [e.get("outcome", "ALLOWED") for e in posts[0]["json"]]
+        assert outcomes == ["ALLOWED", "BLOCKED"]
+
+
+# ---------------------------------------------------------------------------
+# usage push — HTTP status handling
+# ---------------------------------------------------------------------------
+
+
+class TestUsagePushStatusHandling:
+    @staticmethod
+    def _api(monkeypatch, post_resps):
+        _patch(monkeypatch, post_resps=post_resps)
+        monkeypatch.setattr(api_client_http, "_RETRY_BASE_DELAY", 0.0)
+        return HttpGuardAPIClient(
+            api_key="k", base_url="https://api.noveum.ai", flush_interval=3600
+        )
+
+    def test_success_posts_once(self, monkeypatch):
+        api = self._api(monkeypatch, [_Resp(202, {"success": True})])
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        api._flush_once()
+        assert len(_posts()) == 1
+        api.close()
+
+    def test_400_is_not_retried(self, monkeypatch):
+        """A malformed payload fails identically every time — resending it only
+        burns requests."""
+        api = self._api(monkeypatch, [_Resp(400, {"error": "bad"})])
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        api._flush_once()
+        assert len(_posts()) == 1
+        api.close()
+
+    def test_500_is_retried_to_the_attempt_limit(self, monkeypatch):
+        api = self._api(monkeypatch, [_Resp(500)])
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        api._flush_once()
+        assert len(_posts()) == api_client_http._MAX_PUSH_ATTEMPTS
+        api.close()
+
+    def test_retry_reuses_the_same_event_id(self, monkeypatch):
+        """Idempotency: the backend dedups on eventId, so a resend must carry
+        the original one or the retry double-counts."""
+        api = self._api(monkeypatch, [_Resp(503)])
+        cid = _call_id()
+        api.report_usage(cid, "proj", 1.0, "gpt-4o")
+        api._flush_once()
+        sent = [p["json"][0]["eventId"] for p in _posts()]
+        assert sent == [cid] * api_client_http._MAX_PUSH_ATTEMPTS
+        api.close()
+
+    def test_429_is_retried(self, monkeypatch):
+        api = self._api(monkeypatch, [_Resp(429, headers={"Retry-After": "0"})])
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        api._flush_once()
+        assert len(_posts()) == api_client_http._MAX_PUSH_ATTEMPTS
+        api.close()
+
+    def test_recovers_when_a_retry_succeeds(self, monkeypatch):
+        api = self._api(monkeypatch, [_Resp(500), _Resp(202, {"success": True})])
+        api.report_usage(_call_id(), "proj", 1.0, "gpt-4o")
+        api._flush_once()
+        assert len(_posts()) == 2  # stops as soon as one succeeds
+        api.close()
+
+
+class TestRetryDelay:
+    def test_honors_retry_after_seconds(self):
+        api = HttpGuardAPIClient(api_key="k")
+        assert api._retry_delay(_Resp(429, headers={"Retry-After": "7"}), 1) == 7.0
+
+    def test_caps_retry_after(self):
+        """A hostile or mistaken header must not park the flush thread for hours."""
+        api = HttpGuardAPIClient(api_key="k")
+        delay = api._retry_delay(_Resp(429, headers={"Retry-After": "99999"}), 1)
+        assert delay == api_client_http._MAX_RETRY_DELAY
+
+    def test_http_date_falls_back_to_backoff(self):
+        api = HttpGuardAPIClient(api_key="k")
+        resp = _Resp(429, headers={"Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT"})
+        assert api._retry_delay(resp, 2) == api_client_http._RETRY_BASE_DELAY * 2
+
+    def test_backoff_doubles_without_a_header(self):
+        api = HttpGuardAPIClient(api_key="k")
+        base = api_client_http._RETRY_BASE_DELAY
+        delays = [api._retry_delay(_Resp(500), n) for n in (1, 2, 3)]
+        assert delays == [base, base * 2, base * 4]
+
+
+# ---------------------------------------------------------------------------
 # reserve / reconcile — unsupported by the HTTP backend
 # ---------------------------------------------------------------------------
 
@@ -302,6 +482,7 @@ class TestFetchRemotePolicies:
                 "type": "cost_cap",
                 "name": "Monthly budget",
                 "fail_closed": True,
+                "policy_id": "p1",
                 "max_usd": 1500,
                 "window": "30d_rolling",
             }
@@ -340,6 +521,7 @@ class TestFetchRemotePolicies:
                 "type": "rate_limit",
                 "name": "Burst rate",
                 "fail_closed": True,
+                "policy_id": "p2",
                 "windows": [
                     {
                         "period": "1m",

--- a/tests/unit/guard/test_engine.py
+++ b/tests/unit/guard/test_engine.py
@@ -534,3 +534,90 @@ class TestMultipleCostCapPolicies:
         # proj-a blocks (cap=0), proj-b untouched
         assert block is not None
         assert api.current_spend("proj-b") == 0.0
+
+
+class TestBlockedEventReporting:
+    """A block must reach /policies/usage — that is what emails the owner."""
+
+    def test_cost_cap_block_is_reported(self):
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(
+            CostCapPolicy(
+                max_usd=0.0,
+                mode=EnforcementMode.strict,
+                project_id="proj",
+                policy_id="pol_abc123",
+            )
+        )
+        ctx = _ctx()
+
+        block, _ = engine.pre_call(_req(model="gpt-4o"), ctx)
+
+        assert block is not None
+        events = api.blocked_events("proj")
+        assert len(events) == 1
+        assert events[0]["blocked_by"] == "COST_CAP"
+        assert events[0]["policy_id"] == "pol_abc123"
+        assert events[0]["model"] == "gpt-4o"
+        assert events[0]["call_id"] == ctx.call_id
+        assert "Cost cap" in events[0]["reason"]
+
+    def test_blocked_call_is_not_metered(self):
+        """A blocked call never ran, so it must not count toward spend."""
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(
+            CostCapPolicy(max_usd=0.0, mode=EnforcementMode.strict, project_id="proj")
+        )
+        engine.pre_call(_req(), _ctx())
+        assert api.current_spend("proj") == 0.0
+
+    def test_fail_closed_exception_block_is_not_reported(self):
+        """A crashing policy is a bug, not a limit — reporting it would fire a
+        spurious owner email and corrupt the audit log."""
+
+        class Exploding(AbstractPolicy):
+            name = "exploding"
+            fail_closed = True
+
+            def pre(self, parsed, ctx, deps):
+                raise RuntimeError("boom")
+
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(Exploding())
+
+        block, _ = engine.pre_call(_req(), _ctx())
+
+        assert block is not None and block.is_blocking
+        assert api.blocked_events("proj") == []
+
+    def test_control_plane_block_is_not_reported(self):
+        """Failing closed on an unreachable control plane is an availability
+        event, not a cost cap or rate limit."""
+        api = GuardAPIClient()
+        engine = PolicyEngine(api_client=api)
+        engine.set_backend_unavailable(True)
+
+        block, _ = engine.pre_call(_req(), _ctx())
+
+        assert block is not None and block.is_blocking
+        assert api.blocked_events("proj") == []
+
+    def test_report_failure_does_not_break_the_block(self):
+        """Reporting is best-effort; a backend wobble must not turn a clean
+        block into an exception in the caller's LLM call."""
+
+        class ExplodingReporter(GuardAPIClient):
+            def report_blocked(self, *args, **kwargs):
+                raise RuntimeError("usage endpoint down")
+
+        api = ExplodingReporter()
+        engine = PolicyEngine(api_client=api)
+        engine.attach(
+            CostCapPolicy(max_usd=0.0, mode=EnforcementMode.strict, project_id="proj")
+        )
+
+        block, _ = engine.pre_call(_req(), _ctx())
+        assert block is not None and block.is_blocking


### PR DESCRIPTION
# Pull Request

## Description

**feat(guard): report BLOCKED usage events to `/policies/usage`**

The Guard reported a call's cost **after it ran**, but a call it **stopped** was never reported at all. Searching `src/` for `BLOCKED`, `blockedBy`, or `outcome` returns no matches anywhere in the guard package on `main`.

The consequence: a customer can hit their cost cap all day, be blocked every time, and the platform never learns about it — no audit-log entry, no block counted, and no owner "limit hit" email, because that email is triggered by the BLOCKED event the SDK was never sending.

**Where it went missing.** A policy decides to block (`guard/engine.py:136`), the transport turns that into a synthetic 403 for the caller (`guard/transport/sync_transport.py:138`), and between those two points nothing ever touches the usage queue.

Three secondary gaps surfaced in the same review:

1. **`policyId` was discarded.** `_normalize_policy` kept `type`, `name`, `fail_closed` and the config fields but dropped the backend's `policyId`. Even had it survived, `_instantiate_policy` (`guard/poller.py:310`) filters config keys to the constructor signature, and neither policy accepted one.
2. **`blockedBy` had no reliable source.** `PolicyDecision.policy_name` is overwritten by the backend's display name (`guard/poller.py:326`), so a policy named "Q3 budget guard" maps to neither of the two values the API accepts.
3. **The usage POST ignored its own response.** `_post_usage` never read `resp.status_code`: a 400 was silently swallowed, a 500 lost the batch permanently, a 429 was ignored — despite the class docstring claiming "retries are safe because the backend dedups on eventId". The dedup guarantee was real; the retry was never written.

### What this PR does

**Blocked events are reported.** `report_blocked()` added to `GuardAPIClient` and `HttpGuardAPIClient`; blocked events ride the existing batch queue, so one POST can carry both outcomes. Reporting happens in `PolicyEngine.pre_call` rather than in the transports — there are four places that handle a block decision (`sync_transport.py:138`, `async_transport.py:119`, `integrations/bedrock.py:541`, `integrations/crewai.py:58`) and all four get their decision from `pre_call`, so one call site covers them all and no future transport can forget it.

**Only genuine limit trips are sent.** Not every block is a limit being hit: a control-plane failure blocks every call under the synthetic name `_guard_control_plane` (`engine.py:119`), and a crashing policy is turned into a block by `_safe_invoke` (`engine.py:202`). Reporting either as `COST_CAP` would corrupt the audit log and email customers about budgets they never approached — during an outage, at scale. So `CostCapPolicy` and `RateLimitPolicy` tag only their real limit branches with `blocked_by`, and the engine reports only decisions carrying that key. The two synthetic block kinds are excluded structurally, not by a name check.

**`policyId` propagation.** Kept in `_normalize_policy`, accepted by both policy constructors, applied in `update_params` so it survives a backend config push, and attached to the block decision.

**Blocked calls are never metered.** `report_blocked` deliberately does not touch the spend or rate counters — a blocked call never ran, so it must not count toward the limits that blocked it.

**HTTP status handling on the usage push.** `_post_usage` now reads its response: 2xx done; 429 retried honouring `Retry-After` (capped at 30s so a bad header can't park the flush thread); 5xx retried with exponential backoff; any other 4xx logged at error level and dropped, because resending a malformed payload fails identically. Retries reuse the same `eventId`, which is what lets the backend's dedup do its job. Maximum 3 attempts, all on the background flush thread, so a backoff never delays the caller.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test improvements

## How Has This Been Tested?

### Unit tests — 15 new

`tests/unit/guard/test_engine.py` (5): the cost-cap block is reported; the blocked call isn't metered; a fail-closed exception block is **not** reported; a control-plane block is **not** reported; a reporting failure doesn't turn a clean block into a caller-visible error.

`tests/unit/guard/test_api_client_http.py` (10): blocked-event wire shape; optional fields omitted when absent; reason truncated at 500 chars; invalid `blockedBy` dropped before it can poison a batch; blocked and allowed events sharing one batch; 400 not retried; 5xx retried to the attempt limit; retry reuses the `eventId`; 429 retried; recovery when a retry succeeds; plus `Retry-After` parsing, capping, HTTP-date fallback, and backoff doubling.

Two existing assertions were updated — `test_maps_cost_cap_shape` and `test_maps_rate_limit_shape` compared the whole mapped dict with `==`, so adding `policy_id` broke them. Intended contract change, not a regression.

```bash
pytest tests/unit/ -n auto --dist loadscope -q
# 1656 passed, exit 0
```

### Integration tests — new file, live backend

`tests/integration/guard/test_usage_ingest_real.py` — 8 tests, marked `integration`, auto-skipped when credentials are absent.

```bash
pytest tests/integration/guard/test_usage_ingest_real.py -m integration -v -s
# 8 passed, exit 0
```

Requires in `.env`: `NOVEUM_API_KEY` and `NOVEUM_PROJECT` always; `OPENAI_API_KEY` for the tests that make a real LLM call.

Verified against project `guard-testing` using its **real configured policies**, not hand-built ones:

| Policy | Type | policyId | Config |
|---|---|---|---|
| `test1` | RATE_LIMIT | `cmrx5ryad000h0f9dc0k2sr7l` | 1m: 5 requests, 100 tokens |
| `test3` | COST_CAP | `cmrxkwb0t00020gacdvfsy9vx` | $0.01, 30d_rolling |

The file has three layers: two tests driving the real backend policies through `PolicyPoller`, four using locally-constructed policies with synthetic ids so they stay deterministic regardless of how the project is reconfigured, and one confirming the server really does reject a malformed payload.

### Manual testing

- [x] Unit tests
- [x] Integration tests
- [x] Manual testing — probed `/policies/effective` and `/policies/state` directly against production before writing any test, to confirm the credentials, project id, and URL shape.
- [ ] Performance testing — not applicable; no hot-path work added beyond one dict lookup per blocked call, and the network push was already on a background thread.

## Test Configuration

* **Python version:** 3.11.9
* **Operating System:** Windows 11 (win32)
* **Dependencies:** pytest 9.0.2, pytest-xdist 3.8.0, pytest-asyncio 1.3.0, httpx, openai 2.34.0, python-dotenv; live Noveum backend at `https://api.noveum.ai/api`

## Checklist

- [x] My code follows the style guidelines of this project — `black`, `isort`, `ruff check --fix` all clean; `mypy src/noveum_trace/guard/` reports success on 24 files
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas — comments kept to 1–2 lines per the repo guardrail; the non-obvious ones explain *why* fail-closed blocks are excluded and why a 4xx isn't retried
- [ ] I have made corresponding changes to the documentation — no docs changes; this adds no new public API surface, and the behaviour is described in the module docstrings
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes — 1656 passed
- [ ] Any dependent changes have been merged and published in downstream modules — none; the `/policies/usage` endpoint already accepts this payload, as the live runs below confirm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocked calls are now recorded and reported with blocking-limit details, including model, call ID, reason, and optional policy ID.
  * Cost-cap and rate-limit decisions carry backend policy identifiers when available.
* **Reliability**
  * Usage event uploads now retry transient server/rate-limit failures with bounded attempts and respect `Retry-After` when present.
  * Reporting failures for blocked events never impact enforcement outcomes.
* **Validation**
  * Expanded unit and live integration coverage for blocked-event payloads, usage accounting behavior, and retry/idempotency logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a silent audit gap: calls blocked by `CostCapPolicy` or `RateLimitPolicy` were never reported to `/policies/usage`, so the backend never received a BLOCKED event, no audit-log entry was written, and the "limit hit" owner email was never triggered. Three related fixes ship alongside — `policyId` propagation through `_normalize_policy` and both policy constructors, structured `blocked_by` tagging on block decisions, and proper HTTP status handling in `_post_usage` (retry 5xx/429, drop 4xx).

- **Blocked-event reporting** is wired into `PolicyEngine.pre_call()` once, covering all four transports; synthetic blocks (fail-closed exception, control-plane outage) are structurally excluded by requiring a `blocked_by` key that only real limit policies set.
- **`policyId` propagation**: kept in `_normalize_policy`, accepted by both policy constructors, applied in `update_params`, and attached to the block decision state so the BLOCKED event carries the correct backend policy identifier.
- **`_post_usage` retry logic**: 2xx → done; 429/5xx → exponential backoff up to 3 attempts, honouring `Retry-After` (capped at 30 s); other 4xx → logged and dropped; all delays check `_stop` so a backoff never delays `close()`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is additive on the hot path (one dict lookup + a background queue append per blocked call), the enforcement decision is returned to the caller before and regardless of reporting, and the reporting failure path is wrapped in a try/except that logs at debug level.

The blocking logic and the reporting logic are fully decoupled — a reporting failure cannot affect enforcement. The synthetic block kinds (fail-closed exception, control-plane outage) are excluded structurally rather than by name check, and the unit tests verify each exclusion explicitly. The retry changes to _post_usage are well-covered and the _stop event correctly short-circuits delays during shutdown.

**Files Needing Attention:** tests/integration/guard/test_usage_ingest_real.py — the spend-equality assertion in test_blocked_call_is_not_metered uses a 1e-9 tolerance that can produce false failures when test classes run in parallel against a shared backend project.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/noveum_trace/guard/api_client.py | Adds in-memory blocked-event buffer (deque, bounded at _MAX_BLOCKED_EVENTS per project), report_blocked() method that validates blockedBy and stores events without touching spend/rate counters, blocked_events() inspector, and reset() coverage. BLOCKED_BY_VALUES promoted to public so HttpGuardAPIClient can import it. |
| src/noveum_trace/guard/api_client_http.py | Adds report_blocked() that enqueues a BLOCKED event via the existing batch queue; refactors _post_usage to retry 5xx/429 with exponential backoff (honoring Retry-After), drop 4xx without retry, and respect shutdown during delays; adds _retry_delay helper and _now_iso(); propagates policyId in _normalize_policy. |
| src/noveum_trace/guard/engine.py | Adds _report_blocked() called once in pre_call() after rollback, covering all four transports; correctly gates on decision.state["blocked_by"] so synthetic (fail-closed/control-plane) blocks are never reported; wraps in try/except so a reporting failure never propagates to the caller. |
| src/noveum_trace/guard/policies/cost_cap.py | Adds blocked_by = "COST_CAP" class attribute, _policy_id instance field (constructor + update_params), and injects both into the block decision state so the engine can attach them to the BLOCKED event. |
| src/noveum_trace/guard/policies/rate_limit.py | Mirrors cost_cap changes: blocked_by = "RATE_LIMIT", _policy_id added to constructor and update_params; block_state dict is built once before the window loop so both the per-request and per-token block paths carry identical metadata. |
| src/noveum_trace/guard/policies/base.py | Adds blocked_by: ClassVar[Optional[str]] = None to AbstractPolicy so the contract is explicit — None signals "this policy's blocks are not limit events and must not be reported". |
| tests/unit/guard/test_engine.py | Adds TestBlockedEventReporting with five targeted tests: cost-cap block reported, blocked call not metered, fail-closed exception block excluded, control-plane block excluded, and reporting failure doesn't surface to the caller. |
| tests/unit/guard/test_api_client_http.py | Adds TestReportBlocked (wire shape, optional-field elision, 500-char truncation, invalid-blockedBy guard, shared batch), TestUsagePushStatusHandling (200/400/5xx/429/recovery), and TestRetryDelay (Retry-After seconds, cap, HTTP-date fallback, doubling backoff). Extends _FakeClient to support queued responses. |
| tests/integration/guard/test_usage_ingest_real.py | New live-backend integration suite; well-structured with three layers (synthetic policy_id, real poller, malformed-payload 400 probe). The spend-assertion tolerance in test_blocked_call_is_not_metered is dangerously tight for parallel CI runs against a shared project. |
| tests/unit/guard/test_api_client.py | Adds TestReportBlocked for the in-memory client: records event, ignores invalid blockedBy, doesn't meter spend/rate, enforces the bounded buffer (1000 entries), drops oldest on overflow, and clears on reset(). |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Transport
    participant PolicyEngine
    participant Policy as CostCapPolicy/RateLimitPolicy
    participant GuardAPIClient
    participant BackendHTTP as /policies/usage

    Caller->>Transport: LLM request
    Transport->>PolicyEngine: pre_call(parsed, ctx)
    PolicyEngine->>Policy: pre(parsed, ctx, deps)
    Policy-->>PolicyEngine: "PolicyDecision.block(state={blocked_by, policy_id, scope_id})"

    Note over PolicyEngine: Rollback all ran policies via release()

    PolicyEngine->>PolicyEngine: _report_blocked(decision, parsed, ctx)
    PolicyEngine->>GuardAPIClient: report_blocked(call_id, project_id, model, blocked_by, policy_id, reason)

    alt HttpGuardAPIClient
        GuardAPIClient->>GuardAPIClient: _enqueue(project_id, BLOCKED event)
        Note over GuardAPIClient: outcome=BLOCKED, costUsd=0, eventId=call_id
        GuardAPIClient-->>BackendHTTP: POST /policies/usage (batched, async)
        BackendHTTP-->>GuardAPIClient: 202 / 429 retry / 5xx retry / 4xx drop
    else GuardAPIClient in-memory
        GuardAPIClient->>GuardAPIClient: _blocked_events[project_id].append(event)
    end

    PolicyEngine-->>Transport: block_decision
    Transport-->>Caller: 403 PermissionDenied
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(guard): bound the blocked-event buff..."](https://github.com/noveum/noveum-trace/commit/2c0ec20c9883354a1dd3f627edab0a24a3090a75) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47595465)</sub>

<!-- /greptile_comment -->