### PR TITLE
feat: add OpenAI Agents SDK trace processor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,14 @@ jobs:
           pip install -e ".[dev]"
           pip install livekit livekit-agents
 
+      - name: Install OpenAI Agents SDK (Python 3.10+)
+        # openai-agents requires Python 3.10+. On 3.9 the processor's unit tests
+        # run against the module's fallback base-class stub; on 3.10+ we install
+        # the real package so the tests exercise the actual
+        # agents.tracing.TracingProcessor interface (catches upstream API drift).
+        if: matrix.python-version != '3.9'
+        run: pip install "openai-agents>=0.19.2"
+
       - name: Run unit tests with coverage
         run: |
           python -m pytest tests/unit/ --cov=src/noveum_trace --cov-report=xml --cov-report=term-missing -v --junitxml=junit.xml -o junit_family=legacy

--- a/docs/OPENAI_AGENTS_INTEGRATION.md
+++ b/docs/OPENAI_AGENTS_INTEGRATION.md
@@ -1,0 +1,150 @@
+# OpenAI Agents SDK Integration Guide
+
+Trace [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) runs
+with Noveum. The integration registers a `TracingProcessor` that mirrors every
+OpenAI Agents **trace** as a Noveum trace and every OpenAI Agents **span**
+(agent runs, tool/function calls, LLM generations, handoffs, guardrails, MCP tool
+listings) as a Noveum span — preserving the parent-child hierarchy and attaching
+`gen_ai`-compatible `llm.*` / `tool.*` / `agent.*` attributes.
+
+## Prerequisites
+
+- Python 3.10+ (required by `openai-agents`)
+- A Noveum project + API key
+- `openai-agents >= 0.19.2`
+
+## Installation
+
+```bash
+pip install "noveum-trace[openai-agents]"
+```
+
+## Quick start
+
+### 1. Initialize the SDK
+
+```python
+import noveum_trace
+
+noveum_trace.init(project="my-project", api_key="...")
+```
+
+### 2. Register the trace processor
+
+```python
+from agents import add_trace_processor
+from noveum_trace.integrations.openai_agents import NoveumTraceProcessor
+
+add_trace_processor(NoveumTraceProcessor())
+```
+
+### 3. Run your agents
+
+```python
+from agents import Agent, Runner
+
+agent = Agent(name="Assistant", instructions="You are helpful.")
+result = await Runner.run(agent, "Hello!")
+
+noveum_trace.flush()  # export buffered traces before exit
+```
+
+## Convenience factory
+
+`setup_openai_agents_tracing()` creates the processor **and** registers it in one
+call. It requires `noveum_trace.init(...)` to have run first:
+
+```python
+from noveum_trace.integrations.openai_agents import setup_openai_agents_tracing
+
+noveum_trace.init(project="my-project", api_key="...")
+setup_openai_agents_tracing()  # add alongside OpenAI's default exporter
+```
+
+Pass `replace_processors=True` to make Noveum the **only** processor (disables
+OpenAI's own trace upload):
+
+```python
+setup_openai_agents_tracing(replace_processors=True)
+```
+
+## Processor options and privacy
+
+All options are accepted by `NoveumTraceProcessor(...)` and
+`setup_openai_agents_tracing(...)`:
+
+| Option | Default | Captures |
+| --- | --- | --- |
+| `capture_inputs` | `False` | Raw tool / function / custom-span inputs |
+| `capture_outputs` | `False` | Raw tool / function / LLM outputs |
+| `capture_llm_messages` | `False` | Full LLM prompt/response message arrays |
+| `capture_tool_schemas` | `True` | Agent tool & handoff **names** (not argument values) |
+| `capture_trace_metadata` | `True` | OpenAI trace `metadata` and `group_id` |
+| `capture_cost` | `True` | Estimated LLM cost from model + token counts |
+| `trace_name_prefix` | `"openai_agents"` | Prefix used when a workflow has no name |
+
+**Privacy-safe by default.** Raw payloads that may contain sensitive data —
+tool inputs/outputs and LLM message content — are **not** captured unless you opt
+in via `capture_inputs`, `capture_outputs`, or `capture_llm_messages`. Structural
+metadata that is always captured: span type, agent/tool/handoff names, model
+name and provider, token usage, estimated cost, guardrail triggered flag, latency
+(span start/end), and error type/message.
+
+```python
+# Capture full payloads (e.g. in a trusted dev environment)
+NoveumTraceProcessor(
+    capture_inputs=True,
+    capture_outputs=True,
+    capture_llm_messages=True,
+)
+```
+
+## What gets traced
+
+| OpenAI span type | Noveum span | Key attributes |
+| --- | --- | --- |
+| `agent` | `openai_agents.agent` | `agent.name`, `agent.tools`, `agent.handoffs` |
+| `generation` | `openai_agents.generation` | `llm.model`, `llm.input_tokens`, `llm.output_tokens`, `llm.total_tokens`, `llm.cost.*` |
+| `response` | `openai_agents.response` | `llm.model`, `llm.request_id`, token usage |
+| `function` | `openai_agents.function` | `tool.name`, `tool.input`\*, `tool.output`\* |
+| `handoff` | `openai_agents.handoff` | `handoff.from_agent`, `handoff.to_agent` |
+| `guardrail` | `openai_agents.guardrail` | `guardrail.name`, `guardrail.triggered` |
+| `mcp_tools` | `openai_agents.mcp_tools` | `mcp.server_name`, `mcp.tools` |
+| `custom` | `openai_agents.custom` | `custom.name`, `custom.data`\* |
+
+\* Captured only when the corresponding capture flag is enabled.
+
+## Version compatibility
+
+| Component | Supported |
+| --- | --- |
+| `openai-agents` | `>= 0.19.2` |
+| Python | `>= 3.10` |
+
+The processor reads span data defensively (`getattr`), so newer span types are
+recorded generically rather than raising.
+
+## Resilience
+
+Failures inside the processor (a mapping error, an unreachable Noveum backend)
+are logged at debug level and never propagate into your agent run. The OpenAI
+Agents SDK additionally wraps every processor callback in its own try/except.
+
+## Troubleshooting
+
+- **No traces appear:** confirm `noveum_trace.init(...)` ran before the agent
+  executed, and call `noveum_trace.flush()` (or rely on `shutdown`) before the
+  process exits.
+- **`ImportError` from `setup_openai_agents_tracing`:** the `openai-agents` extra
+  is not installed — `pip install "noveum-trace[openai-agents]"`.
+- **Tool arguments / LLM messages missing:** these are opt-in; enable
+  `capture_inputs` / `capture_outputs` / `capture_llm_messages`.
+
+## Example script
+
+See [`docs/examples/openai_agents_integration_example.py`](examples/openai_agents_integration_example.py).
+
+## Next steps
+
+- [OpenAI Agents SDK docs](https://openai.github.io/openai-agents-python/)
+- [OpenAI Agents tracing docs](https://openai.github.io/openai-agents-python/tracing/)

--- a/docs/OPENAI_AGENTS_INTEGRATION.md
+++ b/docs/OPENAI_AGENTS_INTEGRATION.md
@@ -77,20 +77,31 @@ All options are accepted by `NoveumTraceProcessor(...)` and
 
 | Option | Default | Captures |
 | --- | --- | --- |
-| `capture_inputs` | `False` | Raw tool / function / custom-span inputs |
-| `capture_outputs` | `False` | Raw tool / function outputs |
-| `capture_llm_messages` | `False` | Full LLM prompt/response messages (generation & response spans) |
-| `capture_tool_schemas` | `True` | Agent tool & handoff **names** (not argument values) |
+| `capture_inputs` | `True` | Raw tool / function / custom-span inputs |
+| `capture_outputs` | `True` | Raw tool / function outputs |
+| `capture_llm_messages` | `True` | Full LLM prompt/response messages, system prompts and tool calls (generation & response spans) |
+| `capture_tool_schemas` | `True` | Agent tool & handoff names, and the tool schemas offered to the model |
 | `capture_trace_metadata` | `True` | OpenAI trace `metadata` and `group_id` (see privacy note) |
 | `capture_cost` | `True` | Estimated LLM cost from model + token counts |
 | `trace_name_prefix` | `"openai_agents"` | Prefix used when a workflow has no name |
 
-**Privacy-safe by default.** Raw payloads that may contain sensitive data —
-tool inputs/outputs and LLM message content — are **not** captured unless you opt
-in via `capture_inputs`, `capture_outputs`, or `capture_llm_messages`. Structural
-metadata that is always captured: span type, agent/tool/handoff names, model
-name and provider, token usage, estimated cost, guardrail triggered flag, latency
-(span start/end), and error type/message.
+**Everything is captured by default**, matching the other Noveum integrations —
+a trace without prompts, tool arguments and results cannot be replayed, diffed
+or turned into an evaluation dataset. Set any flag to `False` to reduce what is
+sent:
+
+```python
+# Reduce what leaves the process
+NoveumTraceProcessor(
+    capture_inputs=False,
+    capture_outputs=False,
+    capture_llm_messages=False,
+)
+```
+
+**Payloads are never truncated.** System prompts, tool results and message
+arrays routinely run past any fixed character budget, and a clipped prompt is
+useless for evaluation, so this integration records them in full.
 
 **Note on trace metadata and errors.** With `capture_trace_metadata=True`
 (default), the OpenAI trace's `metadata` and `group_id` are serialized as-is,
@@ -100,29 +111,62 @@ Noveum. Set `capture_trace_metadata=False` to disable this. Error details
 for observability and may echo sensitive context; redact at the source if that is
 a concern.
 
-```python
-# Capture full payloads (e.g. in a trusted dev environment)
-NoveumTraceProcessor(
-    capture_inputs=True,
-    capture_outputs=True,
-    capture_llm_messages=True,
-)
-```
+### The SDK has its own payload switch
+
+The Agents SDK decides separately whether to record prompts and responses on its
+span data at all. Running with `RunConfig(trace_include_sensitive_data=False)`,
+or with `OPENAI_AGENTS_DONT_LOG_MODEL_DATA` set in the environment, leaves
+`span_data.input` / `span_data.output` empty **before** any processor sees them —
+no flag here can recover data the SDK never recorded. If prompts are missing
+while `capture_llm_messages=True`, check that switch first.
 
 ## What gets traced
 
+The integration is a mapping layer: the Agents SDK already records the run as a
+trace/span tree, and the processor mirrors that tree into Noveum, translating
+each `SpanData` into `llm.*` / `tool.*` / `agent.*` attributes that the rest of
+the platform (and the `otel_compat` `gen_ai` crosswalk) understands. It does not
+re-instrument the agent or intercept the model client, so it can only report what
+the SDK puts on its span data — the table below is that complete surface.
+
 | OpenAI span type | Noveum span | Key attributes |
 | --- | --- | --- |
-| `agent` | `openai_agents.agent` | `agent.name`, `agent.tools`, `agent.handoffs` |
-| `generation` | `openai_agents.generation` | `llm.model`, `llm.input_tokens`, `llm.output_tokens`, `llm.total_tokens`, `llm.cost.*` |
-| `response` | `openai_agents.response` | `llm.model`, `llm.request_id`, token usage |
-| `function` | `openai_agents.function` | `tool.name`, `tool.input`\*, `tool.output`\* |
+| `agent` | `openai_agents.agent` | `agent.name`, `agent.tools`, `agent.tool_count`, `agent.handoffs`, `agent.output_type`, `agent.metadata` |
+| `generation` | `openai_agents.generation` | `llm.model`, `llm.provider`, `llm.system_prompt`, `llm.input`, `llm.input_text`, `llm.output`, `llm.output_text`, `llm.tool_calls`, `llm.tool_call_count`, `llm.input_tokens`, `llm.output_tokens`, `llm.total_tokens`, `llm.cached_input_tokens`, `llm.cache_write_input_tokens`, `llm.cache_hit`, `llm.reasoning_tokens`, `llm.temperature`, `llm.top_p`, `llm.max_tokens`, `llm.reasoning_effort`, `llm.cost.*` |
+| `response` | `openai_agents.response` | everything above, plus `llm.request_id`, `llm.response_status`, `llm.available_tools`, `llm.available_tool_count`, `llm.reasoning` (reasoning summaries) |
+| `function` | `openai_agents.function` | `tool.name`, `tool.input`, `tool.output`, `tool.is_mcp`, `tool.mcp_data` |
 | `handoff` | `openai_agents.handoff` | `handoff.from_agent`, `handoff.to_agent` |
 | `guardrail` | `openai_agents.guardrail` | `guardrail.name`, `guardrail.triggered` |
-| `mcp_tools` | `openai_agents.mcp_tools` | `mcp.server_name`, `mcp.tools` |
-| `custom` | `openai_agents.custom` | `custom.name`, `custom.data`\* |
+| `mcp_tools` | `openai_agents.mcp_tools` | `mcp.server_name`, `mcp.tools`, `mcp.tool_count` |
+| `custom` | `openai_agents.custom` | `custom.name`, `custom.data` |
+| `task` / `turn` | `openai_agents.task` / `.turn` | `task.name`, `turn.number`, `turn.agent_name`, aggregate token usage |
 
-\* Captured only when the corresponding capture flag is enabled.
+### Where to find each kind of data
+
+The Agents SDK splits a run across span types, so some things are not where you
+might first look:
+
+- **Tool calls and their results** are on `function` spans (`tool.input` /
+  `tool.output`), one per invocation — not on the `agent` span. The model's
+  *decision* to call a tool is also recorded on the model span as
+  `llm.tool_calls`.
+- **The agent's input** is the input of its first model call
+  (`llm.input` / `llm.input_text` on the child `generation` / `response` span).
+  `AgentSpanData` carries only configuration — name, tool names, handoff names,
+  output type, metadata.
+- **Available tools**: names on `agent.tools`; full schemas (with descriptions and
+  JSON-Schema parameters) on `llm.available_tools` for Responses-API calls.
+  Chat-Completions `model_config` carries no tool list upstream, so
+  `generation` spans fall back to the enclosing agent's `agent.tools`.
+- **System prompt**: `llm.system_prompt` — from the `system`/`developer` messages
+  on generation spans, and from `response.instructions` on response spans.
+- **Reasoning / thinking**: `llm.reasoning_tokens` always; the reasoning text
+  itself (`llm.reasoning`) only on response spans, and only when the model
+  returns reasoning summaries.
+- **Prompt caching**: `llm.cached_input_tokens`, `llm.cache_write_input_tokens`
+  and the derived `llm.cache_hit` boolean.
+- **Input images** are not extracted into their own attribute; they remain inside
+  the serialized `llm.input` message array.
 
 ## Version compatibility
 
@@ -148,9 +192,13 @@ Agents SDK additionally wraps every processor callback in its own try/except.
   `shutdown()` releases SDK resources.
 - **`ImportError` from `setup_openai_agents_tracing`:** the `openai-agents` extra
   is not installed — `pip install "noveum-trace[openai-agents]"`.
-- **Tool arguments missing:** enable `capture_inputs` / `capture_outputs`.
-- **LLM prompts/responses missing:** enable `capture_llm_messages` (this controls
-  LLM message content on both generation and response spans).
+- **Tool arguments missing:** these are on by default; check that
+  `capture_inputs` / `capture_outputs` were not disabled.
+- **LLM prompts/responses missing:** `capture_llm_messages` is on by default, so
+  check the SDK's own switch first — `RunConfig(trace_include_sensitive_data=False)`
+  or `OPENAI_AGENTS_DONT_LOG_MODEL_DATA` blanks the payloads upstream.
+- **Tool results not on the agent span:** they are on the child `function` spans;
+  see [Where to find each kind of data](#where-to-find-each-kind-of-data).
 
 ## Example script
 

--- a/docs/OPENAI_AGENTS_INTEGRATION.md
+++ b/docs/OPENAI_AGENTS_INTEGRATION.md
@@ -156,8 +156,9 @@ might first look:
   output type, metadata.
 - **Available tools**: names on `agent.tools`; full schemas (with descriptions and
   JSON-Schema parameters) on `llm.available_tools` for Responses-API calls.
-  Chat-Completions `model_config` carries no tool list upstream, so
-  `generation` spans fall back to the enclosing agent's `agent.tools`.
+  Chat-Completions `model_config` carries no tool list upstream, so `generation`
+  spans carry no tool list of their own — read the tool names from the parent
+  `agent` span's `agent.tools`.
 - **System prompt**: `llm.system_prompt` — from the `system`/`developer` messages
   on generation spans, and from `response.instructions` on response spans.
 - **Reasoning / thinking**: `llm.reasoning_tokens` always; the reasoning text

--- a/docs/OPENAI_AGENTS_INTEGRATION.md
+++ b/docs/OPENAI_AGENTS_INTEGRATION.md
@@ -46,7 +46,8 @@ from agents import Agent, Runner
 agent = Agent(name="Assistant", instructions="You are helpful.")
 result = await Runner.run(agent, "Hello!")
 
-noveum_trace.flush()  # export buffered traces before exit
+noveum_trace.flush()     # export buffered traces
+noveum_trace.shutdown()  # release SDK resources at application termination
 ```
 
 ## Convenience factory
@@ -55,6 +56,7 @@ noveum_trace.flush()  # export buffered traces before exit
 call. It requires `noveum_trace.init(...)` to have run first:
 
 ```python
+import noveum_trace
 from noveum_trace.integrations.openai_agents import setup_openai_agents_tracing
 
 noveum_trace.init(project="my-project", api_key="...")
@@ -76,10 +78,10 @@ All options are accepted by `NoveumTraceProcessor(...)` and
 | Option | Default | Captures |
 | --- | --- | --- |
 | `capture_inputs` | `False` | Raw tool / function / custom-span inputs |
-| `capture_outputs` | `False` | Raw tool / function / LLM outputs |
-| `capture_llm_messages` | `False` | Full LLM prompt/response message arrays |
+| `capture_outputs` | `False` | Raw tool / function outputs |
+| `capture_llm_messages` | `False` | Full LLM prompt/response messages (generation & response spans) |
 | `capture_tool_schemas` | `True` | Agent tool & handoff **names** (not argument values) |
-| `capture_trace_metadata` | `True` | OpenAI trace `metadata` and `group_id` |
+| `capture_trace_metadata` | `True` | OpenAI trace `metadata` and `group_id` (see privacy note) |
 | `capture_cost` | `True` | Estimated LLM cost from model + token counts |
 | `trace_name_prefix` | `"openai_agents"` | Prefix used when a workflow has no name |
 
@@ -89,6 +91,14 @@ in via `capture_inputs`, `capture_outputs`, or `capture_llm_messages`. Structura
 metadata that is always captured: span type, agent/tool/handoff names, model
 name and provider, token usage, estimated cost, guardrail triggered flag, latency
 (span start/end), and error type/message.
+
+**Note on trace metadata and errors.** With `capture_trace_metadata=True`
+(default), the OpenAI trace's `metadata` and `group_id` are serialized as-is,
+with no allowlist or redaction — if you place sensitive data there, it is sent to
+Noveum. Set `capture_trace_metadata=False` to disable this. Error details
+(message, and any structured `error.data` on a span) are also captured by default
+for observability and may echo sensitive context; redact at the source if that is
+a concern.
 
 ```python
 # Capture full payloads (e.g. in a trusted dev environment)
@@ -133,12 +143,14 @@ Agents SDK additionally wraps every processor callback in its own try/except.
 ## Troubleshooting
 
 - **No traces appear:** confirm `noveum_trace.init(...)` ran before the agent
-  executed, and call `noveum_trace.flush()` (or rely on `shutdown`) before the
-  process exits.
+  executed. For a short-lived process, call `noveum_trace.flush()` then
+  `noveum_trace.shutdown()` before it exits — `flush()` sends buffered traces and
+  `shutdown()` releases SDK resources.
 - **`ImportError` from `setup_openai_agents_tracing`:** the `openai-agents` extra
   is not installed — `pip install "noveum-trace[openai-agents]"`.
-- **Tool arguments / LLM messages missing:** these are opt-in; enable
-  `capture_inputs` / `capture_outputs` / `capture_llm_messages`.
+- **Tool arguments missing:** enable `capture_inputs` / `capture_outputs`.
+- **LLM prompts/responses missing:** enable `capture_llm_messages` (this controls
+  LLM message content on both generation and response spans).
 
 ## Example script
 

--- a/docs/examples/openai_agents_integration_example.py
+++ b/docs/examples/openai_agents_integration_example.py
@@ -1,0 +1,62 @@
+"""
+Example: trace an OpenAI Agents SDK run with Noveum.
+
+Install the integration extra::
+
+    pip install "noveum-trace[openai-agents]"
+
+Provide credentials and run::
+
+    export NOVEUM_API_KEY=...
+    export OPENAI_API_KEY=...
+    python docs/examples/openai_agents_integration_example.py
+
+The :class:`NoveumTraceProcessor` mirrors every OpenAI Agents trace/span
+(agent runs, tool calls, LLM generations, handoffs, guardrails) as a Noveum
+trace/span. It is registered alongside the SDK's default processor, so OpenAI's
+own trace upload keeps working; pass ``replace_processors=True`` to
+``setup_openai_agents_tracing`` if you want Noveum to be the only exporter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from agents import Agent, Runner, add_trace_processor, function_tool
+
+import noveum_trace
+from noveum_trace.integrations.openai_agents import NoveumTraceProcessor
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Return a canned weather report for the given city."""
+    return f"The weather in {city} is sunny."
+
+
+async def main() -> None:
+    noveum_trace.init(
+        project="openai-agents-example",
+        api_key=os.environ.get("NOVEUM_API_KEY"),
+    )
+
+    # Capture inputs/outputs is opt-in (privacy-safe defaults). Enable it here so
+    # the example traces show the tool arguments and results.
+    add_trace_processor(NoveumTraceProcessor(capture_inputs=True, capture_outputs=True))
+
+    agent = Agent(
+        name="Weather assistant",
+        instructions="You are a helpful assistant. Use the tools when needed.",
+        tools=[get_weather],
+    )
+
+    result = await Runner.run(agent, "What is the weather in San Francisco?")
+    print(result.final_output)
+
+    # Flush buffered traces before the process exits.
+    noveum_trace.flush()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/examples/openai_agents_integration_example.py
+++ b/docs/examples/openai_agents_integration_example.py
@@ -41,9 +41,10 @@ async def main() -> None:
         api_key=os.environ.get("NOVEUM_API_KEY"),
     )
 
-    # Capture inputs/outputs is opt-in (privacy-safe defaults). Enable it here so
-    # the example traces show the tool arguments and results.
-    add_trace_processor(NoveumTraceProcessor(capture_inputs=True, capture_outputs=True))
+    # Everything is captured by default — prompts, tool arguments and results.
+    # Pass capture_inputs / capture_outputs / capture_llm_messages as False to
+    # reduce what is sent.
+    add_trace_processor(NoveumTraceProcessor())
 
     agent = Agent(
         name="Weather assistant",

--- a/docs/examples/openai_agents_integration_example.py
+++ b/docs/examples/openai_agents_integration_example.py
@@ -51,11 +51,13 @@ async def main() -> None:
         tools=[get_weather],
     )
 
-    result = await Runner.run(agent, "What is the weather in San Francisco?")
-    print(result.final_output)
-
-    # Flush buffered traces before the process exits.
-    noveum_trace.flush()
+    try:
+        result = await Runner.run(agent, "What is the weather in San Francisco?")
+        print(result.final_output)
+    finally:
+        # Flush buffered traces and release SDK resources, even on failure.
+        noveum_trace.flush()
+        noveum_trace.shutdown()
 
 
 if __name__ == "__main__":

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -116,7 +116,8 @@ add_trace_processor(NoveumTraceProcessor())
 
 `NoveumTraceProcessor` implements `agents.tracing.TracingProcessor` and maps each
 OpenAI Agents trace/span (agent, generation, response, tool/function, handoff,
-guardrail) onto a Noveum trace/span. `setup_openai_agents_tracing()` registers it;
+guardrail, `mcp_tools`, `custom`, task/turn) onto a Noveum trace/span, preserving
+parentage from the SDK's own `parent_id`. `setup_openai_agents_tracing()` registers it;
 pass `replace_processors=True` to make Noveum the only processor (disables OpenAI's
 own trace upload). For a short-lived process, call `noveum_trace.flush()` then
 `noveum_trace.shutdown()` before exit.
@@ -170,16 +171,21 @@ All default `True`: `capture_inputs`, `capture_outputs`, `capture_llm_messages`,
 
 ### OpenAI Agents SDK — `NoveumTraceProcessor(...)` / `setup_openai_agents_tracing(...)`
 
-Privacy-safe defaults — unlike the capture-by-default integrations, raw payloads
-are **off** by default: `capture_inputs=False` (tool/function inputs),
-`capture_outputs=False` (tool/function outputs), `capture_llm_messages=False`
-(full LLM prompt/response messages, generation and response spans). Structural
-metadata is on: `capture_tool_schemas=True` (agent tool / handoff names, not
-argument values), `capture_cost=True`. `capture_trace_metadata=True` sends the
-OpenAI trace `metadata` / `group_id` as-is (no redaction) — set it `False` if
-those may hold sensitive data. Non-capture default:
-`trace_name_prefix="openai_agents"`. Model name, provider, token usage, latency,
-and error type/message are always captured.
+All default `True`, matching the other capture-by-default integrations:
+`capture_inputs` (tool/function inputs), `capture_outputs` (tool/function
+outputs), `capture_llm_messages` (full LLM prompt/response messages, system
+prompts and tool calls on generation and response spans), `capture_tool_schemas`
+(agent tool / handoff names plus the tool schemas offered to the model),
+`capture_cost`, and `capture_trace_metadata` — which sends the OpenAI trace
+`metadata` / `group_id` as-is (no redaction), so set it `False` if those may
+hold sensitive data. Non-capture default: `trace_name_prefix="openai_agents"`.
+Model name, provider, token usage (including cached and reasoning tokens),
+latency, and error type/message are always captured. Payloads are not truncated.
+
+Note that the Agents SDK gates payload recording independently: with
+`RunConfig(trace_include_sensitive_data=False)` or the
+`OPENAI_AGENTS_DONT_LOG_MODEL_DATA` environment variable, prompts and responses
+never reach any processor, and no capture flag can recover them.
 
 ### LiveKit — `setup_livekit_tracing(session, *, ...)`
 

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -118,7 +118,8 @@ add_trace_processor(NoveumTraceProcessor())
 OpenAI Agents trace/span (agent, generation, response, tool/function, handoff,
 guardrail) onto a Noveum trace/span. `setup_openai_agents_tracing()` registers it;
 pass `replace_processors=True` to make Noveum the only processor (disables OpenAI's
-own trace upload). Call `noveum_trace.flush()` before a short-lived process exits.
+own trace upload). For a short-lived process, call `noveum_trace.flush()` then
+`noveum_trace.shutdown()` before exit.
 
 ### LiveKit — `setup_livekit_tracing`
 
@@ -171,12 +172,14 @@ All default `True`: `capture_inputs`, `capture_outputs`, `capture_llm_messages`,
 
 Privacy-safe defaults — unlike the capture-by-default integrations, raw payloads
 are **off** by default: `capture_inputs=False` (tool/function inputs),
-`capture_outputs=False` (tool/function/LLM outputs), `capture_llm_messages=False`
-(full LLM prompt/response messages). Structural metadata is on:
-`capture_tool_schemas=True` (agent tool / handoff names, not argument values),
-`capture_trace_metadata=True` (OpenAI trace `metadata` / `group_id`),
-`capture_cost=True`. Non-capture default: `trace_name_prefix="openai_agents"`.
-Model name, provider, token usage, latency, and errors are always captured.
+`capture_outputs=False` (tool/function outputs), `capture_llm_messages=False`
+(full LLM prompt/response messages, generation and response spans). Structural
+metadata is on: `capture_tool_schemas=True` (agent tool / handoff names, not
+argument values), `capture_cost=True`. `capture_trace_metadata=True` sends the
+OpenAI trace `metadata` / `group_id` as-is (no redaction) — set it `False` if
+those may hold sensitive data. Non-capture default:
+`trace_name_prefix="openai_agents"`. Model name, provider, token usage, latency,
+and error type/message are always captured.
 
 ### LiveKit — `setup_livekit_tracing(session, *, ...)`
 

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -24,10 +24,11 @@ released package.
 | LiveKit | `noveum_trace.integrations.livekit` | `livekit` | `setup_livekit_tracing(session)` | Community-maintained observability integration. Candidate for upstream docs/listing. |
 | Pipecat | `noveum_trace.integrations.pipecat` | `pipecat` (add `pipecat-otel` for OTEL span export) | `NoveumPipecatTracer` (two-call: `observe_pipeline` + `register_task_handlers`) | Community-maintained observability integration (observer). Candidate for upstream docs/listing. |
 | CrewAI | `noveum_trace.integrations.crewai` | `crewai` | `setup_crewai_tracing()` (or `NoveumCrewAIListener`) | Community-maintained observability integration (listener). Candidate for upstream docs/listing. |
+| OpenAI Agents SDK | `noveum_trace.integrations.openai_agents` (also re-exported at package root) | `openai-agents` | `setup_openai_agents_tracing()` (or `NoveumTraceProcessor`) | Community-maintained observability integration (external trace processor). Candidate for upstream docs/listing. |
 | OpenTelemetry alignment | `noveum_trace.integrations.pipecat.custom_spans` | `pipecat-otel` | Plain OTEL spans folded into the Pipecat trace via `capture_custom_spans=True` (registers an OTEL `SpanProcessor`) | Bridge only — there is no standalone OTEL exporter. Do not describe a general-purpose OpenTelemetry backend. |
 
-**Not yet supported — do not claim support in any listing:** OpenAI Agents SDK,
-LlamaIndex, AutoGen, Vercel AI SDK, and LiteLLM have no dedicated integration
+**Not yet supported — do not claim support in any listing:** LlamaIndex,
+AutoGen, Vercel AI SDK, and LiteLLM have no dedicated integration
 module in `src/noveum_trace/integrations/`. Direct OpenAI/Anthropic calls can be
 traced with the core context managers (`trace_llm_call`), but that is not a
 framework integration.
@@ -48,6 +49,7 @@ and the upstream framework's own floor.
 | LangGraph | 3.10+ | `langchain-core>=0.1.0` (shares the `langchain` extra) |
 | LiveKit | 3.10+ | `livekit>=1.0.19,<2`, `livekit-agents>=1.0.0` |
 | CrewAI | 3.10+ | `crewai>=0.177.0; python_version>='3.10'` |
+| OpenAI Agents SDK | 3.10+ | `openai-agents>=0.19.2; python_version>='3.10'` |
 | Pipecat | 3.11+ (required by `pipecat-ai`) | `pipecat-ai>=0.0.108`; `pipecat-otel` adds `opentelemetry-api>=1.0.0`, `opentelemetry-sdk>=1.0.0` |
 
 Other extras: `bedrock` (`boto3>=1.34.0`), `pii_redaction` (`spacy>=3.7.0`).
@@ -98,6 +100,26 @@ on current `Crew` versions and raises `ValueError`. Wrap `crew.kickoff()` in
 `try/finally`, call `listener.shutdown()` to detach, then `noveum_trace.flush()`
 so buffered spans are delivered before a short-lived process exits.
 
+### OpenAI Agents SDK — `setup_openai_agents_tracing` / `NoveumTraceProcessor`
+
+```python
+import noveum_trace
+from agents import add_trace_processor
+from noveum_trace.integrations.openai_agents import NoveumTraceProcessor
+
+noveum_trace.init(api_key="...", project="my-agents-app")
+
+add_trace_processor(NoveumTraceProcessor())
+# or: from noveum_trace.integrations.openai_agents import setup_openai_agents_tracing
+#     setup_openai_agents_tracing()  # creates + registers the processor
+```
+
+`NoveumTraceProcessor` implements `agents.tracing.TracingProcessor` and maps each
+OpenAI Agents trace/span (agent, generation, response, tool/function, handoff,
+guardrail) onto a Noveum trace/span. `setup_openai_agents_tracing()` registers it;
+pass `replace_processors=True` to make Noveum the only processor (disables OpenAI's
+own trace upload). Call `noveum_trace.flush()` before a short-lived process exits.
+
 ### LiveKit — `setup_livekit_tracing`
 
 ```python
@@ -144,6 +166,17 @@ All default `True`: `capture_inputs`, `capture_outputs`, `capture_llm_messages`,
 `capture_flow`, `capture_reasoning`, `capture_guardrails`, `capture_streaming`,
 `capture_thinking`. Non-capture defaults: `trace_name_prefix="crewai"`,
 `verbose=False`.
+
+### OpenAI Agents SDK — `NoveumTraceProcessor(...)` / `setup_openai_agents_tracing(...)`
+
+Privacy-safe defaults — unlike the capture-by-default integrations, raw payloads
+are **off** by default: `capture_inputs=False` (tool/function inputs),
+`capture_outputs=False` (tool/function/LLM outputs), `capture_llm_messages=False`
+(full LLM prompt/response messages). Structural metadata is on:
+`capture_tool_schemas=True` (agent tool / handoff names, not argument values),
+`capture_trace_metadata=True` (OpenAI trace `metadata` / `group_id`),
+`capture_cost=True`. Non-capture default: `trace_name_prefix="openai_agents"`.
+Model name, provider, token usage, latency, and errors are always captured.
 
 ### LiveKit — `setup_livekit_tracing(session, *, ...)`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ livekit = ["livekit>=1.0.19,<2", "livekit-agents>=1.0.0"]
 pipecat = ["pipecat-ai>=0.0.108"]
 pipecat-otel = ["pipecat-ai>=0.0.108", "opentelemetry-api>=1.0.0", "opentelemetry-sdk>=1.0.0"]
 crewai = ["crewai>=0.177.0; python_version>='3.10'"]
+openai-agents = ["openai-agents>=0.19.2; python_version>='3.10'"]
 bedrock = ["boto3>=1.34.0"]
 
 # Optional: spaCy for ``PiiPseudonymizer`` NER (heavier than the core SDK; regex-only
@@ -266,6 +267,8 @@ explicit_package_bases = true
 [[tool.mypy.overrides]]
 module = [
     "openai.*",
+    "agents",
+    "agents.*",
     "anthropic.*",
     "opentelemetry",
     "opentelemetry.*",

--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -475,6 +475,19 @@ except ImportError:
     # CrewAI not installed
     pass
 
+try:
+    import agents  # noqa: F401
+
+    from noveum_trace.integrations.openai_agents import (
+        NoveumTraceProcessor,
+        setup_openai_agents_tracing,
+    )
+
+    _integration_exports.extend(["NoveumTraceProcessor", "setup_openai_agents_tracing"])
+except ImportError:
+    # OpenAI Agents SDK not installed
+    pass
+
 # Export public API
 __all__ = [
     # Core functions

--- a/src/noveum_trace/integrations/__init__.py
+++ b/src/noveum_trace/integrations/__init__.py
@@ -70,3 +70,16 @@ try:
     __all__.extend(["NoveumCrewAIListener", "setup_crewai_tracing"])
 except ImportError:
     pass
+
+# OpenAI Agents SDK integration (requires Python 3.10+ and openai-agents)
+try:
+    import agents  # noqa: F401
+
+    from noveum_trace.integrations.openai_agents import (
+        NoveumTraceProcessor,
+        setup_openai_agents_tracing,
+    )
+
+    __all__.extend(["NoveumTraceProcessor", "setup_openai_agents_tracing"])
+except ImportError:
+    pass

--- a/src/noveum_trace/integrations/_common.py
+++ b/src/noveum_trace/integrations/_common.py
@@ -1,0 +1,356 @@
+"""
+Shared helpers for framework integrations.
+
+These helpers are framework-agnostic: span writes, defensive serialization,
+timestamp coercion, provider derivation, token-usage normalisation, and cost
+estimation. Integrations import from here instead of re-implementing the same
+logic per framework.
+
+Every public function absorbs its own exceptions and returns a sensible default,
+so a failing helper can never break the host application.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "coerce_datetime",
+    "derive_provider",
+    "estimate_cost_safe",
+    "extract_usage_tokens",
+    "finish_span",
+    "probe",
+    "safe_serialize",
+    "set_span_attributes",
+    "stringify",
+]
+
+
+# ---------------------------------------------------------------------------
+# Span writes
+# ---------------------------------------------------------------------------
+
+
+def set_span_attributes(span: Any, attributes: dict[str, Any]) -> None:
+    """
+    Write *attributes* onto *span*.
+
+    Tries ``span.set_attributes`` first; on failure or absence, updates
+    ``span.attributes`` when it supports ``.update`` (covers finished spans).
+    """
+    if not attributes or span is None:
+        return
+    try:
+        setter = getattr(span, "set_attributes", None)
+        if callable(setter):
+            setter(attributes)
+            return
+    except Exception:
+        pass
+    try:
+        attr_store = getattr(span, "attributes", None)
+        if attr_store is not None and hasattr(attr_store, "update"):
+            attr_store.update(attributes)
+    except Exception as exc:
+        logger.debug("set_span_attributes failed: %s", exc)
+
+
+def finish_span(span: Any, end_time: Any = None) -> None:
+    """Finish *span*, tolerating an already-finished span and never raising."""
+    if span is None:
+        return
+    try:
+        is_finished = getattr(span, "is_finished", None)
+        if callable(is_finished) and is_finished():
+            return
+        if end_time is None:
+            span.finish()
+        else:
+            span.finish(end_time)
+    except Exception as exc:
+        logger.debug("finish_span failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Attribute probing / serialization
+# ---------------------------------------------------------------------------
+
+
+def probe(source: Any, *keys: str) -> Any:
+    """Read *keys* from a dict or object, returning the first non-None value."""
+    if source is None:
+        return None
+    for key in keys:
+        try:
+            value = (
+                source.get(key)
+                if isinstance(source, dict)
+                else getattr(source, key, None)
+            )
+        except Exception:
+            value = None
+        if value is not None:
+            return value
+    return None
+
+
+def stringify(value: Any) -> str:
+    """
+    Render *value* as a string without truncating it.
+
+    Payloads such as system prompts and tool results routinely exceed any fixed
+    character budget, so nothing is clipped here. Size limiting is the
+    transport's responsibility, not the integration's.
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception as exc:
+        return f"<stringify_error:{type(value).__name__}:{exc}>"
+
+
+def safe_serialize(value: Any, *, max_depth: int = 8) -> Any:
+    """
+    Recursively convert *value* into a JSON-serialisable structure.
+
+    Primitives pass through; dict/list/tuple recurse; Pydantic v2/v1 objects use
+    ``model_dump``/``dict``; objects exposing ``to_dict`` are converted;
+    everything else falls back to ``str``. Depth is capped to guard against
+    cyclic or deeply nested object graphs.
+    """
+    return _safe_serialize_inner(value, depth=0, max_depth=max_depth)
+
+
+def _safe_serialize_inner(value: Any, depth: int, max_depth: int) -> Any:
+    if depth >= max_depth:
+        return f"<max_depth:{type(value).__name__}>"
+    try:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, dict):
+            return {
+                str(k): _safe_serialize_inner(v, depth + 1, max_depth)
+                for k, v in value.items()
+            }
+        if isinstance(value, (list, tuple, set)):
+            return [_safe_serialize_inner(item, depth + 1, max_depth) for item in value]
+        for method in ("model_dump", "dict", "to_dict"):
+            fn = getattr(value, method, None)
+            if callable(fn):
+                try:
+                    return _safe_serialize_inner(fn(), depth + 1, max_depth)
+                except Exception:
+                    continue
+        return str(value)
+    except Exception as exc:
+        return f"<serialization_error:{type(value).__name__}:{exc}>"
+
+
+# ---------------------------------------------------------------------------
+# Timestamps
+# ---------------------------------------------------------------------------
+
+
+def coerce_datetime(value: Any) -> Optional[datetime]:
+    """
+    Convert an ISO-8601 string (or epoch seconds) to a ``datetime``.
+
+    Returns ``None`` when the value is missing or unparseable so callers can
+    fall back to "now".
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value)
+        except (OverflowError, OSError, ValueError):
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider derivation
+# ---------------------------------------------------------------------------
+
+_OPENAI_MODEL_PREFIXES = (
+    "gpt",
+    "o1",
+    "o3",
+    "o4",
+    "chatgpt",
+    "text-",
+    "ada",
+    "babbage",
+    "curie",
+    "davinci",
+)
+
+
+def derive_provider(model: Optional[str]) -> Optional[str]:
+    """
+    Best-effort provider name from a model string.
+
+    Recognises well-known prefixes, falls back to the left side of a LiteLLM
+    ``"provider/model"`` string, and returns ``None`` when undeterminable.
+    """
+    if not model or not isinstance(model, str):
+        return None
+    lowered = model.lower()
+    if any(lowered.startswith(prefix) for prefix in _OPENAI_MODEL_PREFIXES):
+        return "openai"
+    if lowered.startswith("claude"):
+        return "anthropic"
+    if lowered.startswith("gemini") or lowered.startswith("models/gemini"):
+        return "google"
+    if lowered.startswith(("mistral", "mixtral")):
+        return "mistral"
+    if lowered.startswith(("llama", "meta-llama")):
+        return "meta"
+    if lowered.startswith("deepseek"):
+        return "deepseek"
+    if lowered.startswith(("command", "cohere")):
+        return "cohere"
+    if "/" in lowered:
+        return lowered.split("/", 1)[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Token usage
+# ---------------------------------------------------------------------------
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_int(*candidates: Any) -> Optional[int]:
+    """Return the first candidate that coerces to an int, preserving zeros."""
+    for candidate in candidates:
+        coerced = _coerce_int(candidate)
+        if coerced is not None:
+            return coerced
+    return None
+
+
+USAGE_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cached_input_tokens",
+    "cache_write_input_tokens",
+    "reasoning_tokens",
+)
+
+
+def extract_usage_tokens(usage: Any) -> dict[str, Optional[int]]:
+    """
+    Normalise a provider or framework usage payload to canonical token counts.
+
+    Handles the flat OpenAI Agents shapes (``cached_input_tokens``,
+    ``cache_write_input_tokens``), the nested OpenAI shapes
+    (``input_tokens_details.cached_tokens``,
+    ``output_tokens_details.reasoning_tokens``, and their
+    ``prompt_tokens_details`` / ``completion_tokens_details`` aliases), and
+    Chat-Completions naming (``prompt_tokens`` / ``completion_tokens``).
+
+    ``total_tokens`` is computed from input + output when not supplied.
+    """
+    result: dict[str, Optional[int]] = dict.fromkeys(USAGE_KEYS)
+    if usage is None:
+        return result
+    try:
+        result["input_tokens"] = _coerce_int(
+            probe(usage, "input_tokens", "prompt_tokens")
+        )
+        result["output_tokens"] = _coerce_int(
+            probe(usage, "output_tokens", "completion_tokens")
+        )
+        result["total_tokens"] = _coerce_int(probe(usage, "total_tokens"))
+
+        input_details = probe(usage, "input_tokens_details", "prompt_tokens_details")
+        output_details = probe(
+            usage, "output_tokens_details", "completion_tokens_details"
+        )
+
+        # ``or`` is wrong here: a genuine zero (no cache hit) must survive
+        # rather than fall through to the nested lookup.
+        result["cached_input_tokens"] = _first_int(
+            probe(usage, "cached_input_tokens", "cached_tokens"),
+            probe(input_details, "cached_tokens"),
+        )
+        result["cache_write_input_tokens"] = _first_int(
+            probe(usage, "cache_write_input_tokens", "cache_creation_input_tokens"),
+            probe(input_details, "cache_write_tokens"),
+        )
+        result["reasoning_tokens"] = _first_int(
+            probe(usage, "reasoning_tokens"),
+            probe(output_details, "reasoning_tokens"),
+        )
+
+        if (
+            result["total_tokens"] is None
+            and result["input_tokens"] is not None
+            and result["output_tokens"] is not None
+        ):
+            result["total_tokens"] = result["input_tokens"] + result["output_tokens"]
+    except Exception as exc:
+        logger.debug("extract_usage_tokens failed: %s", exc)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Cost
+# ---------------------------------------------------------------------------
+
+
+def estimate_cost_safe(
+    model: Optional[str],
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+) -> dict[str, Any]:
+    """
+    Estimate LLM cost via ``noveum_trace.utils.llm_utils.estimate_cost``.
+
+    Returns a dict with ``input`` / ``output`` / ``total`` / ``currency`` keys,
+    or an empty dict on any failure so callers can safely ``.get(...)``.
+    """
+    if not model:
+        return {}
+    if input_tokens is None and output_tokens is None:
+        return {}
+    try:
+        from noveum_trace.utils.llm_utils import estimate_cost
+
+        cost_info = estimate_cost(
+            model,
+            input_tokens=int(input_tokens or 0),
+            output_tokens=int(output_tokens or 0),
+        )
+        return {
+            "input": cost_info.get("input_cost", 0.0),
+            "output": cost_info.get("output_cost", 0.0),
+            "total": cost_info.get("total_cost", 0.0),
+            "currency": cost_info.get("currency", "USD"),
+        }
+    except Exception as exc:
+        logger.debug("estimate_cost_safe failed for model=%s: %s", model, exc)
+        return {}

--- a/src/noveum_trace/integrations/_common.py
+++ b/src/noveum_trace/integrations/_common.py
@@ -161,6 +161,10 @@ def coerce_datetime(value: Any) -> Optional[datetime]:
     """
     Convert an ISO-8601 string (or epoch seconds) to a ``datetime``.
 
+    A trailing RFC 3339 ``Z`` is rewritten to ``+00:00`` because
+    ``datetime.fromisoformat`` only accepts the ``Z`` designator on Python 3.11+
+    and this package supports 3.9.
+
     Returns ``None`` when the value is missing or unparseable so callers can
     fall back to "now".
     """
@@ -169,8 +173,9 @@ def coerce_datetime(value: Any) -> Optional[datetime]:
     if isinstance(value, datetime):
         return value
     if isinstance(value, str):
+        candidate = value[:-1] + "+00:00" if value.endswith(("Z", "z")) else value
         try:
-            return datetime.fromisoformat(value)
+            return datetime.fromisoformat(candidate)
         except ValueError:
             return None
     if isinstance(value, (int, float)):

--- a/src/noveum_trace/integrations/openai_agents/__init__.py
+++ b/src/noveum_trace/integrations/openai_agents/__init__.py
@@ -29,10 +29,12 @@ Configuration Options
 All options passed to ``NoveumTraceProcessor`` or ``setup_openai_agents_tracing``:
 
   capture_inputs          — Capture raw tool / function / custom inputs (default: off)
-  capture_outputs         — Capture raw tool / function / LLM outputs (default: off)
-  capture_llm_messages    — Capture full LLM prompt/response messages (default: off)
+  capture_outputs         — Capture raw tool / function outputs (default: off)
+  capture_llm_messages    — Capture full LLM prompt/response messages, generation
+                            and response spans (default: off)
   capture_tool_schemas    — Capture agent tool / handoff names (default: on)
-  capture_trace_metadata  — Copy OpenAI trace metadata / group_id (default: on)
+  capture_trace_metadata  — Copy OpenAI trace metadata / group_id (default: on;
+                            may contain sensitive data — see the integration guide)
   capture_cost            — Estimate LLM cost from tokens (default: on)
   trace_name_prefix       — Prefix for unnamed workflows (default: "openai_agents")
 """

--- a/src/noveum_trace/integrations/openai_agents/__init__.py
+++ b/src/noveum_trace/integrations/openai_agents/__init__.py
@@ -1,0 +1,48 @@
+"""
+Noveum OpenAI Agents SDK Integration.
+
+Provides tracing for the `OpenAI Agents SDK <https://openai.github.io/openai-agents-python/>`_
+by implementing a ``TracingProcessor`` that mirrors OpenAI Agents traces/spans as
+Noveum traces/spans.
+
+Installation
+------------
+>>> pip install "noveum-trace[openai-agents]"
+
+Setup
+-----
+>>> import noveum_trace
+>>> from agents import add_trace_processor
+>>> from noveum_trace.integrations.openai_agents import NoveumTraceProcessor
+>>>
+>>> noveum_trace.init(project="my-project", api_key="...")
+>>> add_trace_processor(NoveumTraceProcessor())
+
+or, equivalently, using the convenience factory::
+
+>>> from noveum_trace.integrations.openai_agents import setup_openai_agents_tracing
+>>> noveum_trace.init(project="my-project", api_key="...")
+>>> setup_openai_agents_tracing()
+
+Configuration Options
+---------------------
+All options passed to ``NoveumTraceProcessor`` or ``setup_openai_agents_tracing``:
+
+  capture_inputs          — Capture raw tool / function / custom inputs (default: off)
+  capture_outputs         — Capture raw tool / function / LLM outputs (default: off)
+  capture_llm_messages    — Capture full LLM prompt/response messages (default: off)
+  capture_tool_schemas    — Capture agent tool / handoff names (default: on)
+  capture_trace_metadata  — Copy OpenAI trace metadata / group_id (default: on)
+  capture_cost            — Estimate LLM cost from tokens (default: on)
+  trace_name_prefix       — Prefix for unnamed workflows (default: "openai_agents")
+"""
+
+from noveum_trace.integrations.openai_agents.processor import (
+    NoveumTraceProcessor,
+    setup_openai_agents_tracing,
+)
+
+__all__ = [
+    "NoveumTraceProcessor",
+    "setup_openai_agents_tracing",
+]

--- a/src/noveum_trace/integrations/openai_agents/__init__.py
+++ b/src/noveum_trace/integrations/openai_agents/__init__.py
@@ -28,15 +28,23 @@ Configuration Options
 ---------------------
 All options passed to ``NoveumTraceProcessor`` or ``setup_openai_agents_tracing``:
 
-  capture_inputs          — Capture raw tool / function / custom inputs (default: off)
-  capture_outputs         — Capture raw tool / function outputs (default: off)
-  capture_llm_messages    — Capture full LLM prompt/response messages, generation
-                            and response spans (default: off)
-  capture_tool_schemas    — Capture agent tool / handoff names (default: on)
+  capture_inputs          — Capture raw tool / function / custom inputs (default: on)
+  capture_outputs         — Capture raw tool / function outputs (default: on)
+  capture_llm_messages    — Capture full LLM prompt/response messages, system
+                            prompts and tool calls, on generation and response
+                            spans (default: on)
+  capture_tool_schemas    — Capture agent tool / handoff names and the tool
+                            schemas offered to the model (default: on)
   capture_trace_metadata  — Copy OpenAI trace metadata / group_id (default: on;
                             may contain sensitive data — see the integration guide)
   capture_cost            — Estimate LLM cost from tokens (default: on)
   trace_name_prefix       — Prefix for unnamed workflows (default: "openai_agents")
+
+Everything is captured by default; set the flags to ``False`` to reduce what is
+sent. Note that the Agents SDK separately decides whether to record prompt and
+response payloads at all — with ``RunConfig(trace_include_sensitive_data=False)``
+or ``OPENAI_AGENTS_DONT_LOG_MODEL_DATA`` set, those payloads never reach any
+processor and no flag here can recover them.
 """
 
 from noveum_trace.integrations.openai_agents.processor import (

--- a/src/noveum_trace/integrations/openai_agents/constants.py
+++ b/src/noveum_trace/integrations/openai_agents/constants.py
@@ -73,7 +73,9 @@ ATTR_STATUS = "openai_agents.status"
 ATTR_AGENT_NAME = "agent.name"
 ATTR_AGENT_HANDOFFS = "agent.handoffs"
 ATTR_AGENT_TOOLS = "agent.tools"
+ATTR_AGENT_TOOL_COUNT = "agent.tool_count"
 ATTR_AGENT_OUTPUT_TYPE = "agent.output_type"
+ATTR_AGENT_METADATA = "agent.metadata"
 
 # ---------------------------------------------------------------------------
 # Tool / function attribute keys   (prefix: tool.*)
@@ -82,6 +84,8 @@ ATTR_AGENT_OUTPUT_TYPE = "agent.output_type"
 ATTR_TOOL_NAME = "tool.name"
 ATTR_TOOL_INPUT = "tool.input"
 ATTR_TOOL_OUTPUT = "tool.output"
+ATTR_TOOL_IS_MCP = "tool.is_mcp"
+ATTR_TOOL_MCP_DATA = "tool.mcp_data"
 
 # ---------------------------------------------------------------------------
 # LLM attribute keys   (prefix: llm.* — consumed by the gen_ai crosswalk)
@@ -91,13 +95,27 @@ ATTR_LLM_MODEL = "llm.model"
 ATTR_LLM_PROVIDER = "llm.provider"
 ATTR_LLM_INPUT = "llm.input"
 ATTR_LLM_OUTPUT = "llm.output"
+ATTR_LLM_INPUT_TEXT = "llm.input_text"
+ATTR_LLM_OUTPUT_TEXT = "llm.output_text"
+ATTR_LLM_SYSTEM_PROMPT = "llm.system_prompt"
+ATTR_LLM_AVAILABLE_TOOLS = "llm.available_tools"
+ATTR_LLM_AVAILABLE_TOOL_COUNT = "llm.available_tool_count"
+ATTR_LLM_TOOL_CALLS = "llm.tool_calls"
+ATTR_LLM_TOOL_CALL_COUNT = "llm.tool_call_count"
+ATTR_LLM_REASONING = "llm.reasoning"
 ATTR_LLM_INPUT_TOKENS = "llm.input_tokens"
 ATTR_LLM_OUTPUT_TOKENS = "llm.output_tokens"
 ATTR_LLM_TOTAL_TOKENS = "llm.total_tokens"
+ATTR_LLM_CACHED_INPUT_TOKENS = "llm.cached_input_tokens"
+ATTR_LLM_CACHE_WRITE_INPUT_TOKENS = "llm.cache_write_input_tokens"
+ATTR_LLM_CACHE_HIT = "llm.cache_hit"
+ATTR_LLM_REASONING_TOKENS = "llm.reasoning_tokens"
 ATTR_LLM_TEMPERATURE = "llm.temperature"
 ATTR_LLM_MAX_TOKENS = "llm.max_tokens"
 ATTR_LLM_TOP_P = "llm.top_p"
 ATTR_LLM_REQUEST_ID = "llm.request_id"
+ATTR_LLM_RESPONSE_STATUS = "llm.response_status"
+ATTR_LLM_REASONING_EFFORT = "llm.reasoning_effort"
 ATTR_LLM_COST_INPUT = "llm.cost.input"
 ATTR_LLM_COST_OUTPUT = "llm.cost.output"
 ATTR_LLM_COST_TOTAL = "llm.cost.total"
@@ -123,6 +141,7 @@ ATTR_GUARDRAIL_TRIGGERED = "guardrail.triggered"
 
 ATTR_MCP_SERVER = "mcp.server_name"
 ATTR_MCP_TOOLS = "mcp.tools"
+ATTR_MCP_TOOL_COUNT = "mcp.tool_count"
 
 # ---------------------------------------------------------------------------
 # Custom-span attribute keys   (prefix: custom.*)
@@ -151,10 +170,12 @@ STATUS_OK = "ok"
 STATUS_ERROR = "error"
 
 # ---------------------------------------------------------------------------
-# Limits / defaults
+# Defaults
 # ---------------------------------------------------------------------------
 
-MAX_TEXT_LENGTH = 8_192
+# Payloads are recorded in full. System prompts, tool results and message
+# arrays routinely exceed any fixed character budget, and a clipped prompt is
+# not usable for evaluation or replay, so this integration does not truncate.
 DEFAULT_TRACE_NAME_PREFIX = "openai_agents"
 
 # Informational — the minimum ``openai-agents`` release these mappings were

--- a/src/noveum_trace/integrations/openai_agents/constants.py
+++ b/src/noveum_trace/integrations/openai_agents/constants.py
@@ -1,0 +1,162 @@
+"""
+Constants for the OpenAI Agents SDK integration.
+
+Structure: span name constants, a ``SpanData.type`` → span-name map, span
+attribute key constants (reusing the canonical ``llm.*`` / ``tool.*`` keys the
+rest of the SDK understands), status values, and numeric limits.
+
+Span hierarchy (mirrors the OpenAI Agents trace/span tree)::
+
+    <workflow trace>                 ← one per ``agents`` Trace
+      openai_agents.agent            ← one per Agent invocation
+        openai_agents.generation     ← Chat Completions generation call
+        openai_agents.response       ← Responses API call
+        openai_agents.function       ← tool / function-tool call
+        openai_agents.handoff        ← agent-to-agent handoff
+        openai_agents.guardrail      ← input / output guardrail
+        openai_agents.mcp_tools      ← MCP ``list_tools`` call
+        openai_agents.custom         ← ``custom_span`` created by user code
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Span name constants
+# ---------------------------------------------------------------------------
+
+SPAN_AGENT = "openai_agents.agent"
+SPAN_FUNCTION = "openai_agents.function"
+SPAN_GENERATION = "openai_agents.generation"
+SPAN_RESPONSE = "openai_agents.response"
+SPAN_HANDOFF = "openai_agents.handoff"
+SPAN_GUARDRAIL = "openai_agents.guardrail"
+SPAN_CUSTOM = "openai_agents.custom"
+SPAN_MCP_TOOLS = "openai_agents.mcp_tools"
+SPAN_TRANSCRIPTION = "openai_agents.transcription"
+SPAN_SPEECH = "openai_agents.speech"
+SPAN_SPEECH_GROUP = "openai_agents.speech_group"
+SPAN_TASK = "openai_agents.task"
+SPAN_TURN = "openai_agents.turn"
+SPAN_DEFAULT = "openai_agents.span"
+
+# ``SpanData.type`` string → Noveum span name.
+SPAN_NAME_BY_TYPE: dict[str, str] = {
+    "agent": SPAN_AGENT,
+    "function": SPAN_FUNCTION,
+    "generation": SPAN_GENERATION,
+    "response": SPAN_RESPONSE,
+    "handoff": SPAN_HANDOFF,
+    "guardrail": SPAN_GUARDRAIL,
+    "custom": SPAN_CUSTOM,
+    "mcp_tools": SPAN_MCP_TOOLS,
+    "transcription": SPAN_TRANSCRIPTION,
+    "speech": SPAN_SPEECH,
+    "speech_group": SPAN_SPEECH_GROUP,
+    "task": SPAN_TASK,
+    "turn": SPAN_TURN,
+}
+
+# ---------------------------------------------------------------------------
+# Trace / workflow attribute keys   (prefix: openai_agents.*)
+# ---------------------------------------------------------------------------
+
+ATTR_WORKFLOW_NAME = "openai_agents.workflow_name"
+ATTR_GROUP_ID = "openai_agents.group_id"
+ATTR_TRACE_METADATA = "openai_agents.metadata"
+ATTR_SPAN_TYPE = "openai_agents.span_type"
+ATTR_STATUS = "openai_agents.status"
+
+# ---------------------------------------------------------------------------
+# Agent attribute keys   (prefix: agent.*)
+# ---------------------------------------------------------------------------
+
+ATTR_AGENT_NAME = "agent.name"
+ATTR_AGENT_HANDOFFS = "agent.handoffs"
+ATTR_AGENT_TOOLS = "agent.tools"
+ATTR_AGENT_OUTPUT_TYPE = "agent.output_type"
+
+# ---------------------------------------------------------------------------
+# Tool / function attribute keys   (prefix: tool.*)
+# ---------------------------------------------------------------------------
+
+ATTR_TOOL_NAME = "tool.name"
+ATTR_TOOL_INPUT = "tool.input"
+ATTR_TOOL_OUTPUT = "tool.output"
+
+# ---------------------------------------------------------------------------
+# LLM attribute keys   (prefix: llm.* — consumed by the gen_ai crosswalk)
+# ---------------------------------------------------------------------------
+
+ATTR_LLM_MODEL = "llm.model"
+ATTR_LLM_PROVIDER = "llm.provider"
+ATTR_LLM_INPUT = "llm.input"
+ATTR_LLM_OUTPUT = "llm.output"
+ATTR_LLM_INPUT_TOKENS = "llm.input_tokens"
+ATTR_LLM_OUTPUT_TOKENS = "llm.output_tokens"
+ATTR_LLM_TOTAL_TOKENS = "llm.total_tokens"
+ATTR_LLM_TEMPERATURE = "llm.temperature"
+ATTR_LLM_MAX_TOKENS = "llm.max_tokens"
+ATTR_LLM_TOP_P = "llm.top_p"
+ATTR_LLM_REQUEST_ID = "llm.request_id"
+ATTR_LLM_COST_INPUT = "llm.cost.input"
+ATTR_LLM_COST_OUTPUT = "llm.cost.output"
+ATTR_LLM_COST_TOTAL = "llm.cost.total"
+ATTR_LLM_COST_CURRENCY = "llm.cost.currency"
+
+# ---------------------------------------------------------------------------
+# Handoff attribute keys   (prefix: handoff.*)
+# ---------------------------------------------------------------------------
+
+ATTR_HANDOFF_FROM = "handoff.from_agent"
+ATTR_HANDOFF_TO = "handoff.to_agent"
+
+# ---------------------------------------------------------------------------
+# Guardrail attribute keys   (prefix: guardrail.*)
+# ---------------------------------------------------------------------------
+
+ATTR_GUARDRAIL_NAME = "guardrail.name"
+ATTR_GUARDRAIL_TRIGGERED = "guardrail.triggered"
+
+# ---------------------------------------------------------------------------
+# MCP attribute keys   (prefix: mcp.*)
+# ---------------------------------------------------------------------------
+
+ATTR_MCP_SERVER = "mcp.server_name"
+ATTR_MCP_TOOLS = "mcp.tools"
+
+# ---------------------------------------------------------------------------
+# Custom-span attribute keys   (prefix: custom.*)
+# ---------------------------------------------------------------------------
+
+ATTR_CUSTOM_NAME = "custom.name"
+ATTR_CUSTOM_DATA = "custom.data"
+
+# ---------------------------------------------------------------------------
+# Turn / task attribute keys
+# ---------------------------------------------------------------------------
+
+ATTR_TURN_NUMBER = "turn.number"
+ATTR_TURN_AGENT_NAME = "turn.agent_name"
+ATTR_TASK_NAME = "task.name"
+
+# ---------------------------------------------------------------------------
+# Error / status attribute keys
+# ---------------------------------------------------------------------------
+
+ATTR_ERROR_TYPE = "error.type"
+ATTR_ERROR_MESSAGE = "error.message"
+ATTR_ERROR_DATA = "error.data"
+
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+
+# ---------------------------------------------------------------------------
+# Limits / defaults
+# ---------------------------------------------------------------------------
+
+MAX_TEXT_LENGTH = 8_192
+DEFAULT_TRACE_NAME_PREFIX = "openai_agents"
+
+# Informational — the minimum ``openai-agents`` release these mappings were
+# verified against (see ``pyproject.toml`` for the enforced pin).
+MIN_OPENAI_AGENTS_VERSION = "0.19.2"

--- a/src/noveum_trace/integrations/openai_agents/processor.py
+++ b/src/noveum_trace/integrations/openai_agents/processor.py
@@ -106,9 +106,11 @@ class NoveumTraceProcessor(TracingProcessor):
             (``noveum_trace.init(...)``).
         capture_inputs: Capture raw tool/function/custom inputs. Off by default
             (privacy-safe) because inputs can contain sensitive payloads.
-        capture_outputs: Capture raw tool/function/LLM outputs. Off by default.
-        capture_llm_messages: Capture full LLM prompt/response message arrays.
-            Off by default — this is the most sensitive payload.
+        capture_outputs: Capture raw tool/function outputs. Off by default. (LLM
+            prompt/response content is controlled by ``capture_llm_messages``.)
+        capture_llm_messages: Capture full LLM prompt/response message arrays for
+            both generation and response spans. Off by default — the most
+            sensitive payload.
         capture_tool_schemas: Capture structural metadata such as an agent's tool
             and handoff names. On by default (names/structure, not argument values).
         capture_trace_metadata: Copy the OpenAI trace ``metadata`` / ``group_id``
@@ -393,16 +395,19 @@ class NoveumTraceProcessor(TracingProcessor):
         response_id = getattr(response, "id", None)
         if response_id:
             attributes[C.ATTR_LLM_REQUEST_ID] = str(response_id)
-        if self.capture_inputs:
+        # Response input/output are LLM messages, so they are gated on
+        # ``capture_llm_messages`` (consistent with ``_map_generation``), not on
+        # the tool-oriented ``capture_inputs`` / ``capture_outputs`` flags.
+        if self.capture_llm_messages:
             response_input = getattr(span_data, "input", None)
             if response_input is not None:
                 attributes[C.ATTR_LLM_INPUT] = to_serialisable(response_input)
-        if self.capture_outputs and response is not None:
-            output_text = getattr(response, "output_text", None)
-            if output_text:
-                attributes[C.ATTR_LLM_OUTPUT] = truncate_text(
-                    output_text, C.MAX_TEXT_LENGTH
-                )
+            if response is not None:
+                output_text = getattr(response, "output_text", None)
+                if output_text:
+                    attributes[C.ATTR_LLM_OUTPUT] = truncate_text(
+                        output_text, C.MAX_TEXT_LENGTH
+                    )
 
     def _map_handoff(self, span_data: Any, attributes: dict[str, Any]) -> None:
         from_agent = getattr(span_data, "from_agent", None)

--- a/src/noveum_trace/integrations/openai_agents/processor.py
+++ b/src/noveum_trace/integrations/openai_agents/processor.py
@@ -1,0 +1,576 @@
+"""
+Noveum trace processor for the OpenAI Agents SDK.
+
+:class:`NoveumTraceProcessor` implements the ``agents.tracing.TracingProcessor``
+interface. It maps OpenAI Agents traces onto Noveum traces and OpenAI Agents
+spans onto Noveum spans, preserving parent-child ordering, and attaches
+``gen_ai``-compatible ``llm.*`` / ``tool.*`` / ``agent.*`` attributes.
+
+Register it with the Agents SDK::
+
+    import noveum_trace
+    from agents import add_trace_processor
+    from noveum_trace.integrations.openai_agents import NoveumTraceProcessor
+
+    noveum_trace.init(project="my-project", api_key="...")
+    add_trace_processor(NoveumTraceProcessor())
+
+or use the convenience factory :func:`setup_openai_agents_tracing`.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any, Optional
+
+from noveum_trace.integrations.openai_agents import constants as C
+from noveum_trace.integrations.openai_agents.utils import (
+    coerce_iso_datetime,
+    derive_provider,
+    estimate_cost_safe,
+    extract_model_config,
+    extract_usage_tokens,
+    to_serialisable,
+    truncate_text,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    from agents.tracing import TracingProcessor
+
+    OPENAI_AGENTS_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only without the extra installed
+
+    OPENAI_AGENTS_AVAILABLE = False
+
+    class TracingProcessor:  # type: ignore[no-redef]
+        """
+        Fallback stub used when ``openai-agents`` is not installed.
+
+        Mirrors the lifecycle hooks of ``agents.tracing.TracingProcessor`` so the
+        module imports (and unit tests run) without the optional dependency.
+        """
+
+        def on_trace_start(self, trace: Any) -> None: ...
+
+        def on_trace_end(self, trace: Any) -> None: ...
+
+        def on_span_start(self, span: Any) -> None: ...
+
+        def on_span_end(self, span: Any) -> None: ...
+
+        def shutdown(self) -> None: ...
+
+        def force_flush(self) -> None: ...
+
+
+def _span_data_type(span_data: Any) -> str:
+    """Return the ``SpanData.type`` string (``"generation"``, ``"agent"``, …)."""
+    span_type = getattr(span_data, "type", None)
+    return str(span_type) if span_type is not None else ""
+
+
+def _set_attributes(span: Any, attributes: dict[str, Any]) -> None:
+    """Write *attributes* onto *span*, tolerating already-finished spans."""
+    if not attributes or span is None:
+        return
+    try:
+        span.set_attributes(attributes)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("failed to set span attributes: %s", exc)
+
+
+def _finish_span(span: Any, end_time: Any) -> None:
+    """Finish *span* with *end_time*, never raising into the host application."""
+    if span is None:
+        return
+    try:
+        span.finish(end_time)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("failed to finish span: %s", exc)
+
+
+class NoveumTraceProcessor(TracingProcessor):
+    """
+    Bridge OpenAI Agents SDK tracing into Noveum.
+
+    Instances are safe to register once via ``agents.add_trace_processor``; the
+    processor keys concurrent traces/spans by their OpenAI ids, so multiple agent
+    runs (including async) map cleanly onto separate Noveum traces.
+
+    Args:
+        client: Explicit :class:`~noveum_trace.core.client.NoveumClient`. When
+            omitted the processor uses the globally initialised client
+            (``noveum_trace.init(...)``).
+        capture_inputs: Capture raw tool/function/custom inputs. Off by default
+            (privacy-safe) because inputs can contain sensitive payloads.
+        capture_outputs: Capture raw tool/function/LLM outputs. Off by default.
+        capture_llm_messages: Capture full LLM prompt/response message arrays.
+            Off by default — this is the most sensitive payload.
+        capture_tool_schemas: Capture structural metadata such as an agent's tool
+            and handoff names. On by default (names/structure, not argument values).
+        capture_trace_metadata: Copy the OpenAI trace ``metadata`` / ``group_id``
+            onto the Noveum trace. On by default (user-supplied workflow metadata).
+        capture_cost: Estimate and attach LLM cost from model + token counts.
+        trace_name_prefix: Prefix used when the OpenAI trace has no workflow name.
+    """
+
+    def __init__(
+        self,
+        client: Any = None,
+        *,
+        capture_inputs: bool = False,
+        capture_outputs: bool = False,
+        capture_llm_messages: bool = False,
+        capture_tool_schemas: bool = True,
+        capture_trace_metadata: bool = True,
+        capture_cost: bool = True,
+        trace_name_prefix: str = C.DEFAULT_TRACE_NAME_PREFIX,
+    ) -> None:
+        self._injected_client = client
+        self.capture_inputs = capture_inputs
+        self.capture_outputs = capture_outputs
+        self.capture_llm_messages = capture_llm_messages
+        self.capture_tool_schemas = capture_tool_schemas
+        self.capture_trace_metadata = capture_trace_metadata
+        self.capture_cost = capture_cost
+        self._trace_name_prefix = trace_name_prefix
+        self._lock = threading.RLock()
+        self._traces: dict[str, Any] = {}
+        self._spans: dict[str, Any] = {}
+        self._is_shutdown = False
+
+    # ------------------------------------------------------------------
+    # Client resolution
+    # ------------------------------------------------------------------
+
+    def _get_client(self) -> Any:
+        """Return the injected client, else the global client, else ``None``."""
+        if self._is_shutdown:
+            return None
+        if self._injected_client is not None:
+            return self._injected_client
+        try:
+            from noveum_trace import get_client, is_initialized
+
+            if is_initialized():
+                return get_client()
+        except Exception:  # pragma: no cover - defensive
+            return None
+        return None
+
+    # ------------------------------------------------------------------
+    # TracingProcessor lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def on_trace_start(self, trace: Any) -> None:
+        """Open a Noveum trace mirroring the OpenAI Agents trace."""
+        try:
+            client = self._get_client()
+            if client is None:
+                return
+            trace_id = getattr(trace, "trace_id", None)
+            if trace_id is None:
+                return
+
+            workflow_name = getattr(trace, "name", None)
+            trace_name = (
+                str(workflow_name)
+                if workflow_name
+                else f"{self._trace_name_prefix}.workflow"
+            )
+
+            attributes: dict[str, Any] = {}
+            if workflow_name:
+                attributes[C.ATTR_WORKFLOW_NAME] = str(workflow_name)
+            if self.capture_trace_metadata:
+                group_id = getattr(trace, "group_id", None)
+                if group_id is not None:
+                    attributes[C.ATTR_GROUP_ID] = str(group_id)
+                metadata = getattr(trace, "metadata", None)
+                if metadata:
+                    attributes[C.ATTR_TRACE_METADATA] = to_serialisable(metadata)
+
+            noveum_trace_obj = client.start_trace(
+                name=trace_name,
+                attributes=attributes,
+                set_as_current=False,
+            )
+            with self._lock:
+                self._traces[str(trace_id)] = noveum_trace_obj
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("on_trace_start failed: %s", exc, exc_info=True)
+
+    def on_trace_end(self, trace: Any) -> None:
+        """Finish (and export) the Noveum trace for a completed OpenAI trace."""
+        try:
+            trace_id = getattr(trace, "trace_id", None)
+            if trace_id is None:
+                return
+            with self._lock:
+                noveum_trace_obj = self._traces.pop(str(trace_id), None)
+                orphan_ids = [
+                    span_id
+                    for span_id, span in self._spans.items()
+                    if getattr(span, "trace_id", None)
+                    == getattr(noveum_trace_obj, "trace_id", object())
+                ]
+                orphans = [self._spans.pop(span_id) for span_id in orphan_ids]
+            if noveum_trace_obj is None:
+                return
+            for orphan in orphans:
+                _finish_span(orphan, None)
+
+            client = self._get_client()
+            if client is not None:
+                client.finish_trace(noveum_trace_obj)
+            else:
+                try:
+                    noveum_trace_obj.finish()
+                except Exception:  # pragma: no cover - defensive
+                    pass
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("on_trace_end failed: %s", exc, exc_info=True)
+
+    def on_span_start(self, span: Any) -> None:
+        """Open a Noveum span, linking it to its parent when one exists."""
+        try:
+            trace_id = getattr(span, "trace_id", None)
+            span_id = getattr(span, "span_id", None)
+            if trace_id is None or span_id is None:
+                return
+            with self._lock:
+                noveum_trace_obj = self._traces.get(str(trace_id))
+            if noveum_trace_obj is None:
+                return
+
+            parent_span_id: Optional[str] = None
+            parent_id = getattr(span, "parent_id", None)
+            if parent_id is not None:
+                with self._lock:
+                    parent_noveum_span = self._spans.get(str(parent_id))
+                if parent_noveum_span is not None:
+                    parent_span_id = getattr(parent_noveum_span, "span_id", None)
+
+            span_type = _span_data_type(getattr(span, "span_data", None))
+            span_name = C.SPAN_NAME_BY_TYPE.get(span_type, C.SPAN_DEFAULT)
+            start_time = coerce_iso_datetime(getattr(span, "started_at", None))
+
+            noveum_span = noveum_trace_obj.create_span(
+                name=span_name,
+                parent_span_id=parent_span_id,
+                attributes={C.ATTR_SPAN_TYPE: span_type} if span_type else {},
+                start_time=start_time,
+            )
+            with self._lock:
+                self._spans[str(span_id)] = noveum_span
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("on_span_start failed: %s", exc, exc_info=True)
+
+    def on_span_end(self, span: Any) -> None:
+        """Populate attributes and finish the Noveum span for a completed span."""
+        try:
+            span_id = getattr(span, "span_id", None)
+            if span_id is None:
+                return
+            with self._lock:
+                noveum_span = self._spans.pop(str(span_id), None)
+            if noveum_span is None:
+                return
+
+            span_data = getattr(span, "span_data", None)
+            span_type = _span_data_type(span_data)
+            attributes = self._build_span_attributes(span_type, span_data)
+
+            error = getattr(span, "error", None)
+            if error:
+                self._apply_error(noveum_span, error, attributes)
+            else:
+                attributes[C.ATTR_STATUS] = C.STATUS_OK
+
+            _set_attributes(noveum_span, attributes)
+            end_time = coerce_iso_datetime(getattr(span, "ended_at", None))
+            _finish_span(noveum_span, end_time)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("on_span_end failed: %s", exc, exc_info=True)
+
+    def shutdown(self) -> None:
+        """Flush pending traces on SDK shutdown; never raises into the host app."""
+        try:
+            self._force_flush_client()
+        finally:
+            self._is_shutdown = True
+
+    def force_flush(self) -> None:
+        """Flush the Noveum client so buffered traces are exported promptly."""
+        self._force_flush_client()
+
+    # ------------------------------------------------------------------
+    # Attribute mapping
+    # ------------------------------------------------------------------
+
+    def _build_span_attributes(self, span_type: str, span_data: Any) -> dict[str, Any]:
+        """Dispatch to the per-``SpanData`` mapper for *span_type*."""
+        attributes: dict[str, Any] = {}
+        if span_data is None:
+            return attributes
+        try:
+            if span_type == "agent":
+                self._map_agent(span_data, attributes)
+            elif span_type == "function":
+                self._map_function(span_data, attributes)
+            elif span_type == "generation":
+                self._map_generation(span_data, attributes)
+            elif span_type == "response":
+                self._map_response(span_data, attributes)
+            elif span_type == "handoff":
+                self._map_handoff(span_data, attributes)
+            elif span_type == "guardrail":
+                self._map_guardrail(span_data, attributes)
+            elif span_type == "custom":
+                self._map_custom(span_data, attributes)
+            elif span_type == "mcp_tools":
+                self._map_mcp_tools(span_data, attributes)
+            elif span_type in ("task", "turn"):
+                self._map_task_turn(span_data, attributes)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("attribute mapping failed for %s: %s", span_type, exc)
+        return attributes
+
+    def _map_agent(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        name = getattr(span_data, "name", None)
+        if name:
+            attributes[C.ATTR_AGENT_NAME] = str(name)
+        output_type = getattr(span_data, "output_type", None)
+        if output_type:
+            attributes[C.ATTR_AGENT_OUTPUT_TYPE] = str(output_type)
+        if self.capture_tool_schemas:
+            handoffs = getattr(span_data, "handoffs", None)
+            if handoffs:
+                attributes[C.ATTR_AGENT_HANDOFFS] = to_serialisable(handoffs)
+            tools = getattr(span_data, "tools", None)
+            if tools:
+                attributes[C.ATTR_AGENT_TOOLS] = to_serialisable(tools)
+
+    def _map_function(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        name = getattr(span_data, "name", None)
+        if name:
+            attributes[C.ATTR_TOOL_NAME] = str(name)
+        if self.capture_inputs:
+            tool_input = getattr(span_data, "input", None)
+            if tool_input is not None:
+                attributes[C.ATTR_TOOL_INPUT] = truncate_text(
+                    tool_input, C.MAX_TEXT_LENGTH
+                )
+        if self.capture_outputs:
+            tool_output = getattr(span_data, "output", None)
+            if tool_output is not None:
+                attributes[C.ATTR_TOOL_OUTPUT] = truncate_text(
+                    tool_output, C.MAX_TEXT_LENGTH
+                )
+
+    def _map_generation(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        model = getattr(span_data, "model", None)
+        self._apply_model(model, attributes)
+        self._apply_model_config(getattr(span_data, "model_config", None), attributes)
+        self._apply_usage(model, getattr(span_data, "usage", None), attributes)
+        if self.capture_llm_messages:
+            llm_input = getattr(span_data, "input", None)
+            if llm_input is not None:
+                attributes[C.ATTR_LLM_INPUT] = to_serialisable(llm_input)
+            llm_output = getattr(span_data, "output", None)
+            if llm_output is not None:
+                attributes[C.ATTR_LLM_OUTPUT] = to_serialisable(llm_output)
+
+    def _map_response(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        response = getattr(span_data, "response", None)
+        model = getattr(response, "model", None)
+        self._apply_model(model, attributes)
+        usage = getattr(response, "usage", None) or getattr(span_data, "usage", None)
+        self._apply_usage(model, usage, attributes)
+        response_id = getattr(response, "id", None)
+        if response_id:
+            attributes[C.ATTR_LLM_REQUEST_ID] = str(response_id)
+        if self.capture_inputs:
+            response_input = getattr(span_data, "input", None)
+            if response_input is not None:
+                attributes[C.ATTR_LLM_INPUT] = to_serialisable(response_input)
+        if self.capture_outputs and response is not None:
+            output_text = getattr(response, "output_text", None)
+            if output_text:
+                attributes[C.ATTR_LLM_OUTPUT] = truncate_text(
+                    output_text, C.MAX_TEXT_LENGTH
+                )
+
+    def _map_handoff(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        from_agent = getattr(span_data, "from_agent", None)
+        if from_agent:
+            attributes[C.ATTR_HANDOFF_FROM] = str(from_agent)
+        to_agent = getattr(span_data, "to_agent", None)
+        if to_agent:
+            attributes[C.ATTR_HANDOFF_TO] = str(to_agent)
+
+    def _map_guardrail(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        name = getattr(span_data, "name", None)
+        if name:
+            attributes[C.ATTR_GUARDRAIL_NAME] = str(name)
+        triggered = getattr(span_data, "triggered", None)
+        if triggered is not None:
+            attributes[C.ATTR_GUARDRAIL_TRIGGERED] = bool(triggered)
+
+    def _map_custom(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        name = getattr(span_data, "name", None)
+        if name:
+            attributes[C.ATTR_CUSTOM_NAME] = str(name)
+        if self.capture_inputs:
+            data = getattr(span_data, "data", None)
+            if data:
+                attributes[C.ATTR_CUSTOM_DATA] = to_serialisable(data)
+
+    def _map_mcp_tools(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        server = getattr(span_data, "server", None)
+        if server:
+            attributes[C.ATTR_MCP_SERVER] = str(server)
+        if self.capture_tool_schemas:
+            result = getattr(span_data, "result", None)
+            if result:
+                attributes[C.ATTR_MCP_TOOLS] = to_serialisable(result)
+
+    def _map_task_turn(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        self._apply_usage(None, getattr(span_data, "usage", None), attributes)
+        turn = getattr(span_data, "turn", None)
+        if turn is not None:
+            attributes[C.ATTR_TURN_NUMBER] = turn
+        agent_name = getattr(span_data, "agent_name", None)
+        if agent_name:
+            attributes[C.ATTR_TURN_AGENT_NAME] = str(agent_name)
+        name = getattr(span_data, "name", None)
+        if name:
+            attributes[C.ATTR_TASK_NAME] = str(name)
+
+    def _apply_model(self, model: Any, attributes: dict[str, Any]) -> None:
+        if not model:
+            return
+        attributes[C.ATTR_LLM_MODEL] = str(model)
+        provider = derive_provider(str(model))
+        if provider:
+            attributes[C.ATTR_LLM_PROVIDER] = provider
+
+    def _apply_model_config(
+        self, model_config: Any, attributes: dict[str, Any]
+    ) -> None:
+        config = extract_model_config(model_config)
+        if "temperature" in config:
+            attributes[C.ATTR_LLM_TEMPERATURE] = config["temperature"]
+        if "top_p" in config:
+            attributes[C.ATTR_LLM_TOP_P] = config["top_p"]
+        if "max_tokens" in config:
+            attributes[C.ATTR_LLM_MAX_TOKENS] = config["max_tokens"]
+
+    def _apply_usage(self, model: Any, usage: Any, attributes: dict[str, Any]) -> None:
+        tokens = extract_usage_tokens(usage)
+        if tokens["input_tokens"] is not None:
+            attributes[C.ATTR_LLM_INPUT_TOKENS] = tokens["input_tokens"]
+        if tokens["output_tokens"] is not None:
+            attributes[C.ATTR_LLM_OUTPUT_TOKENS] = tokens["output_tokens"]
+        if tokens["total_tokens"] is not None:
+            attributes[C.ATTR_LLM_TOTAL_TOKENS] = tokens["total_tokens"]
+        if self.capture_cost and model:
+            cost = estimate_cost_safe(
+                str(model), tokens["input_tokens"], tokens["output_tokens"]
+            )
+            if cost.get("total"):
+                attributes[C.ATTR_LLM_COST_INPUT] = cost.get("input")
+                attributes[C.ATTR_LLM_COST_OUTPUT] = cost.get("output")
+                attributes[C.ATTR_LLM_COST_TOTAL] = cost.get("total")
+                attributes[C.ATTR_LLM_COST_CURRENCY] = cost.get("currency")
+
+    def _apply_error(
+        self, noveum_span: Any, error: Any, attributes: dict[str, Any]
+    ) -> None:
+        """Attach error attributes and mark the span ERROR (non-fatal)."""
+        attributes[C.ATTR_STATUS] = C.STATUS_ERROR
+        message: Any = None
+        data: Any = None
+        if isinstance(error, dict):
+            message = error.get("message")
+            data = error.get("data")
+        else:
+            message = getattr(error, "message", None) or str(error)
+            data = getattr(error, "data", None)
+        if message is not None:
+            attributes[C.ATTR_ERROR_MESSAGE] = truncate_text(message, C.MAX_TEXT_LENGTH)
+        if data:
+            attributes[C.ATTR_ERROR_DATA] = to_serialisable(data)
+        try:
+            from noveum_trace.core.span import SpanStatus
+
+            noveum_span.set_status(
+                SpanStatus.ERROR, str(message) if message else "error"
+            )
+        except Exception:  # pragma: no cover - defensive
+            pass
+
+    # ------------------------------------------------------------------
+    # Flush helper
+    # ------------------------------------------------------------------
+
+    def _force_flush_client(self) -> None:
+        try:
+            client = self._get_client()
+            if client is not None:
+                client.flush()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("flush failed: %s", exc)
+
+
+def setup_openai_agents_tracing(
+    *,
+    replace_processors: bool = False,
+    **kwargs: Any,
+) -> NoveumTraceProcessor:
+    """
+    Create a :class:`NoveumTraceProcessor` and register it with the Agents SDK.
+
+    Requires ``noveum_trace.init(...)`` to have been called (or an explicit
+    ``client=`` kwarg). By default the processor is *added* alongside the SDK's
+    own exporter; pass ``replace_processors=True`` to replace all processors
+    (disabling OpenAI's default trace upload).
+
+    Args:
+        replace_processors: Use ``set_trace_processors([...])`` instead of
+            ``add_trace_processor(...)``.
+        **kwargs: Forwarded to :class:`NoveumTraceProcessor` (capture flags, etc.).
+
+    Returns:
+        The registered :class:`NoveumTraceProcessor`.
+
+    Raises:
+        ImportError: If ``openai-agents`` is not installed.
+        TypeError: If ``api_key`` / ``project`` are passed (configure those via
+            ``noveum_trace.init(...)``).
+    """
+    if not OPENAI_AGENTS_AVAILABLE:
+        raise ImportError(
+            "openai-agents is not installed. Install with: "
+            'pip install "noveum-trace[openai-agents]"'
+        )
+    for key in ("api_key", "project"):
+        if key in kwargs:
+            raise TypeError(
+                f"setup_openai_agents_tracing() does not accept {key!r}. "
+                "Use noveum_trace.init(api_key=..., project=...) to configure the "
+                "global client; the processor always uses get_client()."
+            )
+
+    processor = NoveumTraceProcessor(**kwargs)
+
+    from agents import add_trace_processor, set_trace_processors
+
+    if replace_processors:
+        set_trace_processors([processor])
+    else:
+        add_trace_processor(processor)
+    return processor

--- a/src/noveum_trace/integrations/openai_agents/processor.py
+++ b/src/noveum_trace/integrations/openai_agents/processor.py
@@ -24,15 +24,24 @@ import logging
 import threading
 from typing import Any, Optional
 
-from noveum_trace.integrations.openai_agents import constants as C
-from noveum_trace.integrations.openai_agents.utils import (
-    coerce_iso_datetime,
+from noveum_trace.integrations._common import (
+    coerce_datetime,
     derive_provider,
     estimate_cost_safe,
-    extract_model_config,
     extract_usage_tokens,
-    to_serialisable,
-    truncate_text,
+    finish_span,
+    safe_serialize,
+    set_span_attributes,
+    stringify,
+)
+from noveum_trace.integrations.openai_agents import constants as C
+from noveum_trace.integrations.openai_agents.utils import (
+    extract_message_text,
+    extract_model_config,
+    extract_response_output,
+    extract_system_prompt,
+    extract_tool_calls,
+    extract_tool_schemas,
 )
 
 logger = logging.getLogger(__name__)
@@ -72,24 +81,8 @@ def _span_data_type(span_data: Any) -> str:
     return str(span_type) if span_type is not None else ""
 
 
-def _set_attributes(span: Any, attributes: dict[str, Any]) -> None:
-    """Write *attributes* onto *span*, tolerating already-finished spans."""
-    if not attributes or span is None:
-        return
-    try:
-        span.set_attributes(attributes)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("failed to set span attributes: %s", exc)
-
-
-def _finish_span(span: Any, end_time: Any) -> None:
-    """Finish *span* with *end_time*, never raising into the host application."""
-    if span is None:
-        return
-    try:
-        span.finish(end_time)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("failed to finish span: %s", exc)
+_set_attributes = set_span_attributes
+_finish_span = finish_span
 
 
 class NoveumTraceProcessor(TracingProcessor):
@@ -104,28 +97,36 @@ class NoveumTraceProcessor(TracingProcessor):
         client: Explicit :class:`~noveum_trace.core.client.NoveumClient`. When
             omitted the processor uses the globally initialised client
             (``noveum_trace.init(...)``).
-        capture_inputs: Capture raw tool/function/custom inputs. Off by default
-            (privacy-safe) because inputs can contain sensitive payloads.
-        capture_outputs: Capture raw tool/function outputs. Off by default. (LLM
+        capture_inputs: Capture raw tool/function/custom inputs. On by default —
+            a trace without inputs cannot be replayed or evaluated.
+        capture_outputs: Capture raw tool/function outputs. On by default. (LLM
             prompt/response content is controlled by ``capture_llm_messages``.)
-        capture_llm_messages: Capture full LLM prompt/response message arrays for
-            both generation and response spans. Off by default — the most
-            sensitive payload.
+        capture_llm_messages: Capture full LLM prompt/response message arrays,
+            system prompts and tool calls for generation and response spans. On
+            by default.
         capture_tool_schemas: Capture structural metadata such as an agent's tool
-            and handoff names. On by default (names/structure, not argument values).
+            and handoff names and the tool schemas offered to the model.
         capture_trace_metadata: Copy the OpenAI trace ``metadata`` / ``group_id``
             onto the Noveum trace. On by default (user-supplied workflow metadata).
         capture_cost: Estimate and attach LLM cost from model + token counts.
         trace_name_prefix: Prefix used when the OpenAI trace has no workflow name.
+
+    Note:
+        The Agents SDK decides separately whether to *record* prompt and
+        response payloads on its span data at all. Running with
+        ``RunConfig(trace_include_sensitive_data=False)`` or the
+        ``OPENAI_AGENTS_DONT_LOG_MODEL_DATA`` environment variable leaves
+        ``span_data.input`` / ``span_data.output`` unset upstream, and no
+        capture flag here can recover data the SDK never recorded.
     """
 
     def __init__(
         self,
         client: Any = None,
         *,
-        capture_inputs: bool = False,
-        capture_outputs: bool = False,
-        capture_llm_messages: bool = False,
+        capture_inputs: bool = True,
+        capture_outputs: bool = True,
+        capture_llm_messages: bool = True,
         capture_tool_schemas: bool = True,
         capture_trace_metadata: bool = True,
         capture_cost: bool = True,
@@ -142,6 +143,8 @@ class NoveumTraceProcessor(TracingProcessor):
         self._lock = threading.RLock()
         self._traces: dict[str, Any] = {}
         self._spans: dict[str, Any] = {}
+        self._noveum_span_ids: dict[str, str] = {}
+        self._trace_span_ids: dict[str, set[str]] = {}
         self._is_shutdown = False
 
     # ------------------------------------------------------------------
@@ -193,7 +196,7 @@ class NoveumTraceProcessor(TracingProcessor):
                     attributes[C.ATTR_GROUP_ID] = str(group_id)
                 metadata = getattr(trace, "metadata", None)
                 if metadata:
-                    attributes[C.ATTR_TRACE_METADATA] = to_serialisable(metadata)
+                    attributes[C.ATTR_TRACE_METADATA] = safe_serialize(metadata)
 
             noveum_trace_obj = client.start_trace(
                 name=trace_name,
@@ -213,13 +216,16 @@ class NoveumTraceProcessor(TracingProcessor):
                 return
             with self._lock:
                 noveum_trace_obj = self._traces.pop(str(trace_id), None)
-                orphan_ids = [
-                    span_id
-                    for span_id, span in self._spans.items()
-                    if getattr(span, "trace_id", None)
-                    == getattr(noveum_trace_obj, "trace_id", object())
+                owned_span_ids = self._trace_span_ids.pop(str(trace_id), set())
+                orphans = [
+                    span
+                    for span in (
+                        self._spans.pop(owned_id, None) for owned_id in owned_span_ids
+                    )
+                    if span is not None
                 ]
-                orphans = [self._spans.pop(span_id) for span_id in orphan_ids]
+                for owned_id in owned_span_ids:
+                    self._noveum_span_ids.pop(owned_id, None)
             if noveum_trace_obj is None:
                 return
             for orphan in orphans:
@@ -237,7 +243,23 @@ class NoveumTraceProcessor(TracingProcessor):
             logger.debug("on_trace_end failed: %s", exc, exc_info=True)
 
     def on_span_start(self, span: Any) -> None:
-        """Open a Noveum span, linking it to its parent when one exists."""
+        """
+        Open a Noveum span, linking it to its parent when one exists.
+
+        Parentage is taken straight from the Agents SDK: every span carries a
+        ``parent_id`` naming the OpenAI span that encloses it (the SDK maintains
+        that stack in a context variable, so it is correct across concurrent and
+        async agent runs, including handoffs between agents). That OpenAI id is
+        translated through ``_noveum_span_ids`` to the Noveum span it was mapped
+        to, and the result becomes the new span's ``parent_span_id``.
+
+        The id map deliberately outlives the live span objects in ``_spans`` and
+        is only cleared when the whole trace ends, so a child that opens after
+        its parent has already closed still attaches to the right parent instead
+        of silently reattaching to the trace root. A span with no ``parent_id``
+        (or one whose parent was never mapped) becomes a root-level child of the
+        trace.
+        """
         try:
             trace_id = getattr(span, "trace_id", None)
             span_id = getattr(span, "span_id", None)
@@ -252,13 +274,11 @@ class NoveumTraceProcessor(TracingProcessor):
             parent_id = getattr(span, "parent_id", None)
             if parent_id is not None:
                 with self._lock:
-                    parent_noveum_span = self._spans.get(str(parent_id))
-                if parent_noveum_span is not None:
-                    parent_span_id = getattr(parent_noveum_span, "span_id", None)
+                    parent_span_id = self._noveum_span_ids.get(str(parent_id))
 
             span_type = _span_data_type(getattr(span, "span_data", None))
             span_name = C.SPAN_NAME_BY_TYPE.get(span_type, C.SPAN_DEFAULT)
-            start_time = coerce_iso_datetime(getattr(span, "started_at", None))
+            start_time = coerce_datetime(getattr(span, "started_at", None))
 
             noveum_span = noveum_trace_obj.create_span(
                 name=span_name,
@@ -268,6 +288,10 @@ class NoveumTraceProcessor(TracingProcessor):
             )
             with self._lock:
                 self._spans[str(span_id)] = noveum_span
+                mapped_id = getattr(noveum_span, "span_id", None)
+                if mapped_id is not None:
+                    self._noveum_span_ids[str(span_id)] = mapped_id
+                self._trace_span_ids.setdefault(str(trace_id), set()).add(str(span_id))
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("on_span_start failed: %s", exc, exc_info=True)
 
@@ -293,7 +317,7 @@ class NoveumTraceProcessor(TracingProcessor):
                 attributes[C.ATTR_STATUS] = C.STATUS_OK
 
             _set_attributes(noveum_span, attributes)
-            end_time = coerce_iso_datetime(getattr(span, "ended_at", None))
+            end_time = coerce_datetime(getattr(span, "ended_at", None))
             _finish_span(noveum_span, end_time)
         except Exception as exc:  # pragma: no cover - defensive
             logger.debug("on_span_end failed: %s", exc, exc_info=True)
@@ -342,51 +366,86 @@ class NoveumTraceProcessor(TracingProcessor):
         return attributes
 
     def _map_agent(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        """
+        Map an ``agent`` span.
+
+        ``AgentSpanData`` describes the agent's *configuration* — its name, the
+        names of the tools and handoffs it was given, and its output type. The
+        calls it actually made are separate child spans: each tool invocation
+        (arguments and result) is a ``function`` span, each MCP tool listing an
+        ``mcp_tools`` span, each model call a ``generation`` or ``response``
+        span, and the input the agent ran on is the input of its first model
+        call. There is no tool result or conversation payload on this span to
+        read.
+        """
         name = getattr(span_data, "name", None)
         if name:
             attributes[C.ATTR_AGENT_NAME] = str(name)
         output_type = getattr(span_data, "output_type", None)
         if output_type:
             attributes[C.ATTR_AGENT_OUTPUT_TYPE] = str(output_type)
+        metadata = getattr(span_data, "metadata", None)
+        if metadata:
+            attributes[C.ATTR_AGENT_METADATA] = safe_serialize(metadata)
         if self.capture_tool_schemas:
             handoffs = getattr(span_data, "handoffs", None)
             if handoffs:
-                attributes[C.ATTR_AGENT_HANDOFFS] = to_serialisable(handoffs)
+                attributes[C.ATTR_AGENT_HANDOFFS] = safe_serialize(handoffs)
             tools = getattr(span_data, "tools", None)
             if tools:
-                attributes[C.ATTR_AGENT_TOOLS] = to_serialisable(tools)
+                attributes[C.ATTR_AGENT_TOOLS] = safe_serialize(tools)
+                try:
+                    attributes[C.ATTR_AGENT_TOOL_COUNT] = len(tools)
+                except TypeError:
+                    pass
 
     def _map_function(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        """Map a tool/function call: name, arguments, result, MCP provenance."""
         name = getattr(span_data, "name", None)
         if name:
             attributes[C.ATTR_TOOL_NAME] = str(name)
+        mcp_data = getattr(span_data, "mcp_data", None)
+        if mcp_data:
+            attributes[C.ATTR_TOOL_IS_MCP] = True
+            attributes[C.ATTR_TOOL_MCP_DATA] = safe_serialize(mcp_data)
         if self.capture_inputs:
             tool_input = getattr(span_data, "input", None)
             if tool_input is not None:
-                attributes[C.ATTR_TOOL_INPUT] = truncate_text(
-                    tool_input, C.MAX_TEXT_LENGTH
-                )
+                attributes[C.ATTR_TOOL_INPUT] = stringify(tool_input)
         if self.capture_outputs:
             tool_output = getattr(span_data, "output", None)
             if tool_output is not None:
-                attributes[C.ATTR_TOOL_OUTPUT] = truncate_text(
-                    tool_output, C.MAX_TEXT_LENGTH
-                )
+                attributes[C.ATTR_TOOL_OUTPUT] = stringify(tool_output)
 
     def _map_generation(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        """Map a Chat-Completions generation call."""
         model = getattr(span_data, "model", None)
         self._apply_model(model, attributes)
         self._apply_model_config(getattr(span_data, "model_config", None), attributes)
         self._apply_usage(model, getattr(span_data, "usage", None), attributes)
-        if self.capture_llm_messages:
-            llm_input = getattr(span_data, "input", None)
-            if llm_input is not None:
-                attributes[C.ATTR_LLM_INPUT] = to_serialisable(llm_input)
-            llm_output = getattr(span_data, "output", None)
-            if llm_output is not None:
-                attributes[C.ATTR_LLM_OUTPUT] = to_serialisable(llm_output)
+        if not self.capture_llm_messages:
+            return
+
+        llm_input = getattr(span_data, "input", None)
+        if llm_input is not None:
+            attributes[C.ATTR_LLM_INPUT] = safe_serialize(llm_input)
+            system_prompt = extract_system_prompt(llm_input)
+            if system_prompt:
+                attributes[C.ATTR_LLM_SYSTEM_PROMPT] = system_prompt
+            input_text = extract_message_text(llm_input)
+            if input_text:
+                attributes[C.ATTR_LLM_INPUT_TEXT] = input_text
+
+        llm_output = getattr(span_data, "output", None)
+        if llm_output is not None:
+            attributes[C.ATTR_LLM_OUTPUT] = safe_serialize(llm_output)
+            output_text = extract_message_text(llm_output, skip_system=False)
+            if output_text:
+                attributes[C.ATTR_LLM_OUTPUT_TEXT] = output_text
+            self._apply_tool_calls(extract_tool_calls(llm_output), attributes)
 
     def _map_response(self, span_data: Any, attributes: dict[str, Any]) -> None:
+        """Map a Responses-API call, including its tool schemas and reasoning."""
         response = getattr(span_data, "response", None)
         model = getattr(response, "model", None)
         self._apply_model(model, attributes)
@@ -395,19 +454,61 @@ class NoveumTraceProcessor(TracingProcessor):
         response_id = getattr(response, "id", None)
         if response_id:
             attributes[C.ATTR_LLM_REQUEST_ID] = str(response_id)
+
+        if response is not None:
+            self._apply_model_config(response, attributes)
+            status = getattr(response, "status", None)
+            if status:
+                attributes[C.ATTR_LLM_RESPONSE_STATUS] = str(status)
+            if self.capture_tool_schemas:
+                tools = getattr(response, "tools", None)
+                if tools:
+                    schemas = extract_tool_schemas(tools)
+                    if schemas:
+                        attributes[C.ATTR_LLM_AVAILABLE_TOOLS] = schemas
+                        attributes[C.ATTR_LLM_AVAILABLE_TOOL_COUNT] = len(schemas)
+
         # Response input/output are LLM messages, so they are gated on
         # ``capture_llm_messages`` (consistent with ``_map_generation``), not on
         # the tool-oriented ``capture_inputs`` / ``capture_outputs`` flags.
-        if self.capture_llm_messages:
-            response_input = getattr(span_data, "input", None)
-            if response_input is not None:
-                attributes[C.ATTR_LLM_INPUT] = to_serialisable(response_input)
-            if response is not None:
-                output_text = getattr(response, "output_text", None)
-                if output_text:
-                    attributes[C.ATTR_LLM_OUTPUT] = truncate_text(
-                        output_text, C.MAX_TEXT_LENGTH
-                    )
+        if not self.capture_llm_messages:
+            return
+
+        response_input = getattr(span_data, "input", None)
+        if response_input is not None:
+            attributes[C.ATTR_LLM_INPUT] = safe_serialize(response_input)
+            input_text = (
+                response_input
+                if isinstance(response_input, str)
+                else extract_message_text(response_input)
+            )
+            if input_text:
+                attributes[C.ATTR_LLM_INPUT_TEXT] = input_text
+
+        if response is None:
+            return
+        instructions = getattr(response, "instructions", None)
+        if instructions:
+            attributes[C.ATTR_LLM_SYSTEM_PROMPT] = (
+                instructions
+                if isinstance(instructions, str)
+                else stringify(safe_serialize(instructions))
+            )
+        output = extract_response_output(response)
+        if "text" in output:
+            attributes[C.ATTR_LLM_OUTPUT] = output["text"]
+            attributes[C.ATTR_LLM_OUTPUT_TEXT] = output["text"]
+        if "reasoning" in output:
+            attributes[C.ATTR_LLM_REASONING] = output["reasoning"]
+        self._apply_tool_calls(output.get("tool_calls") or [], attributes)
+
+    def _apply_tool_calls(
+        self, tool_calls: list[dict[str, Any]], attributes: dict[str, Any]
+    ) -> None:
+        if not tool_calls:
+            return
+        attributes[C.ATTR_LLM_TOOL_CALLS] = tool_calls
+        attributes[C.ATTR_LLM_TOOL_CALL_COUNT] = len(tool_calls)
 
     def _map_handoff(self, span_data: Any, attributes: dict[str, Any]) -> None:
         from_agent = getattr(span_data, "from_agent", None)
@@ -432,7 +533,7 @@ class NoveumTraceProcessor(TracingProcessor):
         if self.capture_inputs:
             data = getattr(span_data, "data", None)
             if data:
-                attributes[C.ATTR_CUSTOM_DATA] = to_serialisable(data)
+                attributes[C.ATTR_CUSTOM_DATA] = safe_serialize(data)
 
     def _map_mcp_tools(self, span_data: Any, attributes: dict[str, Any]) -> None:
         server = getattr(span_data, "server", None)
@@ -441,7 +542,11 @@ class NoveumTraceProcessor(TracingProcessor):
         if self.capture_tool_schemas:
             result = getattr(span_data, "result", None)
             if result:
-                attributes[C.ATTR_MCP_TOOLS] = to_serialisable(result)
+                attributes[C.ATTR_MCP_TOOLS] = safe_serialize(result)
+                try:
+                    attributes[C.ATTR_MCP_TOOL_COUNT] = len(result)
+                except TypeError:
+                    pass
 
     def _map_task_turn(self, span_data: Any, attributes: dict[str, Any]) -> None:
         self._apply_usage(None, getattr(span_data, "usage", None), attributes)
@@ -473,8 +578,18 @@ class NoveumTraceProcessor(TracingProcessor):
             attributes[C.ATTR_LLM_TOP_P] = config["top_p"]
         if "max_tokens" in config:
             attributes[C.ATTR_LLM_MAX_TOKENS] = config["max_tokens"]
+        if "reasoning_effort" in config:
+            attributes[C.ATTR_LLM_REASONING_EFFORT] = config["reasoning_effort"]
 
     def _apply_usage(self, model: Any, usage: Any, attributes: dict[str, Any]) -> None:
+        """
+        Attach token counts and estimated cost.
+
+        Covers the cache and reasoning breakdowns the SDK reports: generation
+        spans nest them under ``input_tokens_details`` / ``output_tokens_details``
+        while response, turn and task spans report the flat
+        ``cached_input_tokens`` / ``cache_write_input_tokens`` form.
+        """
         tokens = extract_usage_tokens(usage)
         if tokens["input_tokens"] is not None:
             attributes[C.ATTR_LLM_INPUT_TOKENS] = tokens["input_tokens"]
@@ -482,6 +597,15 @@ class NoveumTraceProcessor(TracingProcessor):
             attributes[C.ATTR_LLM_OUTPUT_TOKENS] = tokens["output_tokens"]
         if tokens["total_tokens"] is not None:
             attributes[C.ATTR_LLM_TOTAL_TOKENS] = tokens["total_tokens"]
+        if tokens["cached_input_tokens"] is not None:
+            attributes[C.ATTR_LLM_CACHED_INPUT_TOKENS] = tokens["cached_input_tokens"]
+            attributes[C.ATTR_LLM_CACHE_HIT] = tokens["cached_input_tokens"] > 0
+        if tokens["cache_write_input_tokens"] is not None:
+            attributes[C.ATTR_LLM_CACHE_WRITE_INPUT_TOKENS] = tokens[
+                "cache_write_input_tokens"
+            ]
+        if tokens["reasoning_tokens"] is not None:
+            attributes[C.ATTR_LLM_REASONING_TOKENS] = tokens["reasoning_tokens"]
         if self.capture_cost and model:
             cost = estimate_cost_safe(
                 str(model), tokens["input_tokens"], tokens["output_tokens"]
@@ -506,9 +630,9 @@ class NoveumTraceProcessor(TracingProcessor):
             message = getattr(error, "message", None) or str(error)
             data = getattr(error, "data", None)
         if message is not None:
-            attributes[C.ATTR_ERROR_MESSAGE] = truncate_text(message, C.MAX_TEXT_LENGTH)
+            attributes[C.ATTR_ERROR_MESSAGE] = stringify(message)
         if data:
-            attributes[C.ATTR_ERROR_DATA] = to_serialisable(data)
+            attributes[C.ATTR_ERROR_DATA] = safe_serialize(data)
         try:
             from noveum_trace.core.span import SpanStatus
 

--- a/src/noveum_trace/integrations/openai_agents/utils.py
+++ b/src/noveum_trace/integrations/openai_agents/utils.py
@@ -1,251 +1,305 @@
 """
 Utility helpers for the OpenAI Agents SDK integration.
 
+Framework-agnostic helpers (serialization, timestamps, provider derivation,
+token usage, cost) live in :mod:`noveum_trace.integrations._common` and are
+re-exported here. What remains below is specific to the shapes the Agents SDK
+puts on its ``SpanData`` objects: Chat-Completions message arrays and
+Responses-API output items.
+
 All helpers are zero-impact: every public function absorbs exceptions internally
 and returns a sensible default so a crashing utility can never break the host
 application or the surrounding ``agents`` run.
+
+Nothing here truncates. Payloads such as system prompts and tool results
+routinely exceed any fixed budget, and a clipped payload is not usable for
+evaluation or replay.
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from typing import Any, Optional
+
+from noveum_trace.integrations._common import (
+    coerce_datetime,
+    derive_provider,
+    estimate_cost_safe,
+    extract_usage_tokens,
+    probe,
+    safe_serialize,
+    stringify,
+)
 
 logger = logging.getLogger(__name__)
 
+__all__ = [
+    "coerce_datetime",
+    "coerce_iso_datetime",
+    "derive_provider",
+    "estimate_cost_safe",
+    "extract_message_text",
+    "extract_model_config",
+    "extract_response_output",
+    "extract_system_prompt",
+    "extract_tool_calls",
+    "extract_tool_schemas",
+    "extract_usage_tokens",
+    "safe_serialize",
+    "stringify",
+    "to_serialisable",
+]
 
-# ---------------------------------------------------------------------------
-# Timestamp coercion
-# ---------------------------------------------------------------------------
+# Backwards-compatible aliases for the names this module exported before the
+# shared helpers were hoisted into ``integrations._common``.
+coerce_iso_datetime = coerce_datetime
+to_serialisable = safe_serialize
 
-
-def coerce_iso_datetime(value: Any) -> Optional[datetime]:
-    """
-    Convert an OpenAI Agents ISO-8601 timestamp string to a ``datetime``.
-
-    The Agents SDK stores ``started_at`` / ``ended_at`` as ISO-8601 strings
-    (e.g. ``"2026-08-03T12:34:56.789012+00:00"``). Returns ``None`` when the
-    value is missing or unparseable so callers fall back to "now".
-    """
-    if value is None:
-        return None
-    if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        try:
-            return datetime.fromisoformat(value)
-        except ValueError:
-            return None
-    return None
-
-
-# ---------------------------------------------------------------------------
-# Provider derivation
-# ---------------------------------------------------------------------------
-
-_OPENAI_MODEL_PREFIXES = (
-    "gpt",
-    "o1",
-    "o3",
-    "o4",
-    "chatgpt",
-    "text-",
-    "davinci",
-    "babbage",
-)
-
-
-def derive_provider(model: Optional[str]) -> Optional[str]:
-    """
-    Best-effort provider name from a model string.
-
-    Returns ``"openai"`` / ``"anthropic"`` / ``"google"`` / ``"mistral"`` for
-    well-known prefixes, the left side of a LiteLLM ``"provider/model"`` string,
-    or ``None`` when the provider cannot be determined.
-    """
-    if not model or not isinstance(model, str):
-        return None
-    lowered = model.lower()
-    if any(lowered.startswith(prefix) for prefix in _OPENAI_MODEL_PREFIXES):
-        return "openai"
-    if lowered.startswith("claude"):
-        return "anthropic"
-    if lowered.startswith("gemini") or lowered.startswith("models/gemini"):
-        return "google"
-    if lowered.startswith(("mistral", "mixtral")):
-        return "mistral"
-    if "/" in lowered:
-        return lowered.split("/", 1)[0]
-    return None
+_SYSTEM_ROLES = frozenset({"system", "developer"})
 
 
 # ---------------------------------------------------------------------------
-# Safe serialization
+# Message / content extraction
 # ---------------------------------------------------------------------------
 
 
-def to_serialisable(value: Any, *, max_depth: int = 6) -> Any:
+def _content_to_text(content: Any) -> str:
     """
-    Recursively convert *value* into a JSON-serialisable structure.
+    Flatten a message ``content`` value to plain text.
 
-    Primitives pass through; dict/list/tuple recurse; Pydantic v2/v1 objects use
-    ``model_dump``/``dict``; objects with ``to_dict`` are converted; everything
-    else falls back to ``str``. Depth is capped to guard against deep graphs.
+    Content is either a bare string or a list of typed parts
+    (``{"type": "output_text", "text": ...}``, ``{"type": "input_text", ...}``,
+    ``{"type": "refusal", "refusal": ...}``). Non-text parts (images, audio) are
+    skipped — their payloads belong on dedicated attributes, not in the text.
     """
-    return _to_serialisable_inner(value, depth=0, max_depth=max_depth)
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (list, tuple)):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+                continue
+            text = probe(part, "text", "refusal")
+            if isinstance(text, str):
+                parts.append(text)
+        return "\n".join(p for p in parts if p)
+    text = probe(content, "text", "refusal")
+    return text if isinstance(text, str) else stringify(content)
 
 
-def _to_serialisable_inner(value: Any, depth: int, max_depth: int) -> Any:
-    if depth >= max_depth:
-        return f"<max_depth:{type(value).__name__}>"
+def _iter_messages(messages: Any) -> list[Any]:
+    if messages is None:
+        return []
+    if isinstance(messages, (list, tuple)):
+        return list(messages)
+    return [messages]
+
+
+def extract_system_prompt(messages: Any) -> Optional[str]:
+    """
+    Join the content of every ``system`` / ``developer`` message.
+
+    Returns ``None`` when the message array carries no system instructions.
+    """
     try:
-        if value is None or isinstance(value, (bool, int, float, str)):
-            return value
-        if isinstance(value, dict):
-            return {
-                str(k): _to_serialisable_inner(v, depth + 1, max_depth)
-                for k, v in value.items()
-            }
-        if isinstance(value, (list, tuple)):
-            return [
-                _to_serialisable_inner(item, depth + 1, max_depth) for item in value
-            ]
-        for method in ("model_dump", "dict"):
-            fn = getattr(value, method, None)
-            if callable(fn):
-                try:
-                    return _to_serialisable_inner(fn(), depth + 1, max_depth)
-                except Exception:
-                    pass
-        to_dict = getattr(value, "to_dict", None)
-        if callable(to_dict):
-            try:
-                return _to_serialisable_inner(to_dict(), depth + 1, max_depth)
-            except Exception:
-                pass
-        return str(value)
+        collected = [
+            _content_to_text(probe(message, "content"))
+            for message in _iter_messages(messages)
+            if str(probe(message, "role") or "").lower() in _SYSTEM_ROLES
+        ]
+        joined = "\n\n".join(part for part in collected if part)
+        return joined or None
     except Exception as exc:  # pragma: no cover - defensive
-        return f"<serialization_error:{type(value).__name__}:{exc}>"
-
-
-def truncate_text(text: Any, max_len: int = 8_192) -> str:
-    """Stringify *text* and truncate to *max_len* characters with an ellipsis."""
-    if not isinstance(text, str):
-        text = str(text)
-    if len(text) <= max_len:
-        return text
-    return text[:max_len] + "…"
-
-
-# ---------------------------------------------------------------------------
-# Token / cost extraction
-# ---------------------------------------------------------------------------
-
-
-def _coerce_int(value: Any) -> Optional[int]:
-    if value is None:
+        logger.debug("extract_system_prompt failed: %s", exc)
         return None
+
+
+def extract_message_text(messages: Any, *, skip_system: bool = True) -> Optional[str]:
+    """
+    Join the text content of a message array into a single string.
+
+    System/developer turns are skipped by default because they are reported
+    separately as ``llm.system_prompt``.
+    """
     try:
-        return int(value)
-    except (TypeError, ValueError):
+        collected: list[str] = []
+        for message in _iter_messages(messages):
+            role = str(probe(message, "role") or "").lower()
+            if skip_system and role in _SYSTEM_ROLES:
+                continue
+            text = _content_to_text(probe(message, "content"))
+            if text:
+                collected.append(f"{role}: {text}" if role else text)
+        joined = "\n\n".join(collected)
+        return joined or None
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_message_text failed: %s", exc)
         return None
 
 
-def _probe(source: Any, *keys: str) -> Any:
-    """Read *keys* from a dict or object, returning the first non-None value."""
-    for key in keys:
-        value: Any = None
-        if isinstance(source, dict):
-            value = source.get(key)
-        else:
-            value = getattr(source, key, None)
-        if value is not None:
-            return value
-    return None
+# ---------------------------------------------------------------------------
+# Tool calls / tool schemas
+# ---------------------------------------------------------------------------
 
 
-def extract_usage_tokens(usage: Any) -> dict[str, Optional[int]]:
+def _tool_call_entry(raw: Any) -> Optional[dict[str, Any]]:
+    """Normalise one Chat-Completions or Responses tool call to a flat dict."""
+    function = probe(raw, "function")
+    name = probe(function, "name") if function is not None else None
+    name = name if name is not None else probe(raw, "name")
+    arguments = probe(function, "arguments") if function is not None else None
+    arguments = arguments if arguments is not None else probe(raw, "arguments")
+    call_id = probe(raw, "call_id", "id")
+    if name is None and arguments is None:
+        return None
+    entry: dict[str, Any] = {"name": stringify(name) if name is not None else None}
+    if call_id is not None:
+        entry["call_id"] = stringify(call_id)
+    if arguments is not None:
+        entry["arguments"] = (
+            arguments if isinstance(arguments, str) else safe_serialize(arguments)
+        )
+    return entry
+
+
+def extract_tool_calls(output: Any) -> list[dict[str, Any]]:
     """
-    Normalise an Agents ``usage`` payload to input/output/total token counts.
+    Collect tool calls from a Chat-Completions ``output`` message array.
 
-    Accepts either the ``dict`` the SDK sets on generation/response spans (keys
-    ``input_tokens`` / ``output_tokens``) or a usage object exposing the same
-    attributes. Computes ``total_tokens`` when it is not supplied directly.
+    Handles both the ``message.tool_calls`` shape and Responses-style
+    ``function_call`` items appearing directly in the array.
     """
-    result: dict[str, Optional[int]] = {
-        "input_tokens": None,
-        "output_tokens": None,
-        "total_tokens": None,
-    }
-    if usage is None:
+    calls: list[dict[str, Any]] = []
+    try:
+        for item in _iter_messages(output):
+            item_type = str(probe(item, "type") or "")
+            if item_type in ("function_call", "custom_tool_call"):
+                entry = _tool_call_entry(item)
+                if entry is not None:
+                    calls.append(entry)
+                continue
+            for raw in _iter_messages(probe(item, "tool_calls")):
+                entry = _tool_call_entry(raw)
+                if entry is not None:
+                    calls.append(entry)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_tool_calls failed: %s", exc)
+    return calls
+
+
+def extract_tool_schemas(tools: Any) -> list[dict[str, Any]]:
+    """
+    Normalise a Responses ``response.tools`` list to ``{name, type, description}``.
+
+    Falls back to a serialised form for tool kinds that expose no name (hosted
+    tools such as ``web_search`` carry only a ``type``).
+    """
+    schemas: list[dict[str, Any]] = []
+    try:
+        for tool in _iter_messages(tools):
+            if isinstance(tool, str):
+                schemas.append({"name": tool})
+                continue
+            entry: dict[str, Any] = {}
+            name = probe(tool, "name")
+            if name is not None:
+                entry["name"] = stringify(name)
+            tool_type = probe(tool, "type")
+            if tool_type is not None:
+                entry["type"] = stringify(tool_type)
+            description = probe(tool, "description")
+            if description is not None:
+                entry["description"] = stringify(description)
+            parameters = probe(tool, "parameters")
+            if parameters is not None:
+                entry["parameters"] = safe_serialize(parameters)
+            schemas.append(entry or {"tool": safe_serialize(tool)})
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_tool_schemas failed: %s", exc)
+    return schemas
+
+
+# ---------------------------------------------------------------------------
+# Responses-API output items
+# ---------------------------------------------------------------------------
+
+
+def extract_response_output(response: Any) -> dict[str, Any]:
+    """
+    Split a Responses ``response.output`` item list into its useful parts.
+
+    Returns a dict with ``text`` (assistant message text), ``tool_calls``
+    (function-call items) and ``reasoning`` (reasoning summaries). Missing
+    pieces are omitted rather than reported as empty.
+    """
+    result: dict[str, Any] = {}
+    if response is None:
         return result
     try:
-        result["input_tokens"] = _coerce_int(
-            _probe(usage, "input_tokens", "prompt_tokens")
-        )
-        result["output_tokens"] = _coerce_int(
-            _probe(usage, "output_tokens", "completion_tokens")
-        )
-        result["total_tokens"] = _coerce_int(_probe(usage, "total_tokens"))
-        if (
-            result["total_tokens"] is None
-            and result["input_tokens"] is not None
-            and result["output_tokens"] is not None
-        ):
-            result["total_tokens"] = result["input_tokens"] + result["output_tokens"]
+        items = _iter_messages(probe(response, "output"))
+        texts: list[str] = []
+        reasoning: list[str] = []
+        for item in items:
+            item_type = str(probe(item, "type") or "")
+            if item_type == "message":
+                text = _content_to_text(probe(item, "content"))
+                if text:
+                    texts.append(text)
+            elif item_type == "reasoning":
+                for entry in _iter_messages(probe(item, "summary")):
+                    text = probe(entry, "text")
+                    if isinstance(text, str) and text:
+                        reasoning.append(text)
+
+        output_text = probe(response, "output_text")
+        if isinstance(output_text, str) and output_text:
+            result["text"] = output_text
+        elif texts:
+            result["text"] = "\n\n".join(texts)
+
+        tool_calls = extract_tool_calls(items)
+        if tool_calls:
+            result["tool_calls"] = tool_calls
+        if reasoning:
+            result["reasoning"] = "\n\n".join(reasoning)
     except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("extract_usage_tokens failed: %s", exc)
+        logger.debug("extract_response_output failed: %s", exc)
     return result
 
 
+# ---------------------------------------------------------------------------
+# Model configuration
+# ---------------------------------------------------------------------------
+
+
 def extract_model_config(model_config: Any) -> dict[str, Any]:
-    """Pull common sampling parameters (temperature/top_p/max_tokens) from a config."""
+    """
+    Pull sampling parameters and reasoning effort from a generation's config.
+
+    ``model_config`` is ``ModelSettings.to_traceable_dict()`` plus ``base_url``;
+    it carries no tool list, so available tools are read from the enclosing
+    agent span (``agent.tools``) or from ``response.tools``.
+    """
     params: dict[str, Any] = {}
     if not model_config:
         return params
     try:
-        temperature = _probe(model_config, "temperature")
+        temperature = probe(model_config, "temperature")
         if temperature is not None:
             params["temperature"] = temperature
-        top_p = _probe(model_config, "top_p")
+        top_p = probe(model_config, "top_p")
         if top_p is not None:
             params["top_p"] = top_p
-        max_tokens = _probe(model_config, "max_tokens", "max_output_tokens")
+        max_tokens = probe(model_config, "max_tokens", "max_output_tokens")
         if max_tokens is not None:
             params["max_tokens"] = max_tokens
+        reasoning = probe(model_config, "reasoning")
+        effort = probe(reasoning, "effort") if reasoning is not None else None
+        if effort is not None:
+            params["reasoning_effort"] = stringify(effort)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("extract_model_config failed: %s", exc)
     return params
-
-
-def estimate_cost_safe(
-    model: Optional[str],
-    input_tokens: Optional[int],
-    output_tokens: Optional[int],
-) -> dict[str, Any]:
-    """
-    Estimate LLM cost via ``noveum_trace.utils.llm_utils.estimate_cost``.
-
-    Returns a dict with ``input`` / ``output`` / ``total`` / ``currency`` keys, or
-    an empty dict on any failure so callers can safely ``.get(...)``.
-    """
-    if not model:
-        return {}
-    try:
-        from noveum_trace.utils.llm_utils import estimate_cost
-
-        cost_info = estimate_cost(
-            model,
-            input_tokens=int(input_tokens or 0),
-            output_tokens=int(output_tokens or 0),
-        )
-        return {
-            "input": cost_info.get("input_cost", 0.0),
-            "output": cost_info.get("output_cost", 0.0),
-            "total": cost_info.get("total_cost", 0.0),
-            "currency": cost_info.get("currency", "USD"),
-        }
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("estimate_cost_safe failed for model=%s: %s", model, exc)
-        return {}

--- a/src/noveum_trace/integrations/openai_agents/utils.py
+++ b/src/noveum_trace/integrations/openai_agents/utils.py
@@ -1,0 +1,251 @@
+"""
+Utility helpers for the OpenAI Agents SDK integration.
+
+All helpers are zero-impact: every public function absorbs exceptions internally
+and returns a sensible default so a crashing utility can never break the host
+application or the surrounding ``agents`` run.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Timestamp coercion
+# ---------------------------------------------------------------------------
+
+
+def coerce_iso_datetime(value: Any) -> Optional[datetime]:
+    """
+    Convert an OpenAI Agents ISO-8601 timestamp string to a ``datetime``.
+
+    The Agents SDK stores ``started_at`` / ``ended_at`` as ISO-8601 strings
+    (e.g. ``"2026-08-03T12:34:56.789012+00:00"``). Returns ``None`` when the
+    value is missing or unparseable so callers fall back to "now".
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider derivation
+# ---------------------------------------------------------------------------
+
+_OPENAI_MODEL_PREFIXES = (
+    "gpt",
+    "o1",
+    "o3",
+    "o4",
+    "chatgpt",
+    "text-",
+    "davinci",
+    "babbage",
+)
+
+
+def derive_provider(model: Optional[str]) -> Optional[str]:
+    """
+    Best-effort provider name from a model string.
+
+    Returns ``"openai"`` / ``"anthropic"`` / ``"google"`` / ``"mistral"`` for
+    well-known prefixes, the left side of a LiteLLM ``"provider/model"`` string,
+    or ``None`` when the provider cannot be determined.
+    """
+    if not model or not isinstance(model, str):
+        return None
+    lowered = model.lower()
+    if any(lowered.startswith(prefix) for prefix in _OPENAI_MODEL_PREFIXES):
+        return "openai"
+    if lowered.startswith("claude"):
+        return "anthropic"
+    if lowered.startswith("gemini") or lowered.startswith("models/gemini"):
+        return "google"
+    if lowered.startswith(("mistral", "mixtral")):
+        return "mistral"
+    if "/" in lowered:
+        return lowered.split("/", 1)[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Safe serialization
+# ---------------------------------------------------------------------------
+
+
+def to_serialisable(value: Any, *, max_depth: int = 6) -> Any:
+    """
+    Recursively convert *value* into a JSON-serialisable structure.
+
+    Primitives pass through; dict/list/tuple recurse; Pydantic v2/v1 objects use
+    ``model_dump``/``dict``; objects with ``to_dict`` are converted; everything
+    else falls back to ``str``. Depth is capped to guard against deep graphs.
+    """
+    return _to_serialisable_inner(value, depth=0, max_depth=max_depth)
+
+
+def _to_serialisable_inner(value: Any, depth: int, max_depth: int) -> Any:
+    if depth >= max_depth:
+        return f"<max_depth:{type(value).__name__}>"
+    try:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, dict):
+            return {
+                str(k): _to_serialisable_inner(v, depth + 1, max_depth)
+                for k, v in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [
+                _to_serialisable_inner(item, depth + 1, max_depth) for item in value
+            ]
+        for method in ("model_dump", "dict"):
+            fn = getattr(value, method, None)
+            if callable(fn):
+                try:
+                    return _to_serialisable_inner(fn(), depth + 1, max_depth)
+                except Exception:
+                    pass
+        to_dict = getattr(value, "to_dict", None)
+        if callable(to_dict):
+            try:
+                return _to_serialisable_inner(to_dict(), depth + 1, max_depth)
+            except Exception:
+                pass
+        return str(value)
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"<serialization_error:{type(value).__name__}:{exc}>"
+
+
+def truncate_text(text: Any, max_len: int = 8_192) -> str:
+    """Stringify *text* and truncate to *max_len* characters with an ellipsis."""
+    if not isinstance(text, str):
+        text = str(text)
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "…"
+
+
+# ---------------------------------------------------------------------------
+# Token / cost extraction
+# ---------------------------------------------------------------------------
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _probe(source: Any, *keys: str) -> Any:
+    """Read *keys* from a dict or object, returning the first non-None value."""
+    for key in keys:
+        value: Any = None
+        if isinstance(source, dict):
+            value = source.get(key)
+        else:
+            value = getattr(source, key, None)
+        if value is not None:
+            return value
+    return None
+
+
+def extract_usage_tokens(usage: Any) -> dict[str, Optional[int]]:
+    """
+    Normalise an Agents ``usage`` payload to input/output/total token counts.
+
+    Accepts either the ``dict`` the SDK sets on generation/response spans (keys
+    ``input_tokens`` / ``output_tokens``) or a usage object exposing the same
+    attributes. Computes ``total_tokens`` when it is not supplied directly.
+    """
+    result: dict[str, Optional[int]] = {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+    }
+    if usage is None:
+        return result
+    try:
+        result["input_tokens"] = _coerce_int(
+            _probe(usage, "input_tokens", "prompt_tokens")
+        )
+        result["output_tokens"] = _coerce_int(
+            _probe(usage, "output_tokens", "completion_tokens")
+        )
+        result["total_tokens"] = _coerce_int(_probe(usage, "total_tokens"))
+        if (
+            result["total_tokens"] is None
+            and result["input_tokens"] is not None
+            and result["output_tokens"] is not None
+        ):
+            result["total_tokens"] = result["input_tokens"] + result["output_tokens"]
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_usage_tokens failed: %s", exc)
+    return result
+
+
+def extract_model_config(model_config: Any) -> dict[str, Any]:
+    """Pull common sampling parameters (temperature/top_p/max_tokens) from a config."""
+    params: dict[str, Any] = {}
+    if not model_config:
+        return params
+    try:
+        temperature = _probe(model_config, "temperature")
+        if temperature is not None:
+            params["temperature"] = temperature
+        top_p = _probe(model_config, "top_p")
+        if top_p is not None:
+            params["top_p"] = top_p
+        max_tokens = _probe(model_config, "max_tokens", "max_output_tokens")
+        if max_tokens is not None:
+            params["max_tokens"] = max_tokens
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_model_config failed: %s", exc)
+    return params
+
+
+def estimate_cost_safe(
+    model: Optional[str],
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+) -> dict[str, Any]:
+    """
+    Estimate LLM cost via ``noveum_trace.utils.llm_utils.estimate_cost``.
+
+    Returns a dict with ``input`` / ``output`` / ``total`` / ``currency`` keys, or
+    an empty dict on any failure so callers can safely ``.get(...)``.
+    """
+    if not model:
+        return {}
+    try:
+        from noveum_trace.utils.llm_utils import estimate_cost
+
+        cost_info = estimate_cost(
+            model,
+            input_tokens=int(input_tokens or 0),
+            output_tokens=int(output_tokens or 0),
+        )
+        return {
+            "input": cost_info.get("input_cost", 0.0),
+            "output": cost_info.get("output_cost", 0.0),
+            "total": cost_info.get("total_cost", 0.0),
+            "currency": cost_info.get("currency", "USD"),
+        }
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("estimate_cost_safe failed for model=%s: %s", model, exc)
+        return {}

--- a/src/noveum_trace/integrations/openai_agents/utils.py
+++ b/src/noveum_trace/integrations/openai_agents/utils.py
@@ -280,8 +280,9 @@ def extract_model_config(model_config: Any) -> dict[str, Any]:
     Pull sampling parameters and reasoning effort from a generation's config.
 
     ``model_config`` is ``ModelSettings.to_traceable_dict()`` plus ``base_url``;
-    it carries no tool list, so available tools are read from the enclosing
-    agent span (``agent.tools``) or from ``response.tools``.
+    it carries no tool list, so no tool attributes are emitted here. Tool names
+    live on the enclosing agent span (``agent.tools``) and full schemas on
+    response spans (``llm.available_tools``).
     """
     params: dict[str, Any] = {}
     if not model_config:

--- a/tests/unit/integrations/test_openai_agents_processor.py
+++ b/tests/unit/integrations/test_openai_agents_processor.py
@@ -271,6 +271,37 @@ class TestCaptureFlags:
         assert ("llm.input" in nspan.attributes) is capture
         assert ("llm.output" in nspan.attributes) is capture
 
+    def test_response_llm_content_gated_by_llm_messages(self) -> None:
+        # Response-span input/output are LLM content, gated on
+        # capture_llm_messages — NOT on capture_inputs / capture_outputs.
+        response = SimpleNamespace(
+            model="gpt-4o", id="resp_1", usage=None, output_text="the answer"
+        )
+        sd = SimpleNamespace(type="response", response=response, input="the prompt")
+
+        # capture_inputs/outputs on, capture_llm_messages off -> no LLM content
+        client = _make_client()
+        proc = NoveumTraceProcessor(
+            client=client, capture_inputs=True, capture_outputs=True
+        )
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+        assert nspan.attributes["llm.model"] == "gpt-4o"
+        assert "llm.input" not in nspan.attributes
+        assert "llm.output" not in nspan.attributes
+
+        # capture_llm_messages on -> LLM content captured
+        client2 = _make_client()
+        proc2 = NoveumTraceProcessor(client=client2, capture_llm_messages=True)
+        proc2.on_trace_start(_oai_trace())
+        proc2.on_span_start(_oai_span("s2", sd))
+        nspan2 = proc2._spans["s2"]
+        proc2.on_span_end(_oai_span("s2", sd))
+        assert nspan2.attributes["llm.input"] == "the prompt"
+        assert nspan2.attributes["llm.output"] == "the answer"
+
 
 # ---------------------------------------------------------------------------
 # Errors, flush, shutdown, resilience

--- a/tests/unit/integrations/test_openai_agents_processor.py
+++ b/tests/unit/integrations/test_openai_agents_processor.py
@@ -121,13 +121,30 @@ class TestConstruction:
         assert hasattr(processor_module, "OPENAI_AGENTS_AVAILABLE")
         assert callable(NoveumTraceProcessor)
 
-    def test_privacy_safe_defaults(self) -> None:
+    def test_captures_everything_by_default(self) -> None:
         proc = NoveumTraceProcessor()
+        assert proc.capture_inputs is True
+        assert proc.capture_outputs is True
+        assert proc.capture_llm_messages is True
+        assert proc.capture_tool_schemas is True
+        assert proc.capture_trace_metadata is True
+        assert proc.capture_cost is True
+
+    def test_capture_flags_can_be_disabled(self) -> None:
+        proc = NoveumTraceProcessor(
+            capture_inputs=False,
+            capture_outputs=False,
+            capture_llm_messages=False,
+            capture_tool_schemas=False,
+            capture_trace_metadata=False,
+            capture_cost=False,
+        )
         assert proc.capture_inputs is False
         assert proc.capture_outputs is False
         assert proc.capture_llm_messages is False
-        assert proc.capture_tool_schemas is True
-        assert proc.capture_trace_metadata is True
+        assert proc.capture_tool_schemas is False
+        assert proc.capture_trace_metadata is False
+        assert proc.capture_cost is False
 
 
 # ---------------------------------------------------------------------------
@@ -282,7 +299,10 @@ class TestCaptureFlags:
         # capture_inputs/outputs on, capture_llm_messages off -> no LLM content
         client = _make_client()
         proc = NoveumTraceProcessor(
-            client=client, capture_inputs=True, capture_outputs=True
+            client=client,
+            capture_inputs=True,
+            capture_outputs=True,
+            capture_llm_messages=False,
         )
         proc.on_trace_start(_oai_trace())
         proc.on_span_start(_oai_span("s1", sd))
@@ -376,3 +396,287 @@ class TestSetupFactory:
         else:
             with pytest.raises(ImportError):
                 setup_openai_agents_tracing(api_key="x")
+
+
+# ---------------------------------------------------------------------------
+# Full-payload capture (no truncation, richer LLM/agent/tool attributes)
+# ---------------------------------------------------------------------------
+
+
+class TestFullPayloadCapture:
+    def test_long_payloads_are_not_truncated(self) -> None:
+        huge = "x" * 50_000
+        sd = SimpleNamespace(type="function", name="tool", input=huge, output=huge)
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        assert nspan.attributes["tool.input"] == huge
+        assert nspan.attributes["tool.output"] == huge
+        assert "…" not in nspan.attributes["tool.output"]
+
+    def test_long_system_prompt_survives_intact(self) -> None:
+        prompt = "system instructions " * 2_000
+        sd = SimpleNamespace(
+            type="generation",
+            model="gpt-4o",
+            model_config=None,
+            usage=None,
+            input=[
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": "hi"},
+            ],
+            output=[{"role": "assistant", "content": "hello"}],
+        )
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        assert nspan.attributes["llm.system_prompt"] == prompt
+        assert nspan.attributes["llm.input_text"] == "user: hi"
+        assert nspan.attributes["llm.output_text"] == "assistant: hello"
+
+    def test_generation_captures_tool_calls(self) -> None:
+        sd = SimpleNamespace(
+            type="generation",
+            model="gpt-4o",
+            model_config={"temperature": 0.2, "reasoning": {"effort": "high"}},
+            usage=None,
+            input=[{"role": "user", "content": "weather?"}],
+            output=[
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Paris"}',
+                            },
+                        }
+                    ],
+                }
+            ],
+        )
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        assert nspan.attributes["llm.tool_call_count"] == 1
+        assert nspan.attributes["llm.tool_calls"][0]["name"] == "get_weather"
+        assert nspan.attributes["llm.tool_calls"][0]["arguments"] == '{"city":"Paris"}'
+        assert nspan.attributes["llm.temperature"] == 0.2
+        assert nspan.attributes["llm.reasoning_effort"] == "high"
+
+    def test_generation_captures_cache_and_reasoning_tokens(self) -> None:
+        sd = SimpleNamespace(
+            type="generation",
+            model="gpt-4o",
+            model_config=None,
+            input=None,
+            output=None,
+            usage={
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "total_tokens": 120,
+                "input_tokens_details": {
+                    "cached_tokens": 64,
+                    "cache_write_tokens": 8,
+                },
+                "output_tokens_details": {"reasoning_tokens": 12},
+            },
+        )
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        assert nspan.attributes["llm.cached_input_tokens"] == 64
+        assert nspan.attributes["llm.cache_write_input_tokens"] == 8
+        assert nspan.attributes["llm.reasoning_tokens"] == 12
+        assert nspan.attributes["llm.cache_hit"] is True
+
+    def test_response_span_flat_cache_usage(self) -> None:
+        response = SimpleNamespace(
+            model="gpt-4o", id="resp_1", usage=None, output_text="ok", output=[]
+        )
+        sd = SimpleNamespace(
+            type="response",
+            response=response,
+            input=None,
+            usage={
+                "input_tokens": 10,
+                "output_tokens": 2,
+                "total_tokens": 12,
+                "cached_input_tokens": 0,
+                "cache_write_input_tokens": 0,
+            },
+        )
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        assert nspan.attributes["llm.cached_input_tokens"] == 0
+        assert nspan.attributes["llm.cache_hit"] is False
+
+    def test_response_span_captures_instructions_tools_and_reasoning(self) -> None:
+        response = SimpleNamespace(
+            model="gpt-4o",
+            id="resp_1",
+            usage=None,
+            status="completed",
+            temperature=0.5,
+            top_p=1.0,
+            max_output_tokens=512,
+            instructions="You are a helpful weather bot.",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "description": "Look up weather",
+                    "parameters": {"type": "object"},
+                }
+            ],
+            output=[
+                {"type": "reasoning", "summary": [{"text": "The user wants weather."}]},
+                {
+                    "type": "function_call",
+                    "name": "get_weather",
+                    "call_id": "call_1",
+                    "arguments": '{"city":"Paris"}',
+                },
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "It is sunny."}],
+                },
+            ],
+            output_text="It is sunny.",
+        )
+        sd = SimpleNamespace(type="response", response=response, input="weather?")
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        attrs = nspan.attributes
+        assert attrs["llm.system_prompt"] == "You are a helpful weather bot."
+        assert attrs["llm.available_tool_count"] == 1
+        assert attrs["llm.available_tools"][0]["name"] == "get_weather"
+        assert attrs["llm.tool_calls"][0]["call_id"] == "call_1"
+        assert attrs["llm.reasoning"] == "The user wants weather."
+        assert attrs["llm.output_text"] == "It is sunny."
+        assert attrs["llm.response_status"] == "completed"
+        assert attrs["llm.temperature"] == 0.5
+        assert attrs["llm.max_tokens"] == 512
+
+    def test_agent_span_captures_metadata_and_tool_count(self) -> None:
+        sd = SimpleNamespace(
+            type="agent",
+            name="Weather agent",
+            handoffs=["billing"],
+            tools=["get_weather", "get_forecast"],
+            output_type="str",
+            metadata={"team": "growth"},
+        )
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        assert nspan.attributes["agent.tool_count"] == 2
+        assert nspan.attributes["agent.metadata"] == {"team": "growth"}
+
+    def test_function_span_flags_mcp_tool_calls(self) -> None:
+        sd = SimpleNamespace(
+            type="function",
+            name="search",
+            input="{}",
+            output="result",
+            mcp_data={"server": "docs"},
+        )
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        proc.on_span_start(_oai_span("s1", sd))
+        nspan = proc._spans["s1"]
+        proc.on_span_end(_oai_span("s1", sd))
+
+        assert nspan.attributes["tool.is_mcp"] is True
+        assert nspan.attributes["tool.mcp_data"] == {"server": "docs"}
+
+
+# ---------------------------------------------------------------------------
+# Parent resolution
+# ---------------------------------------------------------------------------
+
+
+class TestParentResolution:
+    def test_child_uses_openai_parent_id(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+
+        parent_sd = SimpleNamespace(type="agent", name="A")
+        child_sd = SimpleNamespace(type="function", name="t", input=None, output=None)
+        proc.on_span_start(_oai_span("p1", parent_sd))
+        parent_noveum_id = proc._spans["p1"].span_id
+        proc.on_span_start(_oai_span("c1", child_sd, parent_id="p1"))
+
+        assert proc._spans["c1"].parent_span_id == parent_noveum_id
+
+    def test_child_starting_after_parent_ends_keeps_parentage(self) -> None:
+        # Parent lookup must survive the parent span closing: the openai-id to
+        # noveum-id map lives for the whole trace, not just while the parent
+        # span object is open.
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+
+        parent_sd = SimpleNamespace(type="agent", name="A")
+        child_sd = SimpleNamespace(type="function", name="t", input=None, output=None)
+        proc.on_span_start(_oai_span("p1", parent_sd))
+        parent_noveum_id = proc._spans["p1"].span_id
+        proc.on_span_end(_oai_span("p1", parent_sd))
+
+        proc.on_span_start(_oai_span("c1", child_sd, parent_id="p1"))
+        assert proc._spans["c1"].parent_span_id == parent_noveum_id
+
+    def test_unknown_parent_falls_back_to_trace_root(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        sd = SimpleNamespace(type="function", name="t", input=None, output=None)
+        proc.on_span_start(_oai_span("c1", sd, parent_id="never-seen"))
+        assert proc._spans["c1"].parent_span_id is None
+
+    def test_trace_end_clears_span_id_map(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        trace = _oai_trace()
+        proc.on_trace_start(trace)
+        sd = SimpleNamespace(type="agent", name="A")
+        proc.on_span_start(_oai_span("p1", sd))
+        proc.on_trace_end(trace)
+
+        assert proc._noveum_span_ids == {}
+        assert proc._trace_span_ids == {}
+        assert proc._spans == {}

--- a/tests/unit/integrations/test_openai_agents_processor.py
+++ b/tests/unit/integrations/test_openai_agents_processor.py
@@ -9,6 +9,7 @@ optional ``openai-agents`` dependency installed.
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -19,6 +20,7 @@ _src = Path(__file__).parents[3] / "src"
 if str(_src) not in sys.path:
     sys.path.insert(0, str(_src))
 
+from noveum_trace.integrations._common import coerce_datetime  # noqa: E402
 from noveum_trace.integrations.openai_agents import (  # noqa: E402
     processor as processor_module,
 )
@@ -680,3 +682,46 @@ class TestParentResolution:
         assert proc._noveum_span_ids == {}
         assert proc._trace_span_ids == {}
         assert proc._spans == {}
+
+
+# ---------------------------------------------------------------------------
+# Timestamp coercion
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampCoercion:
+    @pytest.mark.parametrize(
+        "value",
+        ["2026-08-03T12:00:00Z", "2026-08-03T12:00:00z", "2026-08-03T12:00:00+00:00"],
+    )
+    def test_utc_designator_forms_are_equivalent(self, value: str) -> None:
+        # ``datetime.fromisoformat`` only accepts a trailing ``Z`` on 3.11+, so
+        # without normalisation this silently returns None on 3.9/3.10.
+        parsed = coerce_datetime(value)
+        assert parsed == datetime(2026, 8, 3, 12, 0, tzinfo=timezone.utc)
+
+    def test_unparseable_string_returns_none(self) -> None:
+        assert coerce_datetime("not-a-timestamp") is None
+        assert coerce_datetime("Z") is None
+
+    def test_z_timestamps_preserve_span_timing(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+
+        sd = SimpleNamespace(type="agent", name="A")
+        span = _oai_span(
+            "s1",
+            sd,
+            started_at="2026-08-03T12:00:00Z",
+            ended_at="2026-08-03T12:00:01Z",
+        )
+        proc.on_span_start(span)
+        noveum_span = proc._spans["s1"]
+        proc.on_span_end(span)
+
+        start_time = client._trace.create_span.call_args.kwargs["start_time"]
+        assert start_time == datetime(2026, 8, 3, 12, 0, 0, tzinfo=timezone.utc)
+        noveum_span.finish.assert_called_once_with(
+            datetime(2026, 8, 3, 12, 0, 1, tzinfo=timezone.utc)
+        )

--- a/tests/unit/integrations/test_openai_agents_processor.py
+++ b/tests/unit/integrations/test_openai_agents_processor.py
@@ -1,0 +1,347 @@
+"""
+Unit tests for the OpenAI Agents SDK trace processor.
+
+These tests fake the OpenAI Agents ``Trace`` / ``Span`` payloads and the Noveum
+client, so the suite runs on every supported Python version *without* the
+optional ``openai-agents`` dependency installed.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+_src = Path(__file__).parents[3] / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from noveum_trace.integrations.openai_agents import (  # noqa: E402
+    processor as processor_module,
+)
+from noveum_trace.integrations.openai_agents.processor import (  # noqa: E402
+    NoveumTraceProcessor,
+    setup_openai_agents_tracing,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes — Noveum side
+# ---------------------------------------------------------------------------
+
+
+def _make_noveum_span(span_id: str, trace_id: str = "ntrace-1") -> MagicMock:
+    span = MagicMock()
+    span.span_id = span_id
+    span.trace_id = trace_id
+    span.attributes = {}
+    span.set_attributes = MagicMock(
+        side_effect=lambda attrs: span.attributes.update(attrs)
+    )
+    span.set_status = MagicMock()
+    span.finish = MagicMock()
+    span.is_finished = MagicMock(return_value=False)
+    return span
+
+
+def _make_noveum_trace(trace_id: str = "ntrace-1") -> MagicMock:
+    trace = MagicMock()
+    trace.trace_id = trace_id
+    counter = {"n": 0}
+
+    def _create_span(name, parent_span_id=None, attributes=None, start_time=None):
+        counter["n"] += 1
+        span = _make_noveum_span(f"nspan-{counter['n']}", trace_id=trace_id)
+        span.name = name
+        span.parent_span_id = parent_span_id
+        if attributes:
+            span.attributes.update(attributes)
+        return span
+
+    trace.create_span = MagicMock(side_effect=_create_span)
+    trace.finish = MagicMock()
+    return trace
+
+
+def _make_client(trace_id: str = "ntrace-1") -> MagicMock:
+    client = MagicMock()
+    trace = _make_noveum_trace(trace_id)
+    client.start_trace = MagicMock(return_value=trace)
+    client.finish_trace = MagicMock()
+    client.flush = MagicMock()
+    client._trace = trace
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Fakes — OpenAI Agents side
+# ---------------------------------------------------------------------------
+
+
+def _oai_trace(
+    trace_id: str = "oai-trace-1",
+    name: str = "my-workflow",
+    group_id=None,
+    metadata=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        trace_id=trace_id, name=name, group_id=group_id, metadata=metadata
+    )
+
+
+def _oai_span(
+    span_id: str,
+    span_data,
+    trace_id: str = "oai-trace-1",
+    parent_id=None,
+    started_at: str = "2026-08-03T12:00:00+00:00",
+    ended_at: str = "2026-08-03T12:00:01+00:00",
+    error=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        span_id=span_id,
+        trace_id=trace_id,
+        parent_id=parent_id,
+        started_at=started_at,
+        ended_at=ended_at,
+        error=error,
+        span_data=span_data,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_module_imports_without_optional_dependency(self) -> None:
+        assert hasattr(processor_module, "OPENAI_AGENTS_AVAILABLE")
+        assert callable(NoveumTraceProcessor)
+
+    def test_privacy_safe_defaults(self) -> None:
+        proc = NoveumTraceProcessor()
+        assert proc.capture_inputs is False
+        assert proc.capture_outputs is False
+        assert proc.capture_llm_messages is False
+        assert proc.capture_tool_schemas is True
+        assert proc.capture_trace_metadata is True
+
+
+# ---------------------------------------------------------------------------
+# Trace / span mapping
+# ---------------------------------------------------------------------------
+
+
+class TestTraceMapping:
+    def test_on_trace_start_opens_noveum_trace(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace(name="wf", group_id="g1"))
+
+        client.start_trace.assert_called_once()
+        kwargs = client.start_trace.call_args.kwargs
+        assert kwargs["name"] == "wf"
+        assert kwargs["set_as_current"] is False
+        assert kwargs["attributes"]["openai_agents.workflow_name"] == "wf"
+        assert kwargs["attributes"]["openai_agents.group_id"] == "g1"
+
+    def test_on_trace_end_finishes_and_exports(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        oai = _oai_trace()
+        proc.on_trace_start(oai)
+        proc.on_trace_end(oai)
+        client.finish_trace.assert_called_once_with(client._trace)
+
+    def test_unnamed_workflow_uses_prefix(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace(name=""))
+        assert client.start_trace.call_args.kwargs["name"] == "openai_agents.workflow"
+
+
+class TestSpanMapping:
+    def test_parent_child_linkage(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+
+        parent_sd = SimpleNamespace(
+            type="agent", name="triage", handoffs=None, tools=None, output_type=None
+        )
+        proc.on_span_start(_oai_span("oai-parent", parent_sd))
+
+        child_sd = SimpleNamespace(
+            type="generation",
+            model="gpt-4o",
+            usage={"input_tokens": 1, "output_tokens": 2},
+        )
+        proc.on_span_start(_oai_span("oai-child", child_sd, parent_id="oai-parent"))
+
+        trace = client._trace
+        assert trace.create_span.call_count == 2
+        parent_call = trace.create_span.call_args_list[0]
+        child_call = trace.create_span.call_args_list[1]
+        assert parent_call.kwargs["parent_span_id"] is None
+        assert child_call.kwargs["parent_span_id"] == "nspan-1"
+
+    def test_generation_attributes_mapped(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+
+        sd = SimpleNamespace(
+            type="generation",
+            model="gpt-4o",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            model_config={"temperature": 0.7, "top_p": 0.9},
+        )
+        span = _oai_span("s1", sd)
+        proc.on_span_start(span)
+        nspan = proc._spans["s1"]
+        proc.on_span_end(span)
+
+        assert nspan.attributes["llm.model"] == "gpt-4o"
+        assert nspan.attributes["llm.provider"] == "openai"
+        assert nspan.attributes["llm.input_tokens"] == 10
+        assert nspan.attributes["llm.output_tokens"] == 5
+        assert nspan.attributes["llm.total_tokens"] == 15
+        assert nspan.attributes["llm.temperature"] == 0.7
+        assert nspan.attributes["openai_agents.status"] == "ok"
+        nspan.finish.assert_called_once()
+
+    def test_handoff_attributes_mapped(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        sd = SimpleNamespace(type="handoff", from_agent="triage", to_agent="billing")
+        span = _oai_span("s1", sd)
+        proc.on_span_start(span)
+        nspan = proc._spans["s1"]
+        proc.on_span_end(span)
+        assert nspan.attributes["handoff.from_agent"] == "triage"
+        assert nspan.attributes["handoff.to_agent"] == "billing"
+
+
+# ---------------------------------------------------------------------------
+# Capture flags (privacy)
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureFlags:
+    @pytest.mark.parametrize("capture", [False, True])
+    def test_function_io_gated_by_flags(self, capture: bool) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(
+            client=client, capture_inputs=capture, capture_outputs=capture
+        )
+        proc.on_trace_start(_oai_trace())
+        sd = SimpleNamespace(
+            type="function", name="get_weather", input='{"city":"SF"}', output="sunny"
+        )
+        span = _oai_span("s1", sd)
+        proc.on_span_start(span)
+        nspan = proc._spans["s1"]
+        proc.on_span_end(span)
+
+        assert nspan.attributes["tool.name"] == "get_weather"
+        assert ("tool.input" in nspan.attributes) is capture
+        assert ("tool.output" in nspan.attributes) is capture
+
+    @pytest.mark.parametrize("capture", [False, True])
+    def test_llm_messages_gated_by_flag(self, capture: bool) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client, capture_llm_messages=capture)
+        proc.on_trace_start(_oai_trace())
+        sd = SimpleNamespace(
+            type="generation",
+            model="gpt-4o",
+            usage=None,
+            input=[{"role": "user", "content": "hi"}],
+            output=[{"role": "assistant", "content": "hello"}],
+        )
+        span = _oai_span("s1", sd)
+        proc.on_span_start(span)
+        nspan = proc._spans["s1"]
+        proc.on_span_end(span)
+
+        assert ("llm.input" in nspan.attributes) is capture
+        assert ("llm.output" in nspan.attributes) is capture
+
+
+# ---------------------------------------------------------------------------
+# Errors, flush, shutdown, resilience
+# ---------------------------------------------------------------------------
+
+
+class TestErrorsAndLifecycle:
+    def test_span_error_sets_status(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+        proc.on_trace_start(_oai_trace())
+        sd = SimpleNamespace(type="function", name="boom", input=None, output=None)
+        span = _oai_span("s1", sd, error={"message": "kaboom", "data": {"k": "v"}})
+        proc.on_span_start(span)
+        nspan = proc._spans["s1"]
+        proc.on_span_end(span)
+
+        assert nspan.attributes["openai_agents.status"] == "error"
+        assert nspan.attributes["error.message"] == "kaboom"
+        nspan.set_status.assert_called_once()
+
+    def test_force_flush_and_shutdown(self) -> None:
+        client = _make_client()
+        proc = NoveumTraceProcessor(client=client)
+
+        proc.force_flush()
+        assert client.flush.call_count == 1
+
+        proc.shutdown()
+        assert proc._is_shutdown is True
+        assert client.flush.call_count == 2
+
+        client.flush.reset_mock()
+        proc.force_flush()
+        client.flush.assert_not_called()
+
+    def test_handlers_never_raise(self) -> None:
+        proc = NoveumTraceProcessor(client=_make_client())
+        # Span callbacks for an unknown trace must be silent no-ops.
+        proc.on_span_start(
+            SimpleNamespace(
+                trace_id="unknown",
+                span_id="y",
+                parent_id=None,
+                started_at=None,
+                ended_at=None,
+                error=None,
+                span_data=None,
+            )
+        )
+        proc.on_span_end(
+            SimpleNamespace(span_id="y", ended_at=None, span_data=None, error=None)
+        )
+        proc.on_trace_end(SimpleNamespace(trace_id="unknown"))
+
+    def test_client_failure_is_non_fatal(self) -> None:
+        boom = MagicMock()
+        boom.start_trace.side_effect = RuntimeError("nope")
+        proc = NoveumTraceProcessor(client=boom)
+        proc.on_trace_start(_oai_trace())  # must not raise
+
+    def test_uninitialised_sdk_is_noop(self) -> None:
+        proc = NoveumTraceProcessor()  # no client; global SDK not initialised
+        proc.on_trace_start(_oai_trace())  # must not raise
+
+
+class TestSetupFactory:
+    def test_setup_rejects_api_key(self) -> None:
+        if processor_module.OPENAI_AGENTS_AVAILABLE:
+            with pytest.raises(TypeError):
+                setup_openai_agents_tracing(api_key="x")
+        else:
+            with pytest.raises(ImportError):
+                setup_openai_agents_tracing(api_key="x")


### PR DESCRIPTION
# Pull Request

## Description

Adds a **net-new OpenAI Agents SDK integration** so Noveum can trace `agents`
runs. `NoveumTraceProcessor` implements `agents.tracing.TracingProcessor` and
mirrors every OpenAI Agents **trace** as a Noveum trace and every **span**
(agent, generation, response, function/tool, handoff, guardrail, MCP tools,
custom, task/turn) as a Noveum span, preserving parent-child ordering.

Highlights:
- Maps `gen_ai`-compatible attributes inline (`llm.model`, `llm.provider`,
  `llm.input_tokens`/`output_tokens`/`total_tokens`, `llm.cost.*`, `tool.*`,
  `agent.*`, `handoff.*`, `guardrail.*`) so the existing `otel_compat` crosswalk
  lights up automatically. No `gen_ai.*` keys are emitted directly.
- **Privacy-safe defaults**: raw payloads (tool I/O, LLM messages) are opt-in via
  `capture_inputs` / `capture_outputs` / `capture_llm_messages`; structural
  metadata (names, model, token usage, cost, latency, errors) is always captured.
- `setup_openai_agents_tracing()` convenience factory registers the processor
  (`add_trace_processor`, or `set_trace_processors` via `replace_processors=True`).
- Optional dependency stays optional: `import noveum_trace` works without the
  extra (module uses a fallback base-class stub), and the top-level export is
  gated on the `agents` package being importable.
- All processor callbacks are non-fatal — failures are logged at debug level and
  never propagate into the host agent run.

Verified upstream interface: `openai-agents` **0.19.2** — `TracingProcessor`
abstract hooks `on_trace_start`/`on_trace_end`/`on_span_start`/`on_span_end`/
`shutdown`/`force_flush`; `Trace.trace_id`/`name`/`group_id`/`metadata`;
`Span.span_id`/`trace_id`/`parent_id`/`started_at`/`ended_at`/`span_data`/`error`;
ISO-8601 timestamps; `usage = {"input_tokens", "output_tokens"}`.

Fixes # (NOVEU-275 — OpenAI Agents adapter)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test improvements

## How Has This Been Tested?

- [x] Unit tests — `tests/unit/integrations/test_openai_agents_processor.py`
  (18 tests) fake the OpenAI Agents trace/span payloads and the Noveum client;
  they run **without** the `openai-agents` extra installed.
- [x] Manual testing — verified the processor subclasses the real
  `agents.tracing.TracingProcessor` (all six abstract methods implemented) and
  that the unit suite passes with the real `openai-agents==0.19.2` installed.

Not run: a live end-to-end agent run (requires an OpenAI API key + network).

## Test Configuration

* Python version: 3.13 (target matrix: 3.10–3.13 for this extra)
* Operating System: macOS (CI matrix: ubuntu/windows/macos)
* Dependencies: `openai-agents>=0.19.2` (optional extra); core needs none

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

`pre-commit run` (black 25.1.0, isort 6.0.1, ruff 0.12.3, mypy 1.13.0, bandit)
passes on the changed files; `mypy src/noveum_trace/` is clean.

## Additional Notes

- **Draft** — not for merge yet. Opened per NOVEU-275 P2 to review the adapter
  interface independently from the LlamaIndex adapter.
- CI integration matrix: this adds no dedicated live-run leg (openai-agents needs
  Python 3.10+, so it cannot install on the 3.9 unit legs). The unit tests are
  dependency-light and run on the full matrix as-is. Happy to add a 3.10+
  `integration-test` leg that installs `.[openai-agents]` if desired.
- `docs/integrations/upstream.md` is not on `main` yet (it lives on the P0
  `docs/upstream-submission-plan` branch), so this PR does not touch it. The
  OpenAI Agents support-matrix row can be added when that doc merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OpenAI Agents SDK tracing integration for Python 3.10 and newer.
  * Captures agent, tool, model, handoff, guardrail, task, and error activity with configurable privacy controls.
  * Supports automatic setup, processor registration or replacement, usage tracking, cost estimation, and resilient processing.
  * Added a weather-agent integration example.

* **Documentation**
  * Added installation, configuration, privacy, compatibility, troubleshooting, and usage guidance, including payload and capture behavior.

* **Tests**
  * Added comprehensive coverage for tracing, privacy, error handling, lifecycle behavior, and setup validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an optional OpenAI Agents SDK trace processor that maps SDK traces and spans into Noveum while supporting configurable payload capture and processor registration.
- Adds lifecycle-safe trace/span mapping, attribute extraction, token normalization, and cost estimation.
- Exposes the integration conditionally when the optional `openai-agents` dependency is installed.
- Adds unit coverage, CI installation on supported Python versions, documentation, and an example agent.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the supplied follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/noveum_trace/integrations/openai_agents/processor.py | Implements the processor lifecycle, concurrent trace/span bookkeeping, payload controls, attribute mapping, and registration helper without an eligible follow-up defect. |
| src/noveum_trace/integrations/_common.py | Adds defensive shared helpers for serialization, timestamps, provider inference, usage normalization, span operations, and cost estimation. |
| src/noveum_trace/integrations/openai_agents/utils.py | Adds extraction helpers for model configuration, messages, outputs, tool calls, and schemas. |
| tests/unit/integrations/test_openai_agents_processor.py | Covers processor mapping, privacy flags, lifecycle behavior, registration, cleanup, and optional-dependency operation. |
| pyproject.toml | Adds the optional OpenAI Agents dependency for supported Python versions and corresponding typing overrides. |
| .github/workflows/tests.yml | Installs the real OpenAI Agents SDK on Python 3.10 and newer so CI exercises the upstream processor interface. |
| docs/OPENAI_AGENTS_INTEGRATION.md | Documents installation, registration, mappings, payload controls, compatibility, lifecycle handling, and troubleshooting. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as OpenAI Agents SDK
    participant P as NoveumTraceProcessor
    participant T as Noveum Trace/Span
    participant B as Noveum Backend
    SDK->>P: on_trace_start(trace)
    P->>T: start_trace(...)
    SDK->>P: on_span_start(span)
    P->>T: create_span(parent_span_id)
    SDK->>P: on_span_end(span)
    P->>T: map attributes and finish span
    SDK->>P: on_trace_end(trace)
    P->>T: finish remaining spans and trace
    T->>B: export serialized trace
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: parse RFC 3339 Z timestamps and cor..."](https://github.com/noveum/noveum-trace/commit/ccdef8229bcc70994449a4dbf647ac70c944c857) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50351103)</sub>

<!-- /greptile_comment -->