### PR TITLE
docs: add upstream submission plan and version matrix

### DIFF
--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -82,8 +82,7 @@ from noveum_trace.integrations.crewai import setup_crewai_tracing
 
 noveum_trace.init(api_key="...", project="my-crew")  # required first
 
-listener = setup_crewai_tracing()
-crew.callback_function = listener
+listener = setup_crewai_tracing()  # registers with CrewAI's global event bus
 try:
     crew.kickoff()
 finally:
@@ -92,9 +91,12 @@ finally:
 ```
 
 `setup_crewai_tracing()` raises `RuntimeError` if `noveum_trace.init()` has not
-been called. Wrap `crew.kickoff()` in `try/finally`, call `listener.shutdown()`
-to detach, then `noveum_trace.flush()` so buffered spans are delivered before a
-short-lived process exits.
+been called. The listener registers with CrewAI's global event bus on
+construction (`NoveumCrewAIListener` subclasses `crewai.events.BaseEventListener`),
+so do **not** assign it to `crew.callback_function` — that field does not exist
+on current `Crew` versions and raises `ValueError`. Wrap `crew.kickoff()` in
+`try/finally`, call `listener.shutdown()` to detach, then `noveum_trace.flush()`
+so buffered spans are delivered before a short-lived process exits.
 
 ### LiveKit — `setup_livekit_tracing`
 
@@ -170,14 +172,23 @@ attaching the handler to sensitive chains).
 ### Disabling capture (quick reference)
 
 ```python
-# CrewAI: turn off payload capture
+# CrewAI: turn off every capture channel
 listener = setup_crewai_tracing(
     capture_inputs=False,
     capture_outputs=False,
     capture_llm_messages=False,
     capture_tool_schemas=False,
+    capture_agent_snapshot=False,
+    capture_crew_snapshot=False,
     capture_memory=False,
     capture_knowledge=False,
+    capture_a2a=False,
+    capture_mcp=False,
+    capture_flow=False,
+    capture_reasoning=False,
+    capture_guardrails=False,
+    capture_streaming=False,
+    capture_thinking=False,
 )
 
 # Pipecat: no audio, no LLM/TTS text, no tool-call capture

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -84,10 +84,17 @@ noveum_trace.init(api_key="...", project="my-crew")  # required first
 
 listener = setup_crewai_tracing()
 crew.callback_function = listener
+try:
+    crew.kickoff()
+finally:
+    listener.shutdown()   # detaches the listener
+    noveum_trace.flush()  # shutdown() does not flush the SDK
 ```
 
 `setup_crewai_tracing()` raises `RuntimeError` if `noveum_trace.init()` has not
-been called.
+been called. Wrap `crew.kickoff()` in `try/finally`, call `listener.shutdown()`
+to detach, then `noveum_trace.flush()` so buffered spans are delivered before a
+short-lived process exits.
 
 ### LiveKit — `setup_livekit_tracing`
 
@@ -139,9 +146,11 @@ All default `True`: `capture_inputs`, `capture_outputs`, `capture_llm_messages`,
 ### LiveKit — `setup_livekit_tracing(session, *, ...)`
 
 `enabled=True`, `trace_name_prefix=None`, `record=True`,
-`cleanup_audio_files=True`. `record=True` captures full conversation audio; pass
-`record=False` to disable audio capture. (LiveKit uses `record`, not
-`record_audio`.)
+`cleanup_audio_files=True`. (LiveKit uses `record`, not `record_audio`.)
+`record=False` only stops the wrapper from forcing `session.start(record=True)`;
+if the application starts its own `RecorderIO`, conversation audio can still be
+uploaded. To disable the LiveKit integration entirely (no start-method wrapping,
+no event handlers, no audio upload), pass `enabled=False`.
 
 ### Pipecat — `NoveumPipecatTracer(...)`
 
@@ -157,6 +166,34 @@ observer also exposes `capture_text=True` (LLM/TTS text) and
 No per-field capture toggles; the handler captures prompts, responses, and tool
 results by default. Reduce exposure at the application layer (redaction, or not
 attaching the handler to sensitive chains).
+
+### Disabling capture (quick reference)
+
+```python
+# CrewAI: turn off payload capture
+listener = setup_crewai_tracing(
+    capture_inputs=False,
+    capture_outputs=False,
+    capture_llm_messages=False,
+    capture_tool_schemas=False,
+    capture_memory=False,
+    capture_knowledge=False,
+)
+
+# Pipecat: no audio, no LLM/TTS text, no tool-call capture
+tracer = NoveumPipecatTracer(
+    record_audio=False,
+    record_raw_input_audio=False,
+    capture_text=False,
+    capture_function_calls=False,
+)
+
+# LiveKit: disable the integration entirely (record=False alone is not enough)
+setup_livekit_tracing(session, enabled=False)
+
+# LangChain / LangGraph: omit the handler on chains that handle sensitive data
+result = sensitive_chain.invoke({"text": "..."})  # no callbacks=[handler]
+```
 
 ## 5. Upstream positioning language
 

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -1,0 +1,184 @@
+# Upstream Submission Reference
+
+Engineering-facing reference for submitting Noveum Trace observability
+integrations to upstream ecosystems (Pipecat, CrewAI, LiveKit, LangChain,
+LangGraph). This is the single source of truth for what we can accurately claim
+in an upstream docs or listing PR.
+
+Every symbol, extra, and version below is taken from the current source
+(`pyproject.toml`, `src/noveum_trace/`). Re-verify against source before opening
+any PR — do not document an API, extra, or flag that does not exist in the
+released package.
+
+- Package: `noveum-trace` (PyPI), version `1.5.20`, `requires-python = ">=3.9"`,
+  Apache-2.0.
+- Install: `pip install "noveum-trace[<extra>]"`.
+
+## 1. Support matrix
+
+| Ecosystem | SDK module | Install extra | Canonical API | Upstream status |
+|-----------|-----------|---------------|---------------|-----------------|
+| LangChain | `noveum_trace.integrations.langchain` (also re-exported at package root) | `langchain` | `NoveumTraceCallbackHandler` | Community-maintained observability integration (callback handler). No upstream PR yet. |
+| LangGraph | `noveum_trace.integrations.langchain` (same handler) | `langchain` (no separate `langgraph` extra) | `NoveumTraceCallbackHandler` (optionally `use_langchain_assigned_parent=True`) | Community-maintained observability integration (callback handler). No upstream PR yet. |
+| LiveKit | `noveum_trace.integrations.livekit` | `livekit` | `setup_livekit_tracing(session)` | Community-maintained observability integration. Candidate for upstream docs/listing. |
+| Pipecat | `noveum_trace.integrations.pipecat` | `pipecat` (add `pipecat-otel` for OTEL span export) | `NoveumPipecatTracer` (two-call: `observe_pipeline` + `register_task_handlers`) | Community-maintained observability integration (observer). Candidate for upstream docs/listing. |
+| CrewAI | `noveum_trace.integrations.crewai` | `crewai` | `setup_crewai_tracing()` (or `NoveumCrewAIListener`) | Community-maintained observability integration (listener). Candidate for upstream docs/listing. |
+| OpenTelemetry alignment | `noveum_trace.integrations.pipecat.custom_spans` | `pipecat-otel` | Plain OTEL spans folded into the Pipecat trace via `capture_custom_spans=True` (registers an OTEL `SpanProcessor`) | Bridge only — there is no standalone OTEL exporter. Do not describe a general-purpose OpenTelemetry backend. |
+
+**Not yet supported — do not claim support in any listing:** OpenAI Agents SDK,
+LlamaIndex, AutoGen, Vercel AI SDK, and LiteLLM have no dedicated integration
+module in `src/noveum_trace/integrations/`. Direct OpenAI/Anthropic calls can be
+traced with the core context managers (`trace_llm_call`), but that is not a
+framework integration.
+
+There is no plugin system: `noveum_trace.register_plugin` and
+`noveum_trace.list_plugins` currently raise `NotImplementedError`. Never
+describe Noveum Trace as a "plugin".
+
+## 2. Version compatibility
+
+Effective Python floor per ecosystem is the higher of the SDK core floor (3.9)
+and the upstream framework's own floor.
+
+| Ecosystem | Effective Python floor | Upstream dependency pin |
+|-----------|------------------------|-------------------------|
+| Core SDK / direct OpenAI + Anthropic | 3.9+ | `openai>=1.0.0`, `anthropic>=0.3.0` |
+| LangChain | 3.10+ | `langchain-core>=0.1.0` (+ `Pillow>=9.0.0`) |
+| LangGraph | 3.10+ | `langchain-core>=0.1.0` (shares the `langchain` extra) |
+| LiveKit | 3.10+ | `livekit>=1.0.19,<2`, `livekit-agents>=1.0.0` |
+| CrewAI | 3.10+ | `crewai>=0.177.0; python_version>='3.10'` |
+| Pipecat | 3.11+ (required by `pipecat-ai`) | `pipecat-ai>=0.0.108`; `pipecat-otel` adds `opentelemetry-api>=1.0.0`, `opentelemetry-sdk>=1.0.0` |
+
+Other extras: `bedrock` (`boto3>=1.34.0`), `pii_redaction` (`spacy>=3.7.0`).
+
+## 3. Canonical quick-start API per ecosystem
+
+`noveum_trace.init(api_key=..., project=..., environment=...)` configures the
+global client and must run before any integration setup. Never pass `api_key`
+or `project` into an integration constructor — they belong only in `init()`.
+
+### Pipecat — `NoveumPipecatTracer` (two-call)
+
+```python
+import noveum_trace
+from noveum_trace.integrations.pipecat import NoveumPipecatTracer
+
+noveum_trace.init(api_key="...", project="my-voice-bot")
+
+tracer = NoveumPipecatTracer(record_audio=True)
+pipeline = tracer.observe_pipeline(pipeline)
+task = await tracer.register_task_handlers(task, transport=transport)
+```
+
+`setup_pipecat_tracing` / `NoveumTraceObserver` is the older low-level path; keep
+it only as an advanced option.
+
+### CrewAI — `setup_crewai_tracing`
+
+```python
+import noveum_trace
+from noveum_trace.integrations.crewai import setup_crewai_tracing
+
+noveum_trace.init(api_key="...", project="my-crew")  # required first
+
+listener = setup_crewai_tracing()
+crew.callback_function = listener
+```
+
+`setup_crewai_tracing()` raises `RuntimeError` if `noveum_trace.init()` has not
+been called.
+
+### LiveKit — `setup_livekit_tracing`
+
+```python
+import noveum_trace
+from noveum_trace.integrations.livekit import setup_livekit_tracing
+
+noveum_trace.init(api_key="...", project="voice-agent")
+
+setup_livekit_tracing(session)  # record=True captures full conversation audio
+```
+
+### LangChain / LangGraph — `NoveumTraceCallbackHandler`
+
+```python
+import noveum_trace
+from noveum_trace import NoveumTraceCallbackHandler
+
+noveum_trace.init(api_key="...", project="my-app")
+
+handler = NoveumTraceCallbackHandler()  # create a fresh handler per request
+result = chain.invoke({"text": "..."}, config={"callbacks": [handler]})
+```
+
+The handler keeps internal state, so instantiate a new one per concurrent
+execution (`asyncio.gather`, thread pools). Sequential calls may reuse one
+handler. For LangGraph, `NoveumTraceCallbackHandler(use_langchain_assigned_parent=True)`
+resolves parent/child spans from LangChain's `parent_run_id`.
+
+Short-lived scripts should call `noveum_trace.flush()` before the process exits
+so buffered spans are delivered.
+
+## 4. Capture / privacy flag reference
+
+Noveum Trace can capture prompts, responses, tool inputs/outputs, tool schemas,
+transcripts, conversation history, and audio depending on configuration. Every
+flag below defaults to capturing (`True`) unless noted; document how to disable
+capture whenever an upstream audience may handle sensitive data.
+
+### CrewAI — `setup_crewai_tracing(**kwargs)` → `NoveumCrewAIListener`
+
+All default `True`: `capture_inputs`, `capture_outputs`, `capture_llm_messages`,
+`capture_tool_schemas`, `capture_agent_snapshot`, `capture_crew_snapshot`,
+`capture_memory`, `capture_knowledge`, `capture_a2a`, `capture_mcp`,
+`capture_flow`, `capture_reasoning`, `capture_guardrails`, `capture_streaming`,
+`capture_thinking`. Non-capture defaults: `trace_name_prefix="crewai"`,
+`verbose=False`.
+
+### LiveKit — `setup_livekit_tracing(session, *, ...)`
+
+`enabled=True`, `trace_name_prefix=None`, `record=True`,
+`cleanup_audio_files=True`. `record=True` captures full conversation audio; pass
+`record=False` to disable audio capture. (LiveKit uses `record`, not
+`record_audio`.)
+
+### Pipecat — `NoveumPipecatTracer(...)`
+
+`record_audio=True`, `record_raw_input_audio=True`, `capture_custom_spans=True`,
+`auto_enable_metrics=True`, `capture_errors=True`, `capture_system_logs=False`,
+`capture_session_metadata=True`, plus any `NoveumTraceObserver` kwarg. The
+observer also exposes `capture_text=True` (LLM/TTS text) and
+`capture_function_calls=True` (tool calls). Set `record_audio` /
+`record_raw_input_audio` / `capture_text` to `False` to reduce what is stored.
+
+### LangChain / LangGraph — `NoveumTraceCallbackHandler`
+
+No per-field capture toggles; the handler captures prompts, responses, and tool
+results by default. Reduce exposure at the application layer (redaction, or not
+attaching the handler to sensitive chains).
+
+## 5. Upstream positioning language
+
+**Use:** observability integration, community-maintained, observer, callback
+handler, listener, external tracing processor, trace processor.
+
+**Avoid:** native, first-party, plugin, "officially supported by <upstream>", or
+any wording implying the upstream project maintains or endorses the integration.
+
+## 6. Per-PR acceptance checklist
+
+Before opening an upstream docs/listing PR, confirm:
+
+- [ ] Every snippet runs against the released `noveum-trace` on PyPI (no
+      unreleased APIs).
+- [ ] The install extra referenced actually exists in `pyproject.toml`.
+- [ ] Every symbol name matches the package exports exactly.
+- [ ] The text states the integration is community-maintained (not native /
+      first-party / officially supported).
+- [ ] Links to the Noveum docs, the `noveum-trace` repo, and the PyPI page are
+      included.
+- [ ] No API keys or secrets appear in any example.
+- [ ] Privacy/payload-capture note and Python version-compatibility note are
+      included.
+- [ ] The PR is docs-only unless the upstream maintainers explicitly agree to
+      accept integration code.

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -10,8 +10,9 @@ Every symbol, extra, and version below is taken from the current source
 any PR — do not document an API, extra, or flag that does not exist in the
 released package.
 
-- Package: `noveum-trace` (PyPI), version `1.5.20`, `requires-python = ">=3.9"`,
-  Apache-2.0.
+- Package: `noveum-trace` (PyPI), `requires-python = ">=3.9"`, Apache-2.0. See
+  `pyproject.toml` for the current version (do not pin a version number here — it
+  goes stale on every release).
 - Install: `pip install "noveum-trace[<extra>]"`.
 
 ## 1. Support matrix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Monitoring",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",


### PR DESCRIPTION
# Pull Request

## Description

Adds `docs/integrations/upstream.md`: a single engineering-facing reference for submitting Noveum Trace to upstream ecosystems (Pipecat, CrewAI, LiveKit, LangChain, LangGraph). It covers the support matrix, version compatibility, canonical per-ecosystem APIs, the capture/privacy flag reference, upstream positioning language, and a per-PR acceptance checklist — every symbol and extra taken from the current source.

Also adds the missing Python 3.13 trove classifier so PyPI metadata matches the CI unit-test matrix (`.github/workflows/tests.yml` runs 3.9–3.13).

Docs + one packaging-metadata line only; no code paths change.

Fixes # (link NOVEU-275 tracking issue if applicable)

## Type of change

- [x] Documentation update

## How Has This Been Tested?

- [x] Manual testing

`pre-commit run --files docs/integrations/upstream.md pyproject.toml` passes (trailing-whitespace, end-of-file-fixer; Python hooks correctly skip a docs/toml change). `pyproject.toml` parses via `tomllib`. No code paths changed.

## Test Configuration

* Python version: 3.9–3.13 (per CI matrix)
* Operating System: n/a (docs/metadata only)
* Dependencies: unchanged

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- `requires-python` and the `Development Status :: 3 - Alpha` classifier are intentionally left unchanged — see the open question on the Alpha classifier for the maintainer.
- The existing SDK integration guides (`docs/PIPECAT_INTEGRATION_GUIDE.md`, `docs/LIVEKIT_INTEGRATION_GUIDE.md`, `docs/CREWAI_INTEGRATION.md`) were reviewed and left as-is; no inaccuracies found against current source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an engineering reference for upstream integrations, covering compatibility, setup, privacy, error handling, concurrency, cleanup, and submission requirements.
  * Documented guidance for Pipecat, CrewAI, LiveKit, LangChain, LangGraph, and Pipecat OTEL.
  * Added a per-PR acceptance checklist and guidance for unsupported frameworks.

* **Compatibility**
  * Added Python 3.13 to the supported versions and project classifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `docs/integrations/upstream.md`, an engineering reference for submitting Noveum Trace to upstream ecosystems, and adds the Python 3.13 trove classifier to `pyproject.toml` to align PyPI metadata with the CI matrix. No code paths change.

- **`pyproject.toml`**: Single-line addition of the `Programming Language :: Python :: 3.13` classifier — clean and correct.
- **`docs/integrations/upstream.md`**: Comprehensive upstream-submission reference covering the support matrix, version compatibility, canonical quick-start snippets, capture/privacy flags, positioning language, and a per-PR acceptance checklist. Most content is accurate against the current source, but the CrewAI quick-start section explicitly warns against `crew.callback_function` while existing package docstrings demonstrate exactly that assignment — the two documents give contradictory instructions.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the pyproject.toml change; the new doc should reconcile the crew.callback_function guidance with existing module docstrings before going to any upstream listing.

The pyproject.toml change is a clean single-line classifier addition. The upstream.md is mostly accurate but contains a direct contradiction: it tells readers never to use crew.callback_function (claiming it raises ValueError), while both crewai_listener.py and crewai/__init__.py explicitly show crew.callback_function = listener as the correct wiring pattern. This internal inconsistency undermines the document's stated goal of being a reliable single source of truth for upstream submissions.

**Files Needing Attention:** docs/integrations/upstream.md — the CrewAI quick-start section (§3) and the existing module docstrings in src/noveum_trace/integrations/crewai/ give opposite instructions on crew.callback_function usage.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/integrations/upstream.md | New engineering reference for upstream submissions. Content is largely accurate against pyproject.toml and source, but §3's CrewAI quick-start guidance ("do not assign to crew.callback_function — raises ValueError") directly contradicts the package's own module-level docstrings which show that exact assignment pattern. |
| pyproject.toml | Adds the Python 3.13 trove classifier, aligning PyPI metadata with the CI test matrix (3.9–3.13). Straightforward single-line addition with no other changes. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer reads upstream.md] --> B{Which ecosystem?}
    B --> C[Pipecat]
    B --> D[CrewAI]
    B --> E[LiveKit]
    B --> F[LangChain / LangGraph]

    C --> C1["NoveumPipecatTracer (two-call)\nobserve_pipeline + register_task_handlers"]
    D --> D1["setup_crewai_tracing()\nListener auto-registers via BaseEventListener"]
    D1 --> D2["upstream.md: do NOT use crew.callback_function\n(raises ValueError)"]
    D1 --> D3["crewai/__init__.py docstring:\ncrew.callback_function = listener ⚠️ contradiction"]
    E --> E1["setup_livekit_tracing(session)\nrecord=True captures audio"]
    F --> F1["NoveumTraceCallbackHandler\nnew instance per concurrent request"]

    D2 -.->|conflict| D3
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs: fix CrewAI listener registration a..."](https://github.com/noveum/noveum-trace/commit/5cd88018488709a7820b0256ee201be6deda2099) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49582888)</sub>

<!-- /greptile_comment -->