### PR TITLE
feat: add LlamaIndex instrumentation integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
           pip install livekit livekit-agents
+          # llama-index-core is pure-Python and installs on 3.9-3.13, so the
+          # LlamaIndex handler unit tests run on the full matrix.
+          pip install "llama-index-core>=0.11,<1.0"
 
       - name: Run unit tests with coverage
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
           pip install livekit livekit-agents
-          # llama-index-core is pure-Python and installs on 3.9-3.13, so the
-          # LlamaIndex handler unit tests run on the full matrix.
-          pip install "llama-index-core>=0.11,<1.0"
+
+      - name: Install llama-index-core (Python 3.10+)
+        # llama-index-core requires Python 3.10+ (its transitive `banks` dep uses
+        # 3.10 union syntax). On 3.9 the LlamaIndex handler tests skip via
+        # importorskip; on 3.10+ they run against the real package.
+        if: matrix.python-version != '3.9'
+        run: pip install "llama-index-core>=0.11,<1.0"
 
       - name: Run unit tests with coverage
         run: |

--- a/docs/LLAMAINDEX_INTEGRATION.md
+++ b/docs/LLAMAINDEX_INTEGRATION.md
@@ -1,0 +1,132 @@
+# LlamaIndex Integration Guide
+
+Trace [LlamaIndex](https://docs.llamaindex.ai/) query pipelines with Noveum. The
+integration registers **span** and **event** handlers on LlamaIndex's modern
+instrumentation dispatcher (`llama_index.core.instrumentation`) and mirrors every
+operation — query engines, retrievers, synthesizers, LLM calls, embedding calls,
+rerankers — as a Noveum trace/span, preserving the parent-child hierarchy that
+LlamaIndex threads through its `active_span_id` context variable.
+
+## Prerequisites
+
+- Python 3.9+
+- A Noveum project + API key
+- `llama-index-core >= 0.11`
+
+## Installation
+
+```bash
+pip install "noveum-trace[llamaindex]"
+```
+
+## Quick start
+
+### 1. Initialize the SDK
+
+```python
+import noveum_trace
+
+noveum_trace.init(project="my-project", api_key="...")
+```
+
+### 2. Register the handlers
+
+```python
+from noveum_trace.integrations.llamaindex import setup_llamaindex_tracing
+
+setup_llamaindex_tracing()
+```
+
+### 3. Build and query your index
+
+```python
+from llama_index.core import Document, VectorStoreIndex
+
+index = VectorStoreIndex.from_documents([Document(text="...")])
+response = index.as_query_engine().query("...")
+
+noveum_trace.flush()  # export buffered traces before exit
+```
+
+`setup_llamaindex_tracing()` attaches to the **root** dispatcher, so all
+LlamaIndex activity is traced. Each top-level operation (e.g. a query) opens a new
+Noveum trace; nested operations become child spans under it.
+
+## What gets traced
+
+| LlamaIndex activity | Noveum span type | Key attributes |
+| --- | --- | --- |
+| Query engine (`.query`) | `query` | `query.text`\*, `query.response`\* |
+| Retriever (`.retrieve`) | `retrieval` | `retrieval.node_count`, `retrieval.scores`, `retrieval.nodes`\* |
+| Synthesizer | `synthesize` | — |
+| LLM (`chat`/`complete`/`predict`) | `llm` | `llm.model`, `llm.provider`, `llm.input_tokens`, `llm.output_tokens`, `llm.total_tokens`, `llm.input`\*, `llm.output`\* |
+| Embedding | `embedding` | `embedding.model`, `embedding.chunk_count`, `embedding.vector_count` |
+| Reranker / node postprocessor | `rerank` | `rerank.model`, `rerank.top_n`, `rerank.input_node_count`, `rerank.output_node_count` |
+
+\* Captured only when the corresponding capture flag is enabled.
+
+Every span also carries `llamaindex.operation` (the `Class.method` name) and
+`llamaindex.span_type`.
+
+## Configuration options and privacy
+
+All options are accepted by `setup_llamaindex_tracing(...)`:
+
+| Option | Default | Captures |
+| --- | --- | --- |
+| `capture_inputs` | `False` | Query / retrieval query text |
+| `capture_outputs` | `False` | Response text and retrieved node content |
+| `capture_llm_messages` | `False` | Full LLM prompt/response message arrays |
+| `client` | global | Explicit Noveum client instead of the initialized global |
+| `trace_name_prefix` | `"llamaindex"` | Prefix used when an operation name is unavailable |
+| `dispatcher` | root | Dispatcher to register on (defaults to `get_dispatcher()`) |
+
+**Privacy-safe by default.** Raw payloads that may contain sensitive data — query
+text, retrieved document content, and LLM message content — are **not** captured
+unless you opt in. Structural metadata that is always captured: operation name,
+span type, model name and provider, token usage, node counts and similarity
+scores, embedding counts, and error type/message.
+
+```python
+# Capture full payloads (e.g. in a trusted dev environment)
+setup_llamaindex_tracing(
+    capture_inputs=True,
+    capture_outputs=True,
+    capture_llm_messages=True,
+)
+```
+
+## Version compatibility
+
+| Component | Supported |
+| --- | --- |
+| `llama-index-core` | `>= 0.11, < 1.0` |
+| Python | `>= 3.9` |
+
+The integration targets the stable `llama_index.core.instrumentation` dispatcher
+(available since 0.10.x). Handlers read event/span fields defensively, so newer
+event types are recorded generically rather than raising.
+
+## Resilience
+
+Failures inside the handlers (a mapping error, an unreachable Noveum backend) are
+logged at debug level and never propagate. LlamaIndex additionally swallows
+handler exceptions in its dispatcher, so tracing can never break a query.
+
+## Troubleshooting
+
+- **No traces appear:** confirm `noveum_trace.init(...)` ran before
+  `setup_llamaindex_tracing()`, and call `noveum_trace.flush()` before exit.
+- **Query text / node content missing:** these are opt-in; enable
+  `capture_inputs` / `capture_outputs` / `capture_llm_messages`.
+- **Token counts missing:** LlamaIndex exposes usage on the provider-native
+  `response.raw`; some LLM integrations do not populate it.
+
+## Example script
+
+See [`docs/examples/llamaindex_integration_example.py`](examples/llamaindex_integration_example.py).
+
+## Next steps
+
+- [LlamaIndex docs](https://docs.llamaindex.ai/)
+- [LlamaIndex instrumentation docs](https://docs.llamaindex.ai/en/stable/module_guides/observability/instrumentation/)

--- a/docs/LLAMAINDEX_INTEGRATION.md
+++ b/docs/LLAMAINDEX_INTEGRATION.md
@@ -9,7 +9,7 @@ LlamaIndex threads through its `active_span_id` context variable.
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.10+ (required by current `llama-index-core`)
 - A Noveum project + API key
 - `llama-index-core >= 0.11`
 
@@ -101,7 +101,7 @@ setup_llamaindex_tracing(
 | Component | Supported |
 | --- | --- |
 | `llama-index-core` | `>= 0.11, < 1.0` |
-| Python | `>= 3.9` |
+| Python | `>= 3.10` (required by current `llama-index-core`) |
 
 The integration targets the stable `llama_index.core.instrumentation` dispatcher
 (available since 0.10.x). Handlers read event/span fields defensively, so newer

--- a/docs/LLAMAINDEX_INTEGRATION.md
+++ b/docs/LLAMAINDEX_INTEGRATION.md
@@ -57,17 +57,66 @@ Noveum trace; nested operations become child spans under it.
 
 | LlamaIndex activity | Noveum span type | Key attributes |
 | --- | --- | --- |
-| Query engine (`.query`) | `query` | `query.text`\*, `query.response`\* |
-| Retriever (`.retrieve`) | `retrieval` | `retrieval.node_count`, `retrieval.scores`, `retrieval.nodes`\* |
-| Synthesizer | `synthesize` | — |
-| LLM (`chat`/`complete`/`predict`) | `llm` | `llm.model`, `llm.provider`, `llm.input_tokens`, `llm.output_tokens`, `llm.total_tokens`, `llm.input`\*, `llm.output`\* |
-| Embedding | `embedding` | `embedding.model`, `embedding.chunk_count`, `embedding.vector_count` |
-| Reranker / node postprocessor | `rerank` | `rerank.model`, `rerank.top_n`, `rerank.input_node_count`, `rerank.output_node_count` |
+| Query engine (`.query`) | `query` | `query.text`, `query.response`, `query.source_nodes` |
+| Retriever (`.retrieve`) | `retrieval` | `retrieval.query`, `retrieval.top_k`, `retrieval.node_count`, `retrieval.scores`, `retrieval.nodes` |
+| Synthesizer | `synthesize` | — (the work shows up on the nested `llm` span) |
+| LLM (`chat`/`complete`/`predict`) | `llm` | `llm.model`, `llm.provider`, `llm.system_prompt`, `llm.input`, `llm.output`, `llm.available_tools`, `llm.available_tool_count`, `llm.tool_calls`, `llm.tool_call_count`, `llm.input_tokens`, `llm.output_tokens`, `llm.total_tokens`, `llm.cached_input_tokens`, `llm.reasoning_tokens`, `llm.cost.*` |
+| Agent tool call | (on the enclosing span) | `tool.name`, `tool.description`, `tool.input` |
+| Embedding | `embedding` | `embedding.model`, `embedding.chunk_count`, `embedding.vector_count`, `embedding.dimensions`, `embedding.chunks`† |
+| Reranker / node postprocessor | `rerank` | `rerank.model`, `rerank.top_n`, `rerank.query`, `rerank.input_node_count`, `rerank.output_node_count`, `rerank.input_nodes`, `rerank.output_nodes`, `rerank.input_scores`, `rerank.output_scores` |
 
-\* Captured only when the corresponding capture flag is enabled.
+† `embedding.chunks` requires `capture_embedding_chunks=True` — see
+[Embedding capture](#embedding-capture).
 
 Every span also carries `llamaindex.operation` (the `Class.method` name) and
 `llamaindex.span_type`.
+
+### What a "node" contains
+
+A LlamaIndex **node** is one chunk of a source document — the unit the index
+stores, the retriever returns and the synthesizer reads. `retrieval.nodes`,
+`query.source_nodes` and the two `rerank.*_nodes` attributes are lists of:
+
+```json
+{
+  "id": "a8c7c8e0-…",
+  "score": 0.83,
+  "text": "Paris is the capital of France. …",
+  "metadata": {"file_name": "france.md", "page_label": "2"}
+}
+```
+
+`text` is the node's **full chunk content**, untruncated — the actual passage
+the model was given, so a trace can be replayed or turned into an evaluation
+example. `metadata` carries whatever the loader attached (source file, page,
+custom tags), which is how a retrieved chunk is traced back to its document.
+`score` is the retriever's own similarity/distance for that hit.
+
+### Retrieval scores and top-k
+
+`retrieval.scores` is the ordered list of top-k similarity scores, best match
+first — the distances for the closest hits. `retrieval.top_k` is the configured
+`similarity_top_k`, read off the retriever instance (the retrieval events
+themselves do not carry it).
+
+The **total number of vectors in the vector store** is not available: LlamaIndex's
+instrumentation reports per-call activity, not index statistics, and no event or
+retriever attribute exposes a collection count. Getting it would mean querying
+the vector store directly, which the tracing layer deliberately does not do.
+What is recorded per embedding call is `embedding.vector_count` (vectors produced
+by that call) and `embedding.dimensions` (vector width).
+
+### Reranking
+
+Both sides of a rerank are captured, not just counts: `rerank.input_nodes` /
+`rerank.input_scores` are what went in, `rerank.output_nodes` /
+`rerank.output_scores` are the reranked result, so the reordering is directly
+comparable.
+
+For an **LLM-backed reranker** (`LLMRerank` and friends), the scoring prompt runs
+through the dispatcher as a nested `llm` span. Its reasoning is captured there as
+`llm.output` — the rerank events themselves carry only node lists, so the model's
+justification lives on the child span rather than on the `rerank` span.
 
 ## Configuration options and privacy
 
@@ -75,27 +124,50 @@ All options are accepted by `setup_llamaindex_tracing(...)`:
 
 | Option | Default | Captures |
 | --- | --- | --- |
-| `capture_inputs` | `False` | Query / retrieval query text |
-| `capture_outputs` | `False` | Response text and retrieved node content |
-| `capture_llm_messages` | `False` | Full LLM prompt/response message arrays |
+| `capture_inputs` | `True` | Query text, retrieval/rerank query text, rerank input nodes, agent tool arguments |
+| `capture_outputs` | `True` | Response text, retrieved node content, query source nodes, reranked output nodes |
+| `capture_llm_messages` | `True` | Full LLM prompt/response messages, system prompts, available tool schemas |
+| `capture_cost` | `True` | Estimated LLM cost from model + token counts |
+| `capture_embedding_chunks` | `False` | The text being embedded (see below) |
 | `client` | global | Explicit Noveum client instead of the initialized global |
 | `trace_name_prefix` | `"llamaindex"` | Prefix used when an operation name is unavailable |
 | `dispatcher` | root | Dispatcher to register on (defaults to `get_dispatcher()`) |
 
-**Privacy-safe by default.** Raw payloads that may contain sensitive data — query
-text, retrieved document content, and LLM message content — are **not** captured
-unless you opt in. Structural metadata that is always captured: operation name,
-span type, model name and provider, token usage, node counts and similarity
-scores, embedding counts, and error type/message.
+**Everything is captured by default**, matching the other Noveum integrations —
+a RAG trace without the query, the retrieved chunks and the synthesized answer
+cannot be replayed, debugged or turned into an evaluation dataset. Set any flag
+to `False` to reduce what is sent:
 
 ```python
-# Capture full payloads (e.g. in a trusted dev environment)
+# Reduce what leaves the process
 setup_llamaindex_tracing(
-    capture_inputs=True,
-    capture_outputs=True,
-    capture_llm_messages=True,
+    capture_inputs=False,
+    capture_outputs=False,
+    capture_llm_messages=False,
 )
 ```
+
+**Payloads are never truncated.** Prompts, retrieved node text and synthesized
+answers routinely run past any fixed character budget, and a clipped node is
+useless for evaluation, so they are recorded in full.
+
+### Embedding capture
+
+`capture_embedding_chunks` is the one flag that defaults to **off**, and it is
+deliberately separate from `capture_inputs`.
+
+Indexing a corpus emits one embedding call per batch, so capturing the chunk
+*text* on embedding spans copies the entire source corpus into the trace store —
+fine for a small index you want to build evaluation datasets from, expensive for
+a large production one. Turn it on when you need the embedded text; leave it off
+for bulk indexing.
+
+Either way you still get `embedding.chunk_count`, `embedding.vector_count` and
+`embedding.dimensions`. The **embedding vectors themselves are never attached** to
+a span under any setting: a float array is not readable in a trace viewer and not
+useful to an evaluation. Note that retrieved chunk text is a separate matter —
+that arrives on `retrieval.nodes` under `capture_outputs`, and is bounded by
+top-k rather than by corpus size.
 
 ## Version compatibility
 
@@ -121,10 +193,15 @@ handler exceptions in its dispatcher, so tracing can never break a query.
   no explicit `client=` is given). For short-lived processes, call
   `noveum_trace.flush()` then `noveum_trace.shutdown()` before exit — `flush()`
   sends buffered traces and `shutdown()` releases SDK resources.
-- **Query text / node content missing:** these are opt-in; enable
-  `capture_inputs` / `capture_outputs` / `capture_llm_messages`.
+- **Query text / node content missing:** these are on by default; check that
+  `capture_inputs` / `capture_outputs` / `capture_llm_messages` were not disabled.
 - **Token counts missing:** LlamaIndex exposes usage on the provider-native
   `response.raw`; some LLM integrations do not populate it.
+- **Cost missing:** cost is derived from the model name on the start event plus
+  the token counts on the end event — if either is absent (as with `MockLLM`, or
+  a model the registry does not price), no cost attributes are written.
+- **Embedded text missing:** `capture_embedding_chunks` is opt-in; see
+  [Embedding capture](#embedding-capture).
 
 ## Example script
 

--- a/docs/LLAMAINDEX_INTEGRATION.md
+++ b/docs/LLAMAINDEX_INTEGRATION.md
@@ -45,7 +45,8 @@ from llama_index.core import Document, VectorStoreIndex
 index = VectorStoreIndex.from_documents([Document(text="...")])
 response = index.as_query_engine().query("...")
 
-noveum_trace.flush()  # export buffered traces before exit
+noveum_trace.flush()     # export buffered traces
+noveum_trace.shutdown()  # release SDK resources at application termination
 ```
 
 `setup_llamaindex_tracing()` attaches to the **root** dispatcher, so all
@@ -116,7 +117,10 @@ handler exceptions in its dispatcher, so tracing can never break a query.
 ## Troubleshooting
 
 - **No traces appear:** confirm `noveum_trace.init(...)` ran before
-  `setup_llamaindex_tracing()`, and call `noveum_trace.flush()` before exit.
+  `setup_llamaindex_tracing()` (it now raises if the SDK is not initialized and
+  no explicit `client=` is given). For short-lived processes, call
+  `noveum_trace.flush()` then `noveum_trace.shutdown()` before exit — `flush()`
+  sends buffered traces and `shutdown()` releases SDK resources.
 - **Query text / node content missing:** these are opt-in; enable
   `capture_inputs` / `capture_outputs` / `capture_llm_messages`.
 - **Token counts missing:** LlamaIndex exposes usage on the provider-native

--- a/docs/LLAMAINDEX_INTEGRATION.md
+++ b/docs/LLAMAINDEX_INTEGRATION.md
@@ -94,10 +94,13 @@ custom tags), which is how a retrieved chunk is traced back to its document.
 
 ### Retrieval scores and top-k
 
-`retrieval.scores` is the ordered list of top-k similarity scores, best match
-first — the distances for the closest hits. `retrieval.top_k` is the configured
-`similarity_top_k`, read off the retriever instance (the retrieval events
-themselves do not carry it).
+`retrieval.scores` is the list of per-node scores exactly as the retriever
+returned them, in the retriever's own order. What a score *means* — cosine
+similarity, inner product, an L2 distance, a fused rank — and whether higher or
+lower is better depends on the retriever and the underlying vector store, so the
+integration records the values verbatim rather than normalizing or re-sorting
+them. `retrieval.top_k` is the configured `similarity_top_k`, read off the
+retriever instance (the retrieval events themselves do not carry it).
 
 The **total number of vectors in the vector store** is not available: LlamaIndex's
 instrumentation reports per-call activity, not index statistics, and no event or
@@ -125,8 +128,8 @@ All options are accepted by `setup_llamaindex_tracing(...)`:
 | Option | Default | Captures |
 | --- | --- | --- |
 | `capture_inputs` | `True` | Query text, retrieval/rerank query text, rerank input nodes, agent tool arguments |
-| `capture_outputs` | `True` | Response text, retrieved node content, query source nodes, reranked output nodes |
-| `capture_llm_messages` | `True` | Full LLM prompt/response messages, system prompts, available tool schemas |
+| `capture_outputs` | `True` | LLM response text (`llm.output`), query response text, retrieved node content, query source nodes, reranked output nodes |
+| `capture_llm_messages` | `True` | LLM prompt messages (`llm.input`), system prompts, available tool schemas |
 | `capture_cost` | `True` | Estimated LLM cost from model + token counts |
 | `capture_embedding_chunks` | `False` | The text being embedded (see below) |
 | `client` | global | Explicit Noveum client instead of the initialized global |

--- a/docs/examples/llamaindex_integration_example.py
+++ b/docs/examples/llamaindex_integration_example.py
@@ -32,9 +32,10 @@ def main() -> None:
         api_key=os.environ.get("NOVEUM_API_KEY"),
     )
 
-    # Capture outputs is opt-in (privacy-safe defaults); enable it so the example
-    # traces include the answer text and retrieved node content.
-    setup_llamaindex_tracing(capture_outputs=True)
+    # Everything is captured by default — query text, retrieved node content and
+    # the synthesized answer. capture_embedding_chunks is the one opt-in: it adds
+    # the text being embedded, which on a large corpus is a lot of data.
+    setup_llamaindex_tracing()
 
     documents = [
         Document(text="Noveum provides AI tracing and observability for LLM apps."),

--- a/docs/examples/llamaindex_integration_example.py
+++ b/docs/examples/llamaindex_integration_example.py
@@ -1,0 +1,54 @@
+"""
+Example: trace a LlamaIndex query pipeline with Noveum.
+
+Install the integration extra (plus the LlamaIndex readers/LLM you use)::
+
+    pip install "noveum-trace[llamaindex]" llama-index
+
+Provide credentials and run::
+
+    export NOVEUM_API_KEY=...
+    export OPENAI_API_KEY=...
+    python docs/examples/llamaindex_integration_example.py
+
+``setup_llamaindex_tracing`` registers span + event handlers on LlamaIndex's
+instrumentation dispatcher, so every query engine, retriever, synthesizer, LLM,
+and embedding call is mirrored as a Noveum trace/span — no other code changes.
+"""
+
+from __future__ import annotations
+
+import os
+
+from llama_index.core import Document, VectorStoreIndex
+
+import noveum_trace
+from noveum_trace.integrations.llamaindex import setup_llamaindex_tracing
+
+
+def main() -> None:
+    noveum_trace.init(
+        project="llamaindex-example",
+        api_key=os.environ.get("NOVEUM_API_KEY"),
+    )
+
+    # Capture outputs is opt-in (privacy-safe defaults); enable it so the example
+    # traces include the answer text and retrieved node content.
+    setup_llamaindex_tracing(capture_outputs=True)
+
+    documents = [
+        Document(text="Noveum provides AI tracing and observability for LLM apps."),
+        Document(text="LlamaIndex builds retrieval-augmented generation pipelines."),
+    ]
+    index = VectorStoreIndex.from_documents(documents)
+
+    query_engine = index.as_query_engine()
+    response = query_engine.query("What does Noveum do?")
+    print(response)
+
+    # Flush buffered traces before the process exits.
+    noveum_trace.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/llamaindex_integration_example.py
+++ b/docs/examples/llamaindex_integration_example.py
@@ -40,14 +40,15 @@ def main() -> None:
         Document(text="Noveum provides AI tracing and observability for LLM apps."),
         Document(text="LlamaIndex builds retrieval-augmented generation pipelines."),
     ]
-    index = VectorStoreIndex.from_documents(documents)
 
-    query_engine = index.as_query_engine()
-    response = query_engine.query("What does Noveum do?")
-    print(response)
-
-    # Flush buffered traces before the process exits.
-    noveum_trace.flush()
+    try:
+        index = VectorStoreIndex.from_documents(documents)
+        response = index.as_query_engine().query("What does Noveum do?")
+        print(response)
+    finally:
+        # Flush buffered traces and release SDK resources, even on failure.
+        noveum_trace.flush()
+        noveum_trace.shutdown()
 
 
 if __name__ == "__main__":

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -188,11 +188,12 @@ observer also exposes `capture_text=True` (LLM/TTS text) and
 
 All default `True`, matching the other capture-by-default integrations:
 `capture_inputs` (query / retrieval / rerank query text, rerank input nodes,
-agent tool arguments), `capture_outputs` (response text, retrieved node content,
-query source nodes, reranked output nodes), `capture_llm_messages` (full LLM
-prompt/response messages, system prompts, available tool schemas), and
+agent tool arguments), `capture_outputs` (LLM response text, query response text,
+retrieved node content, query source nodes, reranked output nodes),
+`capture_llm_messages` (LLM prompt messages, system prompts, available tool
+schemas — *not* LLM responses, which follow `capture_outputs`), and
 `capture_cost`. Non-capture default: `trace_name_prefix="llamaindex"`. Model
-name, token usage, node counts and similarity scores, configured `top_k`,
+name, token usage, node counts and retriever-reported scores, configured `top_k`,
 embedding counts and vector width, and errors are always captured. Payloads are
 not truncated.
 

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -21,13 +21,14 @@ released package.
 |-----------|-----------|---------------|---------------|-----------------|
 | LangChain | `noveum_trace.integrations.langchain` (also re-exported at package root) | `langchain` | `NoveumTraceCallbackHandler` | Community-maintained observability integration (callback handler). No upstream PR yet. |
 | LangGraph | `noveum_trace.integrations.langchain` (same handler) | `langchain` (no separate `langgraph` extra) | `NoveumTraceCallbackHandler` (optionally `use_langchain_assigned_parent=True`) | Community-maintained observability integration (callback handler). No upstream PR yet. |
+| LlamaIndex | `noveum_trace.integrations.llamaindex` (also re-exported at package root) | `llamaindex` | `setup_llamaindex_tracing()` | Community-maintained observability integration (instrumentation span + event handlers). Candidate for upstream docs/listing. |
 | LiveKit | `noveum_trace.integrations.livekit` | `livekit` | `setup_livekit_tracing(session)` | Community-maintained observability integration. Candidate for upstream docs/listing. |
 | Pipecat | `noveum_trace.integrations.pipecat` | `pipecat` (add `pipecat-otel` for OTEL span export) | `NoveumPipecatTracer` (two-call: `observe_pipeline` + `register_task_handlers`) | Community-maintained observability integration (observer). Candidate for upstream docs/listing. |
 | CrewAI | `noveum_trace.integrations.crewai` | `crewai` | `setup_crewai_tracing()` (or `NoveumCrewAIListener`) | Community-maintained observability integration (listener). Candidate for upstream docs/listing. |
 | OpenTelemetry alignment | `noveum_trace.integrations.pipecat.custom_spans` | `pipecat-otel` | Plain OTEL spans folded into the Pipecat trace via `capture_custom_spans=True` (registers an OTEL `SpanProcessor`) | Bridge only — there is no standalone OTEL exporter. Do not describe a general-purpose OpenTelemetry backend. |
 
 **Not yet supported — do not claim support in any listing:** OpenAI Agents SDK,
-LlamaIndex, AutoGen, Vercel AI SDK, and LiteLLM have no dedicated integration
+AutoGen, Vercel AI SDK, and LiteLLM have no dedicated integration
 module in `src/noveum_trace/integrations/`. Direct OpenAI/Anthropic calls can be
 traced with the core context managers (`trace_llm_call`), but that is not a
 framework integration.
@@ -46,6 +47,7 @@ and the upstream framework's own floor.
 | Core SDK / direct OpenAI + Anthropic | 3.9+ | `openai>=1.0.0`, `anthropic>=0.3.0` |
 | LangChain | 3.10+ | `langchain-core>=0.1.0` (+ `Pillow>=9.0.0`) |
 | LangGraph | 3.10+ | `langchain-core>=0.1.0` (shares the `langchain` extra) |
+| LlamaIndex | 3.9+ | `llama-index-core>=0.11,<1.0` |
 | LiveKit | 3.10+ | `livekit>=1.0.19,<2`, `livekit-agents>=1.0.0` |
 | CrewAI | 3.10+ | `crewai>=0.177.0; python_version>='3.10'` |
 | Pipecat | 3.11+ (required by `pipecat-ai`) | `pipecat-ai>=0.0.108`; `pipecat-otel` adds `opentelemetry-api>=1.0.0`, `opentelemetry-sdk>=1.0.0` |
@@ -109,6 +111,23 @@ noveum_trace.init(api_key="...", project="voice-agent")
 setup_livekit_tracing(session)  # record=True captures full conversation audio
 ```
 
+### LlamaIndex — `setup_llamaindex_tracing`
+
+```python
+import noveum_trace
+from noveum_trace.integrations.llamaindex import setup_llamaindex_tracing
+
+noveum_trace.init(api_key="...", project="my-rag-app")
+
+setup_llamaindex_tracing()  # registers span + event handlers on the root dispatcher
+# ... build and query your index as usual ...
+```
+
+Registers span + event handlers on LlamaIndex's instrumentation dispatcher
+(`llama_index.core.instrumentation`), mapping query engines, retrievers,
+synthesizers, LLM, and embedding calls onto Noveum traces/spans. Call
+`noveum_trace.flush()` before a short-lived process exits.
+
 ### LangChain / LangGraph — `NoveumTraceCallbackHandler`
 
 ```python
@@ -162,6 +181,15 @@ no event handlers, no audio upload), pass `enabled=False`.
 observer also exposes `capture_text=True` (LLM/TTS text) and
 `capture_function_calls=True` (tool calls). Set `record_audio` /
 `record_raw_input_audio` / `capture_text` to `False` to reduce what is stored.
+
+### LlamaIndex — `setup_llamaindex_tracing(...)`
+
+Privacy-safe defaults — raw payloads are **off** by default: `capture_inputs=False`
+(query / retrieval query text), `capture_outputs=False` (response text and
+retrieved node content), `capture_llm_messages=False` (full LLM prompt/response
+messages). Non-capture default: `trace_name_prefix="llamaindex"`. Model name,
+token usage, node counts and similarity scores, embedding counts, and errors are
+always captured.
 
 ### LangChain / LangGraph — `NoveumTraceCallbackHandler`
 

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -47,7 +47,7 @@ and the upstream framework's own floor.
 | Core SDK / direct OpenAI + Anthropic | 3.9+ | `openai>=1.0.0`, `anthropic>=0.3.0` |
 | LangChain | 3.10+ | `langchain-core>=0.1.0` (+ `Pillow>=9.0.0`) |
 | LangGraph | 3.10+ | `langchain-core>=0.1.0` (shares the `langchain` extra) |
-| LlamaIndex | 3.9+ | `llama-index-core>=0.11,<1.0` |
+| LlamaIndex | 3.10+ | `llama-index-core>=0.11,<1.0; python_version>='3.10'` |
 | LiveKit | 3.10+ | `livekit>=1.0.19,<2`, `livekit-agents>=1.0.0` |
 | CrewAI | 3.10+ | `crewai>=0.177.0; python_version>='3.10'` |
 | Pipecat | 3.11+ (required by `pipecat-ai`) | `pipecat-ai>=0.0.108`; `pipecat-otel` adds `opentelemetry-api>=1.0.0`, `opentelemetry-sdk>=1.0.0` |

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -125,8 +125,10 @@ setup_llamaindex_tracing()  # registers span + event handlers on the root dispat
 
 Registers span + event handlers on LlamaIndex's instrumentation dispatcher
 (`llama_index.core.instrumentation`), mapping query engines, retrievers,
-synthesizers, LLM, and embedding calls onto Noveum traces/spans. Call
-`noveum_trace.flush()` before a short-lived process exits.
+synthesizers, LLM, and embedding calls onto Noveum traces/spans.
+`setup_llamaindex_tracing()` raises if `noveum_trace.init()` has not run and no
+explicit `client=` is given. For a short-lived process, call
+`noveum_trace.flush()` then `noveum_trace.shutdown()` before exit.
 
 ### LangChain / LangGraph — `NoveumTraceCallbackHandler`
 

--- a/docs/integrations/upstream.md
+++ b/docs/integrations/upstream.md
@@ -186,12 +186,21 @@ observer also exposes `capture_text=True` (LLM/TTS text) and
 
 ### LlamaIndex — `setup_llamaindex_tracing(...)`
 
-Privacy-safe defaults — raw payloads are **off** by default: `capture_inputs=False`
-(query / retrieval query text), `capture_outputs=False` (response text and
-retrieved node content), `capture_llm_messages=False` (full LLM prompt/response
-messages). Non-capture default: `trace_name_prefix="llamaindex"`. Model name,
-token usage, node counts and similarity scores, embedding counts, and errors are
-always captured.
+All default `True`, matching the other capture-by-default integrations:
+`capture_inputs` (query / retrieval / rerank query text, rerank input nodes,
+agent tool arguments), `capture_outputs` (response text, retrieved node content,
+query source nodes, reranked output nodes), `capture_llm_messages` (full LLM
+prompt/response messages, system prompts, available tool schemas), and
+`capture_cost`. Non-capture default: `trace_name_prefix="llamaindex"`. Model
+name, token usage, node counts and similarity scores, configured `top_k`,
+embedding counts and vector width, and errors are always captured. Payloads are
+not truncated.
+
+The one exception is `capture_embedding_chunks=False` — the *text* being
+embedded. Indexing a corpus emits an embedding call per batch, so enabling it
+copies the whole source corpus into the trace store; useful for building
+evaluation datasets from a small index, expensive on a large one. Embedding
+vectors themselves are never attached under any setting.
 
 ### LangChain / LangGraph — `NoveumTraceCallbackHandler`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ livekit = ["livekit>=1.0.19,<2", "livekit-agents>=1.0.0"]
 pipecat = ["pipecat-ai>=0.0.108"]
 pipecat-otel = ["pipecat-ai>=0.0.108", "opentelemetry-api>=1.0.0", "opentelemetry-sdk>=1.0.0"]
 crewai = ["crewai>=0.177.0; python_version>='3.10'"]
-llamaindex = ["llama-index-core>=0.11.0,<1.0.0"]
+llamaindex = ["llama-index-core>=0.11.0,<1.0.0; python_version>='3.10'"]
 bedrock = ["boto3>=1.34.0"]
 
 # Optional: spaCy for ``PiiPseudonymizer`` NER (heavier than the core SDK; regex-only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ livekit = ["livekit>=1.0.19,<2", "livekit-agents>=1.0.0"]
 pipecat = ["pipecat-ai>=0.0.108"]
 pipecat-otel = ["pipecat-ai>=0.0.108", "opentelemetry-api>=1.0.0", "opentelemetry-sdk>=1.0.0"]
 crewai = ["crewai>=0.177.0; python_version>='3.10'"]
+llamaindex = ["llama-index-core>=0.11.0,<1.0.0"]
 bedrock = ["boto3>=1.34.0"]
 
 # Optional: spaCy for ``PiiPseudonymizer`` NER (heavier than the core SDK; regex-only
@@ -274,6 +275,10 @@ module = [
     "langchain_core.*",
     "livekit.*",
     "pipecat.*",
+    "llama_index",
+    "llama_index.*",
+    "llama_index_instrumentation",
+    "llama_index_instrumentation.*",
     "crewai",
     "crewai.*",
     "boto3",

--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -484,8 +484,9 @@ try:
     _integration_exports.extend(
         ["NoveumLlamaIndexSpanHandler", "setup_llamaindex_tracing"]
     )
-except ImportError:
-    # LlamaIndex not installed
+except Exception:
+    # LlamaIndex not installed, or unusable on this runtime (e.g. Python 3.9).
+    # An optional integration must never break ``import noveum_trace``.
     pass
 
 # Export public API

--- a/src/noveum_trace/__init__.py
+++ b/src/noveum_trace/__init__.py
@@ -475,6 +475,19 @@ except ImportError:
     # CrewAI not installed
     pass
 
+try:
+    from noveum_trace.integrations.llamaindex import (
+        NoveumLlamaIndexSpanHandler,
+        setup_llamaindex_tracing,
+    )
+
+    _integration_exports.extend(
+        ["NoveumLlamaIndexSpanHandler", "setup_llamaindex_tracing"]
+    )
+except ImportError:
+    # LlamaIndex not installed
+    pass
+
 # Export public API
 __all__ = [
     # Core functions

--- a/src/noveum_trace/integrations/__init__.py
+++ b/src/noveum_trace/integrations/__init__.py
@@ -70,3 +70,14 @@ try:
     __all__.extend(["NoveumCrewAIListener", "setup_crewai_tracing"])
 except ImportError:
     pass
+
+# LlamaIndex integration (requires llama-index-core)
+try:
+    from noveum_trace.integrations.llamaindex import (
+        NoveumLlamaIndexSpanHandler,
+        setup_llamaindex_tracing,
+    )
+
+    __all__.extend(["NoveumLlamaIndexSpanHandler", "setup_llamaindex_tracing"])
+except ImportError:
+    pass

--- a/src/noveum_trace/integrations/__init__.py
+++ b/src/noveum_trace/integrations/__init__.py
@@ -71,7 +71,11 @@ try:
 except ImportError:
     pass
 
-# LlamaIndex integration (requires llama-index-core)
+# LlamaIndex integration (requires llama-index-core, Python 3.10+).
+# Catch any exception, not just ImportError: llama-index-core's import chain can
+# raise other errors on unsupported runtimes (e.g. a transitive `banks` TypeError
+# on Python 3.9), and an optional integration must never break ``import
+# noveum_trace``.
 try:
     from noveum_trace.integrations.llamaindex import (
         NoveumLlamaIndexSpanHandler,
@@ -79,5 +83,5 @@ try:
     )
 
     __all__.extend(["NoveumLlamaIndexSpanHandler", "setup_llamaindex_tracing"])
-except ImportError:
+except Exception:
     pass

--- a/src/noveum_trace/integrations/_common.py
+++ b/src/noveum_trace/integrations/_common.py
@@ -1,0 +1,356 @@
+"""
+Shared helpers for framework integrations.
+
+These helpers are framework-agnostic: span writes, defensive serialization,
+timestamp coercion, provider derivation, token-usage normalisation, and cost
+estimation. Integrations import from here instead of re-implementing the same
+logic per framework.
+
+Every public function absorbs its own exceptions and returns a sensible default,
+so a failing helper can never break the host application.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "coerce_datetime",
+    "derive_provider",
+    "estimate_cost_safe",
+    "extract_usage_tokens",
+    "finish_span",
+    "probe",
+    "safe_serialize",
+    "set_span_attributes",
+    "stringify",
+]
+
+
+# ---------------------------------------------------------------------------
+# Span writes
+# ---------------------------------------------------------------------------
+
+
+def set_span_attributes(span: Any, attributes: dict[str, Any]) -> None:
+    """
+    Write *attributes* onto *span*.
+
+    Tries ``span.set_attributes`` first; on failure or absence, updates
+    ``span.attributes`` when it supports ``.update`` (covers finished spans).
+    """
+    if not attributes or span is None:
+        return
+    try:
+        setter = getattr(span, "set_attributes", None)
+        if callable(setter):
+            setter(attributes)
+            return
+    except Exception:
+        pass
+    try:
+        attr_store = getattr(span, "attributes", None)
+        if attr_store is not None and hasattr(attr_store, "update"):
+            attr_store.update(attributes)
+    except Exception as exc:
+        logger.debug("set_span_attributes failed: %s", exc)
+
+
+def finish_span(span: Any, end_time: Any = None) -> None:
+    """Finish *span*, tolerating an already-finished span and never raising."""
+    if span is None:
+        return
+    try:
+        is_finished = getattr(span, "is_finished", None)
+        if callable(is_finished) and is_finished():
+            return
+        if end_time is None:
+            span.finish()
+        else:
+            span.finish(end_time)
+    except Exception as exc:
+        logger.debug("finish_span failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Attribute probing / serialization
+# ---------------------------------------------------------------------------
+
+
+def probe(source: Any, *keys: str) -> Any:
+    """Read *keys* from a dict or object, returning the first non-None value."""
+    if source is None:
+        return None
+    for key in keys:
+        try:
+            value = (
+                source.get(key)
+                if isinstance(source, dict)
+                else getattr(source, key, None)
+            )
+        except Exception:
+            value = None
+        if value is not None:
+            return value
+    return None
+
+
+def stringify(value: Any) -> str:
+    """
+    Render *value* as a string without truncating it.
+
+    Payloads such as system prompts and tool results routinely exceed any fixed
+    character budget, so nothing is clipped here. Size limiting is the
+    transport's responsibility, not the integration's.
+    """
+    if isinstance(value, str):
+        return value
+    try:
+        return str(value)
+    except Exception as exc:
+        return f"<stringify_error:{type(value).__name__}:{exc}>"
+
+
+def safe_serialize(value: Any, *, max_depth: int = 8) -> Any:
+    """
+    Recursively convert *value* into a JSON-serialisable structure.
+
+    Primitives pass through; dict/list/tuple recurse; Pydantic v2/v1 objects use
+    ``model_dump``/``dict``; objects exposing ``to_dict`` are converted;
+    everything else falls back to ``str``. Depth is capped to guard against
+    cyclic or deeply nested object graphs.
+    """
+    return _safe_serialize_inner(value, depth=0, max_depth=max_depth)
+
+
+def _safe_serialize_inner(value: Any, depth: int, max_depth: int) -> Any:
+    if depth >= max_depth:
+        return f"<max_depth:{type(value).__name__}>"
+    try:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, dict):
+            return {
+                str(k): _safe_serialize_inner(v, depth + 1, max_depth)
+                for k, v in value.items()
+            }
+        if isinstance(value, (list, tuple, set)):
+            return [_safe_serialize_inner(item, depth + 1, max_depth) for item in value]
+        for method in ("model_dump", "dict", "to_dict"):
+            fn = getattr(value, method, None)
+            if callable(fn):
+                try:
+                    return _safe_serialize_inner(fn(), depth + 1, max_depth)
+                except Exception:
+                    continue
+        return str(value)
+    except Exception as exc:
+        return f"<serialization_error:{type(value).__name__}:{exc}>"
+
+
+# ---------------------------------------------------------------------------
+# Timestamps
+# ---------------------------------------------------------------------------
+
+
+def coerce_datetime(value: Any) -> Optional[datetime]:
+    """
+    Convert an ISO-8601 string (or epoch seconds) to a ``datetime``.
+
+    Returns ``None`` when the value is missing or unparseable so callers can
+    fall back to "now".
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value)
+        except (OverflowError, OSError, ValueError):
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider derivation
+# ---------------------------------------------------------------------------
+
+_OPENAI_MODEL_PREFIXES = (
+    "gpt",
+    "o1",
+    "o3",
+    "o4",
+    "chatgpt",
+    "text-",
+    "ada",
+    "babbage",
+    "curie",
+    "davinci",
+)
+
+
+def derive_provider(model: Optional[str]) -> Optional[str]:
+    """
+    Best-effort provider name from a model string.
+
+    Recognises well-known prefixes, falls back to the left side of a LiteLLM
+    ``"provider/model"`` string, and returns ``None`` when undeterminable.
+    """
+    if not model or not isinstance(model, str):
+        return None
+    lowered = model.lower()
+    if any(lowered.startswith(prefix) for prefix in _OPENAI_MODEL_PREFIXES):
+        return "openai"
+    if lowered.startswith("claude"):
+        return "anthropic"
+    if lowered.startswith("gemini") or lowered.startswith("models/gemini"):
+        return "google"
+    if lowered.startswith(("mistral", "mixtral")):
+        return "mistral"
+    if lowered.startswith(("llama", "meta-llama")):
+        return "meta"
+    if lowered.startswith("deepseek"):
+        return "deepseek"
+    if lowered.startswith(("command", "cohere")):
+        return "cohere"
+    if "/" in lowered:
+        return lowered.split("/", 1)[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Token usage
+# ---------------------------------------------------------------------------
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_int(*candidates: Any) -> Optional[int]:
+    """Return the first candidate that coerces to an int, preserving zeros."""
+    for candidate in candidates:
+        coerced = _coerce_int(candidate)
+        if coerced is not None:
+            return coerced
+    return None
+
+
+USAGE_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cached_input_tokens",
+    "cache_write_input_tokens",
+    "reasoning_tokens",
+)
+
+
+def extract_usage_tokens(usage: Any) -> dict[str, Optional[int]]:
+    """
+    Normalise a provider or framework usage payload to canonical token counts.
+
+    Handles the flat OpenAI Agents shapes (``cached_input_tokens``,
+    ``cache_write_input_tokens``), the nested OpenAI shapes
+    (``input_tokens_details.cached_tokens``,
+    ``output_tokens_details.reasoning_tokens``, and their
+    ``prompt_tokens_details`` / ``completion_tokens_details`` aliases), and
+    Chat-Completions naming (``prompt_tokens`` / ``completion_tokens``).
+
+    ``total_tokens`` is computed from input + output when not supplied.
+    """
+    result: dict[str, Optional[int]] = dict.fromkeys(USAGE_KEYS)
+    if usage is None:
+        return result
+    try:
+        result["input_tokens"] = _coerce_int(
+            probe(usage, "input_tokens", "prompt_tokens")
+        )
+        result["output_tokens"] = _coerce_int(
+            probe(usage, "output_tokens", "completion_tokens")
+        )
+        result["total_tokens"] = _coerce_int(probe(usage, "total_tokens"))
+
+        input_details = probe(usage, "input_tokens_details", "prompt_tokens_details")
+        output_details = probe(
+            usage, "output_tokens_details", "completion_tokens_details"
+        )
+
+        # ``or`` is wrong here: a genuine zero (no cache hit) must survive
+        # rather than fall through to the nested lookup.
+        result["cached_input_tokens"] = _first_int(
+            probe(usage, "cached_input_tokens", "cached_tokens"),
+            probe(input_details, "cached_tokens"),
+        )
+        result["cache_write_input_tokens"] = _first_int(
+            probe(usage, "cache_write_input_tokens", "cache_creation_input_tokens"),
+            probe(input_details, "cache_write_tokens"),
+        )
+        result["reasoning_tokens"] = _first_int(
+            probe(usage, "reasoning_tokens"),
+            probe(output_details, "reasoning_tokens"),
+        )
+
+        if (
+            result["total_tokens"] is None
+            and result["input_tokens"] is not None
+            and result["output_tokens"] is not None
+        ):
+            result["total_tokens"] = result["input_tokens"] + result["output_tokens"]
+    except Exception as exc:
+        logger.debug("extract_usage_tokens failed: %s", exc)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Cost
+# ---------------------------------------------------------------------------
+
+
+def estimate_cost_safe(
+    model: Optional[str],
+    input_tokens: Optional[int],
+    output_tokens: Optional[int],
+) -> dict[str, Any]:
+    """
+    Estimate LLM cost via ``noveum_trace.utils.llm_utils.estimate_cost``.
+
+    Returns a dict with ``input`` / ``output`` / ``total`` / ``currency`` keys,
+    or an empty dict on any failure so callers can safely ``.get(...)``.
+    """
+    if not model:
+        return {}
+    if input_tokens is None and output_tokens is None:
+        return {}
+    try:
+        from noveum_trace.utils.llm_utils import estimate_cost
+
+        cost_info = estimate_cost(
+            model,
+            input_tokens=int(input_tokens or 0),
+            output_tokens=int(output_tokens or 0),
+        )
+        return {
+            "input": cost_info.get("input_cost", 0.0),
+            "output": cost_info.get("output_cost", 0.0),
+            "total": cost_info.get("total_cost", 0.0),
+            "currency": cost_info.get("currency", "USD"),
+        }
+    except Exception as exc:
+        logger.debug("estimate_cost_safe failed for model=%s: %s", model, exc)
+        return {}

--- a/src/noveum_trace/integrations/llamaindex/__init__.py
+++ b/src/noveum_trace/integrations/llamaindex/__init__.py
@@ -1,0 +1,46 @@
+"""
+Noveum LlamaIndex Integration.
+
+Provides tracing for `LlamaIndex <https://docs.llamaindex.ai/>`_ query pipelines
+(query engines, retrievers, synthesizers, LLM and embedding calls) by registering
+span + event handlers on LlamaIndex's modern instrumentation dispatcher.
+
+Installation
+------------
+>>> pip install "noveum-trace[llamaindex]"
+
+Setup
+-----
+>>> import noveum_trace
+>>> from noveum_trace.integrations.llamaindex import setup_llamaindex_tracing
+>>>
+>>> noveum_trace.init(project="my-project", api_key="...")
+>>> setup_llamaindex_tracing()
+>>>
+>>> # ... build and query your index as usual ...
+>>> noveum_trace.flush()
+
+Configuration Options
+---------------------
+All options passed to ``setup_llamaindex_tracing``:
+
+  capture_inputs        — Capture query / retrieval query text (default: off)
+  capture_outputs       — Capture response text and retrieved node content
+                          (default: off)
+  capture_llm_messages  — Capture full LLM prompt/response messages (default: off)
+  trace_name_prefix     — Prefix for unnamed operations (default: "llamaindex")
+"""
+
+from noveum_trace.integrations.llamaindex.handler import (
+    NoveumLlamaIndexEventHandler,
+    NoveumLlamaIndexSpan,
+    NoveumLlamaIndexSpanHandler,
+    setup_llamaindex_tracing,
+)
+
+__all__ = [
+    "NoveumLlamaIndexEventHandler",
+    "NoveumLlamaIndexSpan",
+    "NoveumLlamaIndexSpanHandler",
+    "setup_llamaindex_tracing",
+]

--- a/src/noveum_trace/integrations/llamaindex/__init__.py
+++ b/src/noveum_trace/integrations/llamaindex/__init__.py
@@ -24,10 +24,18 @@ Configuration Options
 ---------------------
 All options passed to ``setup_llamaindex_tracing``:
 
-  capture_inputs        — Capture query / retrieval query text (default: off)
-  capture_outputs       — Capture response text and retrieved node content
-                          (default: off)
-  capture_llm_messages  — Capture full LLM prompt/response messages (default: off)
+  capture_inputs        — Capture query / retrieval / rerank query text, rerank
+                          input nodes, agent tool arguments (default: on)
+  capture_outputs       — Capture LLM response text, query response text,
+                          retrieved node content, query source nodes and
+                          reranked output nodes (default: on)
+  capture_llm_messages  — Capture LLM prompt messages, system prompts and
+                          available tool schemas (default: on). LLM responses
+                          follow capture_outputs, not this flag.
+  capture_cost          — Estimate LLM cost from model and token counts
+                          (default: on)
+  capture_embedding_chunks
+                        — Capture the text being embedded (default: off)
   trace_name_prefix     — Prefix for unnamed operations (default: "llamaindex")
 """
 

--- a/src/noveum_trace/integrations/llamaindex/constants.py
+++ b/src/noveum_trace/integrations/llamaindex/constants.py
@@ -64,9 +64,28 @@ ATTR_LLM_MODEL = "llm.model"
 ATTR_LLM_PROVIDER = "llm.provider"
 ATTR_LLM_INPUT = "llm.input"
 ATTR_LLM_OUTPUT = "llm.output"
+ATTR_LLM_SYSTEM_PROMPT = "llm.system_prompt"
+ATTR_LLM_AVAILABLE_TOOLS = "llm.available_tools"
+ATTR_LLM_AVAILABLE_TOOL_COUNT = "llm.available_tool_count"
+ATTR_LLM_TOOL_CALLS = "llm.tool_calls"
+ATTR_LLM_TOOL_CALL_COUNT = "llm.tool_call_count"
 ATTR_LLM_INPUT_TOKENS = "llm.input_tokens"
 ATTR_LLM_OUTPUT_TOKENS = "llm.output_tokens"
 ATTR_LLM_TOTAL_TOKENS = "llm.total_tokens"
+ATTR_LLM_CACHED_INPUT_TOKENS = "llm.cached_input_tokens"
+ATTR_LLM_REASONING_TOKENS = "llm.reasoning_tokens"
+ATTR_LLM_COST_INPUT = "llm.cost.input"
+ATTR_LLM_COST_OUTPUT = "llm.cost.output"
+ATTR_LLM_COST_TOTAL = "llm.cost.total"
+ATTR_LLM_COST_CURRENCY = "llm.cost.currency"
+
+# ---------------------------------------------------------------------------
+# Tool attribute keys   (prefix: tool.*)
+# ---------------------------------------------------------------------------
+
+ATTR_TOOL_NAME = "tool.name"
+ATTR_TOOL_DESCRIPTION = "tool.description"
+ATTR_TOOL_INPUT = "tool.input"
 
 # ---------------------------------------------------------------------------
 # Embedding attribute keys   (prefix: embedding.*)
@@ -75,6 +94,8 @@ ATTR_LLM_TOTAL_TOKENS = "llm.total_tokens"
 ATTR_EMBEDDING_MODEL = "embedding.model"
 ATTR_EMBEDDING_CHUNK_COUNT = "embedding.chunk_count"
 ATTR_EMBEDDING_VECTOR_COUNT = "embedding.vector_count"
+ATTR_EMBEDDING_DIMENSIONS = "embedding.dimensions"
+ATTR_EMBEDDING_CHUNKS = "embedding.chunks"
 
 # ---------------------------------------------------------------------------
 # Retrieval attribute keys   (prefix: retrieval.*)
@@ -84,6 +105,7 @@ ATTR_RETRIEVAL_QUERY = "retrieval.query"
 ATTR_RETRIEVAL_NODE_COUNT = "retrieval.node_count"
 ATTR_RETRIEVAL_SCORES = "retrieval.scores"
 ATTR_RETRIEVAL_NODES = "retrieval.nodes"
+ATTR_RETRIEVAL_TOP_K = "retrieval.top_k"
 
 # ---------------------------------------------------------------------------
 # Query attribute keys   (prefix: query.*)
@@ -91,6 +113,7 @@ ATTR_RETRIEVAL_NODES = "retrieval.nodes"
 
 ATTR_QUERY_TEXT = "query.text"
 ATTR_QUERY_RESPONSE = "query.response"
+ATTR_QUERY_SOURCE_NODES = "query.source_nodes"
 
 # ---------------------------------------------------------------------------
 # Rerank attribute keys   (prefix: rerank.*)
@@ -98,8 +121,13 @@ ATTR_QUERY_RESPONSE = "query.response"
 
 ATTR_RERANK_MODEL = "rerank.model"
 ATTR_RERANK_TOP_N = "rerank.top_n"
+ATTR_RERANK_QUERY = "rerank.query"
 ATTR_RERANK_INPUT_NODE_COUNT = "rerank.input_node_count"
 ATTR_RERANK_OUTPUT_NODE_COUNT = "rerank.output_node_count"
+ATTR_RERANK_INPUT_NODES = "rerank.input_nodes"
+ATTR_RERANK_OUTPUT_NODES = "rerank.output_nodes"
+ATTR_RERANK_INPUT_SCORES = "rerank.input_scores"
+ATTR_RERANK_OUTPUT_SCORES = "rerank.output_scores"
 
 # ---------------------------------------------------------------------------
 # Error / status attribute keys
@@ -112,11 +140,12 @@ STATUS_OK = "ok"
 STATUS_ERROR = "error"
 
 # ---------------------------------------------------------------------------
-# Limits / defaults
+# Defaults
 # ---------------------------------------------------------------------------
 
-MAX_TEXT_LENGTH = 8_192
-MAX_NODE_CONTENT_LENGTH = 2_048
+# Payloads are recorded in full. Prompts, retrieved node text and synthesized
+# answers routinely exceed any fixed character budget, and a clipped node is
+# not usable for evaluation or replay, so this integration does not truncate.
 DEFAULT_TRACE_NAME_PREFIX = "llamaindex"
 
 # Informational — the minimum ``llama-index-core`` release the instrumentation

--- a/src/noveum_trace/integrations/llamaindex/constants.py
+++ b/src/noveum_trace/integrations/llamaindex/constants.py
@@ -1,0 +1,124 @@
+"""
+Constants for the LlamaIndex integration.
+
+Structure: span attribute key constants (reusing the canonical ``llm.*`` keys the
+rest of the SDK understands), an operation → span-type classifier map, status
+values, and numeric limits.
+
+Span hierarchy mirrors the LlamaIndex instrumentation span tree, e.g.::
+
+    RetrieverQueryEngine.query            ← root (one Noveum trace)
+      VectorIndexRetriever.retrieve       ← retrieval
+        OpenAIEmbedding.get_query_embedding  ← embedding
+      CompactAndRefine.synthesize         ← synthesize
+        OpenAI.chat                        ← llm
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Span-type classification
+# ---------------------------------------------------------------------------
+
+SPAN_TYPE_LLM = "llm"
+SPAN_TYPE_EMBEDDING = "embedding"
+SPAN_TYPE_RETRIEVAL = "retrieval"
+SPAN_TYPE_QUERY = "query"
+SPAN_TYPE_SYNTHESIZE = "synthesize"
+SPAN_TYPE_RERANK = "rerank"
+SPAN_TYPE_AGENT = "agent"
+SPAN_TYPE_OTHER = "other"
+
+# Substring (lower-cased) → span-type, checked in order against the operation name
+# (e.g. ``"VectorIndexRetriever.retrieve"``) when no event has classified the span.
+OPERATION_TYPE_HINTS: tuple[tuple[str, str], ...] = (
+    ("retriev", SPAN_TYPE_RETRIEVAL),
+    ("rerank", SPAN_TYPE_RERANK),
+    ("postprocess", SPAN_TYPE_RERANK),
+    ("embed", SPAN_TYPE_EMBEDDING),
+    ("synthe", SPAN_TYPE_SYNTHESIZE),
+    ("get_response", SPAN_TYPE_SYNTHESIZE),
+    ("chat", SPAN_TYPE_LLM),
+    ("complete", SPAN_TYPE_LLM),
+    ("predict", SPAN_TYPE_LLM),
+    ("query", SPAN_TYPE_QUERY),
+    ("agent", SPAN_TYPE_AGENT),
+)
+
+# ---------------------------------------------------------------------------
+# Common / trace attribute keys   (prefix: llamaindex.*)
+# ---------------------------------------------------------------------------
+
+ATTR_OPERATION = "llamaindex.operation"
+ATTR_SPAN_TYPE = "llamaindex.span_type"
+ATTR_FRAMEWORK = "llamaindex.framework"
+ATTR_STATUS = "llamaindex.status"
+
+FRAMEWORK_NAME = "llama_index"
+
+# ---------------------------------------------------------------------------
+# LLM attribute keys   (prefix: llm.* — consumed by the gen_ai crosswalk)
+# ---------------------------------------------------------------------------
+
+ATTR_LLM_MODEL = "llm.model"
+ATTR_LLM_PROVIDER = "llm.provider"
+ATTR_LLM_INPUT = "llm.input"
+ATTR_LLM_OUTPUT = "llm.output"
+ATTR_LLM_INPUT_TOKENS = "llm.input_tokens"
+ATTR_LLM_OUTPUT_TOKENS = "llm.output_tokens"
+ATTR_LLM_TOTAL_TOKENS = "llm.total_tokens"
+
+# ---------------------------------------------------------------------------
+# Embedding attribute keys   (prefix: embedding.*)
+# ---------------------------------------------------------------------------
+
+ATTR_EMBEDDING_MODEL = "embedding.model"
+ATTR_EMBEDDING_CHUNK_COUNT = "embedding.chunk_count"
+ATTR_EMBEDDING_VECTOR_COUNT = "embedding.vector_count"
+
+# ---------------------------------------------------------------------------
+# Retrieval attribute keys   (prefix: retrieval.*)
+# ---------------------------------------------------------------------------
+
+ATTR_RETRIEVAL_QUERY = "retrieval.query"
+ATTR_RETRIEVAL_NODE_COUNT = "retrieval.node_count"
+ATTR_RETRIEVAL_SCORES = "retrieval.scores"
+ATTR_RETRIEVAL_NODES = "retrieval.nodes"
+
+# ---------------------------------------------------------------------------
+# Query attribute keys   (prefix: query.*)
+# ---------------------------------------------------------------------------
+
+ATTR_QUERY_TEXT = "query.text"
+ATTR_QUERY_RESPONSE = "query.response"
+
+# ---------------------------------------------------------------------------
+# Rerank attribute keys   (prefix: rerank.*)
+# ---------------------------------------------------------------------------
+
+ATTR_RERANK_MODEL = "rerank.model"
+ATTR_RERANK_TOP_N = "rerank.top_n"
+ATTR_RERANK_INPUT_NODE_COUNT = "rerank.input_node_count"
+ATTR_RERANK_OUTPUT_NODE_COUNT = "rerank.output_node_count"
+
+# ---------------------------------------------------------------------------
+# Error / status attribute keys
+# ---------------------------------------------------------------------------
+
+ATTR_ERROR_TYPE = "error.type"
+ATTR_ERROR_MESSAGE = "error.message"
+
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+
+# ---------------------------------------------------------------------------
+# Limits / defaults
+# ---------------------------------------------------------------------------
+
+MAX_TEXT_LENGTH = 8_192
+MAX_NODE_CONTENT_LENGTH = 2_048
+DEFAULT_TRACE_NAME_PREFIX = "llamaindex"
+
+# Informational — the minimum ``llama-index-core`` release the instrumentation
+# API used here was verified against (see ``pyproject.toml`` for the pin).
+MIN_LLAMA_INDEX_CORE_VERSION = "0.11.0"

--- a/src/noveum_trace/integrations/llamaindex/handler.py
+++ b/src/noveum_trace/integrations/llamaindex/handler.py
@@ -25,19 +25,28 @@ from llama_index.core.instrumentation.event_handlers.base import BaseEventHandle
 from llama_index.core.instrumentation.span.base import BaseSpan
 from llama_index.core.instrumentation.span_handlers.base import BaseSpanHandler
 
+from noveum_trace.integrations._common import (
+    estimate_cost_safe,
+    finish_span,
+    probe,
+    set_span_attributes,
+    stringify,
+)
 from noveum_trace.integrations.llamaindex import constants as C
 from noveum_trace.integrations.llamaindex.utils import (
     classify_operation,
     derive_provider,
     extract_model_name,
-    extract_node_contents,
     extract_node_scores,
     extract_query_str,
     extract_response_text,
+    extract_system_prompt,
     extract_token_usage,
+    extract_tool_metadata,
     operation_from_span_id,
     serialize_messages,
-    truncate_text,
+    serialize_nodes,
+    vector_dimensions,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,23 +62,8 @@ _LLM_END_EVENTS = frozenset(
 # ---------------------------------------------------------------------------
 
 
-def _set_attrs(span: Any, attrs: dict[str, Any]) -> None:
-    if not attrs or span is None:
-        return
-    try:
-        span.set_attributes(attrs)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("failed to set span attributes: %s", exc)
-
-
-def _finish_span(span: Any) -> None:
-    if span is None:
-        return
-    try:
-        if not span.is_finished():
-            span.finish()
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("failed to finish span: %s", exc)
+_set_attrs = set_span_attributes
+_finish_span = finish_span
 
 
 def _apply_error(span: Any, err: Any) -> None:
@@ -78,7 +72,7 @@ def _apply_error(span: Any, err: Any) -> None:
     attrs: dict[str, Any] = {C.ATTR_STATUS: C.STATUS_ERROR}
     if err is not None:
         attrs[C.ATTR_ERROR_TYPE] = type(err).__name__
-        attrs[C.ATTR_ERROR_MESSAGE] = truncate_text(str(err), C.MAX_TEXT_LENGTH)
+        attrs[C.ATTR_ERROR_MESSAGE] = stringify(err)
     try:
         span.set_attributes(attrs)
         from noveum_trace.core.span import SpanStatus
@@ -166,6 +160,11 @@ class NoveumLlamaIndexSpanHandler(BaseSpanHandler[NoveumLlamaIndexSpan]):
                 C.ATTR_OPERATION: operation,
                 C.ATTR_SPAN_TYPE: classify_operation(operation),
             }
+            # The retriever instance is the only place the configured top-k is
+            # visible; the retrieval events do not carry it.
+            top_k = probe(instance, "similarity_top_k", "top_k")
+            if isinstance(top_k, int):
+                attributes[C.ATTR_RETRIEVAL_TOP_K] = top_k
 
             parent = self.open_spans.get(parent_span_id) if parent_span_id else None
             if parent is not None and getattr(parent, "noveum_trace", None) is not None:
@@ -283,9 +282,11 @@ class NoveumLlamaIndexEventHandler(BaseEventHandler):
     """
 
     span_handler: Any = None
-    capture_inputs: bool = False
-    capture_outputs: bool = False
-    capture_llm_messages: bool = False
+    capture_inputs: bool = True
+    capture_outputs: bool = True
+    capture_llm_messages: bool = True
+    capture_cost: bool = True
+    capture_embedding_chunks: bool = False
 
     @classmethod
     def class_name(cls) -> str:
@@ -322,7 +323,9 @@ class NoveumLlamaIndexEventHandler(BaseEventHandler):
         if name in _LLM_START_EVENTS:
             self._map_llm_start(event, attrs)
         elif name in _LLM_END_EVENTS:
-            self._map_llm_end(event, attrs)
+            self._map_llm_end(event, attrs, noveum_span)
+        elif name == "AgentToolCallEvent":
+            self._map_tool_call(event, attrs)
         elif name == "EmbeddingStartEvent":
             attrs[C.ATTR_SPAN_TYPE] = C.SPAN_TYPE_EMBEDDING
             model = extract_model_name(getattr(event, "model_dict", None))
@@ -335,7 +338,7 @@ class NoveumLlamaIndexEventHandler(BaseEventHandler):
             if self.capture_inputs:
                 query = extract_query_str(getattr(event, "str_or_query_bundle", None))
                 if query:
-                    attrs[C.ATTR_RETRIEVAL_QUERY] = truncate_text(query)
+                    attrs[C.ATTR_RETRIEVAL_QUERY] = query
         elif name == "RetrievalEndEvent":
             self._map_retrieval_end(event, attrs)
         elif name == "QueryStartEvent":
@@ -343,18 +346,13 @@ class NoveumLlamaIndexEventHandler(BaseEventHandler):
             if self.capture_inputs:
                 query = extract_query_str(getattr(event, "query", None))
                 if query:
-                    attrs[C.ATTR_QUERY_TEXT] = truncate_text(query)
+                    attrs[C.ATTR_QUERY_TEXT] = query
         elif name == "QueryEndEvent":
-            if self.capture_outputs:
-                response = getattr(event, "response", None)
-                if response is not None:
-                    attrs[C.ATTR_QUERY_RESPONSE] = truncate_text(str(response))
+            self._map_query_end(event, attrs)
         elif name == "ReRankStartEvent":
             self._map_rerank_start(event, attrs)
         elif name == "ReRankEndEvent":
-            nodes = getattr(event, "nodes", None)
-            if nodes is not None:
-                attrs[C.ATTR_RERANK_OUTPUT_NODE_COUNT] = len(nodes)
+            self._map_rerank_end(event, attrs)
 
         _set_attrs(noveum_span, attrs)
 
@@ -366,15 +364,31 @@ class NoveumLlamaIndexEventHandler(BaseEventHandler):
             provider = derive_provider(model)
             if provider:
                 attrs[C.ATTR_LLM_PROVIDER] = provider
+
+        model_dict = getattr(event, "model_dict", None)
+        additional = getattr(event, "additional_kwargs", None)
+        tools = probe(additional, "tools") or probe(model_dict, "tools")
+        if tools and self.capture_llm_messages:
+            schemas = [
+                extract_tool_metadata(tool) or {"tool": stringify(tool)}
+                for tool in tools
+            ]
+            attrs[C.ATTR_LLM_AVAILABLE_TOOLS] = schemas
+            attrs[C.ATTR_LLM_AVAILABLE_TOOL_COUNT] = len(schemas)
+
         if self.capture_llm_messages:
-            messages = serialize_messages(getattr(event, "messages", None))
+            raw_messages = getattr(event, "messages", None)
+            messages = serialize_messages(raw_messages)
             if messages:
                 attrs[C.ATTR_LLM_INPUT] = messages
+                system_prompt = extract_system_prompt(raw_messages)
+                if system_prompt:
+                    attrs[C.ATTR_LLM_SYSTEM_PROMPT] = system_prompt
             prompt = getattr(event, "prompt", None)
             if prompt is not None:
-                attrs[C.ATTR_LLM_INPUT] = truncate_text(prompt)
+                attrs[C.ATTR_LLM_INPUT] = stringify(prompt)
 
-    def _map_llm_end(self, event: Any, attrs: dict[str, Any]) -> None:
+    def _map_llm_end(self, event: Any, attrs: dict[str, Any], noveum_span: Any) -> None:
         response = getattr(event, "response", None)
         usage = extract_token_usage(response)
         if usage["input_tokens"] is not None:
@@ -383,31 +397,135 @@ class NoveumLlamaIndexEventHandler(BaseEventHandler):
             attrs[C.ATTR_LLM_OUTPUT_TOKENS] = usage["output_tokens"]
         if usage["total_tokens"] is not None:
             attrs[C.ATTR_LLM_TOTAL_TOKENS] = usage["total_tokens"]
+        if usage["cached_input_tokens"] is not None:
+            attrs[C.ATTR_LLM_CACHED_INPUT_TOKENS] = usage["cached_input_tokens"]
+        if usage["reasoning_tokens"] is not None:
+            attrs[C.ATTR_LLM_REASONING_TOKENS] = usage["reasoning_tokens"]
+
+        if self.capture_cost:
+            self._apply_cost(usage, attrs, noveum_span)
+
+        tool_calls = self._response_tool_calls(response)
+        if tool_calls:
+            attrs[C.ATTR_LLM_TOOL_CALLS] = tool_calls
+            attrs[C.ATTR_LLM_TOOL_CALL_COUNT] = len(tool_calls)
+
         if self.capture_outputs:
             text = extract_response_text(response)
             if text is None:
                 output = getattr(event, "output", None)
-                text = str(output) if output is not None else None
+                text = stringify(output) if output is not None else None
             if text:
-                attrs[C.ATTR_LLM_OUTPUT] = truncate_text(text)
+                attrs[C.ATTR_LLM_OUTPUT] = text
+
+    def _apply_cost(
+        self, usage: dict[str, Any], attrs: dict[str, Any], noveum_span: Any
+    ) -> None:
+        """
+        Estimate cost from the model recorded by the matching start event.
+
+        LlamaIndex splits a call across ``LLMChatStartEvent`` (which carries the
+        model) and ``LLMChatEndEvent`` (which carries usage), so the model is
+        read back off the span the start event already annotated.
+        """
+        model = attrs.get(C.ATTR_LLM_MODEL)
+        if not model:
+            existing = getattr(noveum_span, "attributes", None)
+            if isinstance(existing, dict):
+                model = existing.get(C.ATTR_LLM_MODEL)
+        if not model:
+            return
+        cost = estimate_cost_safe(
+            str(model), usage["input_tokens"], usage["output_tokens"]
+        )
+        if cost.get("total"):
+            attrs[C.ATTR_LLM_COST_INPUT] = cost.get("input")
+            attrs[C.ATTR_LLM_COST_OUTPUT] = cost.get("output")
+            attrs[C.ATTR_LLM_COST_TOTAL] = cost.get("total")
+            attrs[C.ATTR_LLM_COST_CURRENCY] = cost.get("currency")
+
+    def _response_tool_calls(self, response: Any) -> list[dict[str, Any]]:
+        """Pull tool calls off a ``ChatResponse`` message's additional kwargs."""
+        message = probe(response, "message")
+        additional = (
+            probe(message, "additional_kwargs") if message is not None else None
+        )
+        raw_calls = probe(additional, "tool_calls") if additional else None
+        calls: list[dict[str, Any]] = []
+        for raw in raw_calls or []:
+            function = probe(raw, "function")
+            name = (
+                probe(function, "name") if function is not None else probe(raw, "name")
+            )
+            arguments = (
+                probe(function, "arguments")
+                if function is not None
+                else probe(raw, "arguments")
+            )
+            if name is None and arguments is None:
+                continue
+            entry: dict[str, Any] = {"name": stringify(name) if name else None}
+            call_id = probe(raw, "id", "tool_call_id")
+            if call_id is not None:
+                entry["call_id"] = stringify(call_id)
+            if arguments is not None:
+                entry["arguments"] = stringify(arguments)
+            calls.append(entry)
+        return calls
+
+    def _map_tool_call(self, event: Any, attrs: dict[str, Any]) -> None:
+        """Map an agent tool invocation (``AgentToolCallEvent``)."""
+        metadata = extract_tool_metadata(getattr(event, "tool", None))
+        if metadata.get("name"):
+            attrs[C.ATTR_TOOL_NAME] = metadata["name"]
+        if metadata.get("description"):
+            attrs[C.ATTR_TOOL_DESCRIPTION] = metadata["description"]
+        if self.capture_inputs:
+            arguments = getattr(event, "arguments", None)
+            if arguments is not None:
+                attrs[C.ATTR_TOOL_INPUT] = stringify(arguments)
 
     def _map_embedding_end(self, event: Any, attrs: dict[str, Any]) -> None:
+        """
+        Map an embedding call.
+
+        Counts and vector width are always recorded; the chunk *text* is behind
+        ``capture_embedding_chunks`` because indexing a corpus emits one
+        embedding call per batch, and capturing their text would copy the whole
+        source corpus into the trace store. The embedding vectors themselves are
+        never attached — a float array is not usable in a trace viewer.
+        """
         chunks = getattr(event, "chunks", None)
         if chunks is not None:
             attrs[C.ATTR_EMBEDDING_CHUNK_COUNT] = len(chunks)
+            if self.capture_embedding_chunks:
+                attrs[C.ATTR_EMBEDDING_CHUNKS] = [stringify(c) for c in chunks]
         embeddings = getattr(event, "embeddings", None)
         if embeddings is not None:
             attrs[C.ATTR_EMBEDDING_VECTOR_COUNT] = len(embeddings)
+            dimensions = vector_dimensions(embeddings)
+            if dimensions is not None:
+                attrs[C.ATTR_EMBEDDING_DIMENSIONS] = dimensions
 
     def _map_retrieval_end(self, event: Any, attrs: dict[str, Any]) -> None:
         nodes = getattr(event, "nodes", None)
-        if nodes is not None:
-            attrs[C.ATTR_RETRIEVAL_NODE_COUNT] = len(nodes)
-            attrs[C.ATTR_RETRIEVAL_SCORES] = extract_node_scores(nodes)
-            if self.capture_outputs:
-                attrs[C.ATTR_RETRIEVAL_NODES] = extract_node_contents(
-                    nodes, C.MAX_NODE_CONTENT_LENGTH
-                )
+        if nodes is None:
+            return
+        attrs[C.ATTR_RETRIEVAL_NODE_COUNT] = len(nodes)
+        # Ordered best-match first: the retriever's own top-k similarity scores.
+        attrs[C.ATTR_RETRIEVAL_SCORES] = extract_node_scores(nodes)
+        if self.capture_outputs:
+            attrs[C.ATTR_RETRIEVAL_NODES] = serialize_nodes(nodes)
+
+    def _map_query_end(self, event: Any, attrs: dict[str, Any]) -> None:
+        response = getattr(event, "response", None)
+        if response is None:
+            return
+        if self.capture_outputs:
+            attrs[C.ATTR_QUERY_RESPONSE] = stringify(response)
+            source_nodes = getattr(response, "source_nodes", None)
+            if source_nodes:
+                attrs[C.ATTR_QUERY_SOURCE_NODES] = serialize_nodes(source_nodes)
 
     def _map_rerank_start(self, event: Any, attrs: dict[str, Any]) -> None:
         attrs[C.ATTR_SPAN_TYPE] = C.SPAN_TYPE_RERANK
@@ -417,17 +535,43 @@ class NoveumLlamaIndexEventHandler(BaseEventHandler):
         top_n = getattr(event, "top_n", None)
         if top_n is not None:
             attrs[C.ATTR_RERANK_TOP_N] = top_n
+        if self.capture_inputs:
+            query = extract_query_str(getattr(event, "query", None))
+            if query:
+                attrs[C.ATTR_RERANK_QUERY] = query
         nodes = getattr(event, "nodes", None)
         if nodes is not None:
             attrs[C.ATTR_RERANK_INPUT_NODE_COUNT] = len(nodes)
+            attrs[C.ATTR_RERANK_INPUT_SCORES] = extract_node_scores(nodes)
+            if self.capture_inputs:
+                attrs[C.ATTR_RERANK_INPUT_NODES] = serialize_nodes(nodes)
+
+    def _map_rerank_end(self, event: Any, attrs: dict[str, Any]) -> None:
+        """
+        Map the reranked result set.
+
+        An LLM-backed reranker (``LLMRerank`` and friends) runs its scoring
+        prompt through the dispatcher as a nested LLM span, so its reasoning is
+        captured there as ``llm.output`` rather than on this span — the rerank
+        events themselves carry only the node lists.
+        """
+        nodes = getattr(event, "nodes", None)
+        if nodes is None:
+            return
+        attrs[C.ATTR_RERANK_OUTPUT_NODE_COUNT] = len(nodes)
+        attrs[C.ATTR_RERANK_OUTPUT_SCORES] = extract_node_scores(nodes)
+        if self.capture_outputs:
+            attrs[C.ATTR_RERANK_OUTPUT_NODES] = serialize_nodes(nodes)
 
 
 def setup_llamaindex_tracing(
     client: Any = None,
     *,
-    capture_inputs: bool = False,
-    capture_outputs: bool = False,
-    capture_llm_messages: bool = False,
+    capture_inputs: bool = True,
+    capture_outputs: bool = True,
+    capture_llm_messages: bool = True,
+    capture_cost: bool = True,
+    capture_embedding_chunks: bool = False,
     trace_name_prefix: str = C.DEFAULT_TRACE_NAME_PREFIX,
     dispatcher: Any = None,
 ) -> NoveumLlamaIndexSpanHandler:
@@ -440,11 +584,21 @@ def setup_llamaindex_tracing(
 
     Args:
         client: Explicit Noveum client. Defaults to the globally initialised one.
-        capture_inputs: Capture query / retrieval query text (default off).
-        capture_outputs: Capture response text and retrieved node content
-            (default off).
-        capture_llm_messages: Capture full LLM prompt/response messages
-            (default off — the most sensitive payload).
+        capture_inputs: Capture query text, retrieval and rerank query text,
+            rerank input nodes, and agent tool arguments (default on).
+        capture_outputs: Capture response text, retrieved node content, query
+            source nodes and reranked output nodes (default on).
+        capture_llm_messages: Capture full LLM prompt/response messages, system
+            prompts and available tool schemas (default on).
+        capture_cost: Estimate LLM cost from the model and token counts
+            (default on).
+        capture_embedding_chunks: Capture the *text* being embedded (default
+            **off**). Indexing a corpus emits an embedding call per batch, so
+            turning this on copies the whole source corpus into the trace
+            store — useful when building evaluation datasets from a small
+            index, expensive on a large one. Counts, vector counts and vector
+            width are recorded either way; the embedding vectors themselves are
+            never attached.
         trace_name_prefix: Prefix used when an operation name cannot be derived.
         dispatcher: Dispatcher to register on. Defaults to the root dispatcher
             (``get_dispatcher()``).
@@ -479,6 +633,8 @@ def setup_llamaindex_tracing(
         capture_inputs=capture_inputs,
         capture_outputs=capture_outputs,
         capture_llm_messages=capture_llm_messages,
+        capture_cost=capture_cost,
+        capture_embedding_chunks=capture_embedding_chunks,
     )
     target = dispatcher if dispatcher is not None else get_dispatcher()
     target.add_span_handler(span_handler)

--- a/src/noveum_trace/integrations/llamaindex/handler.py
+++ b/src/noveum_trace/integrations/llamaindex/handler.py
@@ -451,7 +451,25 @@ def setup_llamaindex_tracing(
 
     Returns:
         The registered :class:`NoveumLlamaIndexSpanHandler`.
+
+    Raises:
+        RuntimeError: If ``noveum_trace.init()`` has not been called and no
+            explicit ``client`` is provided (otherwise LlamaIndex activity would
+            be silently untraced).
     """
+    if client is None:
+        try:
+            from noveum_trace import is_initialized
+        except ImportError as exc:  # pragma: no cover - noveum_trace always present
+            raise RuntimeError(
+                "noveum_trace is not installed. Install with: pip install noveum-trace"
+            ) from exc
+        if not is_initialized():
+            raise RuntimeError(
+                "Noveum tracing is not initialized. Call noveum_trace.init() "
+                "before setup_llamaindex_tracing() (or pass an explicit client=)."
+            )
+
     span_handler = NoveumLlamaIndexSpanHandler(
         client=client,
         trace_name_prefix=trace_name_prefix,

--- a/src/noveum_trace/integrations/llamaindex/handler.py
+++ b/src/noveum_trace/integrations/llamaindex/handler.py
@@ -586,10 +586,12 @@ def setup_llamaindex_tracing(
         client: Explicit Noveum client. Defaults to the globally initialised one.
         capture_inputs: Capture query text, retrieval and rerank query text,
             rerank input nodes, and agent tool arguments (default on).
-        capture_outputs: Capture response text, retrieved node content, query
-            source nodes and reranked output nodes (default on).
-        capture_llm_messages: Capture full LLM prompt/response messages, system
-            prompts and available tool schemas (default on).
+        capture_outputs: Capture LLM response text (``llm.output``), query
+            response text, retrieved node content, query source nodes and
+            reranked output nodes (default on).
+        capture_llm_messages: Capture LLM prompt messages (``llm.input``),
+            system prompts and available tool schemas (default on). LLM
+            *responses* are governed by ``capture_outputs``, not this flag.
         capture_cost: Estimate LLM cost from the model and token counts
             (default on).
         capture_embedding_chunks: Capture the *text* being embedded (default

--- a/src/noveum_trace/integrations/llamaindex/handler.py
+++ b/src/noveum_trace/integrations/llamaindex/handler.py
@@ -1,0 +1,468 @@
+"""
+Noveum instrumentation handlers for LlamaIndex.
+
+Bridges LlamaIndex's modern instrumentation system
+(``llama_index.core.instrumentation``) into Noveum:
+
+* :class:`NoveumLlamaIndexSpanHandler` maps every LlamaIndex span (query engine,
+  retriever, synthesizer, LLM, embedding calls) onto Noveum traces/spans,
+  preserving the parent-child hierarchy that LlamaIndex threads through its
+  ``active_span_id`` context variable.
+* :class:`NoveumLlamaIndexEventHandler` enriches the corresponding open Noveum
+  span with LLM / embedding / retrieval / rerank attributes from the events that
+  fire inside each span.
+
+Register both on the root dispatcher with :func:`setup_llamaindex_tracing`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from llama_index.core.instrumentation import get_dispatcher
+from llama_index.core.instrumentation.event_handlers.base import BaseEventHandler
+from llama_index.core.instrumentation.span.base import BaseSpan
+from llama_index.core.instrumentation.span_handlers.base import BaseSpanHandler
+
+from noveum_trace.integrations.llamaindex import constants as C
+from noveum_trace.integrations.llamaindex.utils import (
+    classify_operation,
+    derive_provider,
+    extract_model_name,
+    extract_node_contents,
+    extract_node_scores,
+    extract_query_str,
+    extract_response_text,
+    extract_token_usage,
+    operation_from_span_id,
+    serialize_messages,
+    truncate_text,
+)
+
+logger = logging.getLogger(__name__)
+
+_LLM_START_EVENTS = frozenset({"LLMChatStartEvent", "LLMCompletionStartEvent"})
+_LLM_END_EVENTS = frozenset(
+    {"LLMChatEndEvent", "LLMCompletionEndEvent", "LLMPredictEndEvent"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Span attribute helpers (module-level, never raise)
+# ---------------------------------------------------------------------------
+
+
+def _set_attrs(span: Any, attrs: dict[str, Any]) -> None:
+    if not attrs or span is None:
+        return
+    try:
+        span.set_attributes(attrs)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("failed to set span attributes: %s", exc)
+
+
+def _finish_span(span: Any) -> None:
+    if span is None:
+        return
+    try:
+        if not span.is_finished():
+            span.finish()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("failed to finish span: %s", exc)
+
+
+def _apply_error(span: Any, err: Any) -> None:
+    if span is None:
+        return
+    attrs: dict[str, Any] = {C.ATTR_STATUS: C.STATUS_ERROR}
+    if err is not None:
+        attrs[C.ATTR_ERROR_TYPE] = type(err).__name__
+        attrs[C.ATTR_ERROR_MESSAGE] = truncate_text(str(err), C.MAX_TEXT_LENGTH)
+    try:
+        span.set_attributes(attrs)
+        from noveum_trace.core.span import SpanStatus
+
+        span.set_status(SpanStatus.ERROR, str(err) if err else "error")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("failed to mark span error: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Span type
+# ---------------------------------------------------------------------------
+
+
+class NoveumLlamaIndexSpan(BaseSpan):
+    """A LlamaIndex span carrying its mapped Noveum trace/span handles."""
+
+    noveum_span: Any = None
+    noveum_trace: Any = None
+    is_root: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Span handler
+# ---------------------------------------------------------------------------
+
+
+class NoveumLlamaIndexSpanHandler(BaseSpanHandler[NoveumLlamaIndexSpan]):
+    """
+    Maps LlamaIndex spans onto Noveum traces/spans.
+
+    Each top-level LlamaIndex span (``parent_span_id is None``) opens a new Noveum
+    trace; nested spans become Noveum child spans under the same trace. The Noveum
+    handles ride on the returned :class:`NoveumLlamaIndexSpan`, so a child resolves
+    its parent purely from ``open_spans`` — no separate bookkeeping.
+    """
+
+    client: Any = None
+    trace_name_prefix: str = C.DEFAULT_TRACE_NAME_PREFIX
+
+    def __init__(
+        self,
+        client: Any = None,
+        trace_name_prefix: str = C.DEFAULT_TRACE_NAME_PREFIX,
+        **kwargs: Any,
+    ) -> None:
+        # ``BaseSpanHandler`` defines a custom ``__init__`` whose signature does
+        # not accept extra fields, so bridge our config in explicitly.
+        super().__init__(**kwargs)
+        self.client = client
+        self.trace_name_prefix = trace_name_prefix
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "NoveumLlamaIndexSpanHandler"
+
+    def _get_client(self) -> Any:
+        if self.client is not None:
+            return self.client
+        try:
+            from noveum_trace import get_client, is_initialized
+
+            if is_initialized():
+                return get_client()
+        except Exception:  # pragma: no cover - defensive
+            return None
+        return None
+
+    def new_span(
+        self,
+        id_: str,
+        bound_args: Any,
+        instance: Optional[Any] = None,
+        parent_span_id: Optional[str] = None,
+        tags: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Optional[NoveumLlamaIndexSpan]:
+        try:
+            client = self._get_client()
+            if client is None:
+                return None
+
+            operation = operation_from_span_id(id_)
+            attributes: dict[str, Any] = {
+                C.ATTR_OPERATION: operation,
+                C.ATTR_SPAN_TYPE: classify_operation(operation),
+            }
+
+            parent = self.open_spans.get(parent_span_id) if parent_span_id else None
+            if parent is not None and getattr(parent, "noveum_trace", None) is not None:
+                noveum_trace_obj = parent.noveum_trace
+                parent_noveum_span = getattr(parent, "noveum_span", None)
+                parent_noveum_span_id = getattr(parent_noveum_span, "span_id", None)
+                noveum_span = noveum_trace_obj.create_span(
+                    name=operation,
+                    parent_span_id=parent_noveum_span_id,
+                    attributes=attributes,
+                )
+                return NoveumLlamaIndexSpan(
+                    id_=id_,
+                    parent_id=parent_span_id,
+                    tags=tags or {},
+                    noveum_span=noveum_span,
+                    noveum_trace=noveum_trace_obj,
+                    is_root=False,
+                )
+
+            # Root span → open a new Noveum trace.
+            attributes[C.ATTR_FRAMEWORK] = C.FRAMEWORK_NAME
+            noveum_trace_obj = client.start_trace(
+                name=operation or f"{self.trace_name_prefix}.trace",
+                attributes={C.ATTR_FRAMEWORK: C.FRAMEWORK_NAME},
+                set_as_current=False,
+            )
+            noveum_span = noveum_trace_obj.create_span(
+                name=operation,
+                parent_span_id=None,
+                attributes=attributes,
+            )
+            return NoveumLlamaIndexSpan(
+                id_=id_,
+                parent_id=parent_span_id,
+                tags=tags or {},
+                noveum_span=noveum_span,
+                noveum_trace=noveum_trace_obj,
+                is_root=True,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("new_span failed: %s", exc, exc_info=True)
+            return None
+
+    def prepare_to_exit_span(
+        self,
+        id_: str,
+        bound_args: Any,
+        instance: Optional[Any] = None,
+        result: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> Optional[NoveumLlamaIndexSpan]:
+        span = self.open_spans.get(id_)
+        if span is None:
+            return None
+        try:
+            noveum_span = getattr(span, "noveum_span", None)
+            if noveum_span is not None:
+                _set_attrs(noveum_span, {C.ATTR_STATUS: C.STATUS_OK})
+                _finish_span(noveum_span)
+            if getattr(span, "is_root", False):
+                self._finish_trace(span)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("prepare_to_exit_span failed: %s", exc, exc_info=True)
+        return span
+
+    def prepare_to_drop_span(
+        self,
+        id_: str,
+        bound_args: Any,
+        instance: Optional[Any] = None,
+        err: Optional[BaseException] = None,
+        **kwargs: Any,
+    ) -> Optional[NoveumLlamaIndexSpan]:
+        span = self.open_spans.get(id_)
+        if span is None:
+            return None
+        try:
+            noveum_span = getattr(span, "noveum_span", None)
+            if noveum_span is not None:
+                _apply_error(noveum_span, err)
+                _finish_span(noveum_span)
+            if getattr(span, "is_root", False):
+                self._finish_trace(span)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("prepare_to_drop_span failed: %s", exc, exc_info=True)
+        return span
+
+    def _finish_trace(self, span: NoveumLlamaIndexSpan) -> None:
+        noveum_trace_obj = getattr(span, "noveum_trace", None)
+        if noveum_trace_obj is None:
+            return
+        try:
+            client = self._get_client()
+            if client is not None:
+                client.finish_trace(noveum_trace_obj)
+            else:
+                noveum_trace_obj.finish()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("finish trace failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Event handler
+# ---------------------------------------------------------------------------
+
+
+class NoveumLlamaIndexEventHandler(BaseEventHandler):
+    """
+    Enriches open Noveum spans with data from LlamaIndex events.
+
+    Correlates each event to its span via ``event.span_id`` (which equals the
+    enclosing span's ``id_``) and attaches LLM / embedding / retrieval / rerank
+    attributes to that span's Noveum span.
+    """
+
+    span_handler: Any = None
+    capture_inputs: bool = False
+    capture_outputs: bool = False
+    capture_llm_messages: bool = False
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "NoveumLlamaIndexEventHandler"
+
+    def handle(self, event: Any, **kwargs: Any) -> Any:
+        try:
+            self._handle(event)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("event handle failed: %s", exc, exc_info=True)
+        return None
+
+    def _resolve_span(self, event: Any) -> Any:
+        span_handler = self.span_handler
+        if span_handler is None:
+            return None
+        span_id = getattr(event, "span_id", None)
+        if span_id is None:
+            return None
+        mapped = span_handler.open_spans.get(span_id)
+        return getattr(mapped, "noveum_span", None) if mapped is not None else None
+
+    def _handle(self, event: Any) -> None:
+        noveum_span = self._resolve_span(event)
+        if noveum_span is None:
+            return
+        name = type(event).__name__
+
+        if name == "ExceptionEvent":
+            _apply_error(noveum_span, getattr(event, "exception", None))
+            return
+
+        attrs: dict[str, Any] = {}
+        if name in _LLM_START_EVENTS:
+            self._map_llm_start(event, attrs)
+        elif name in _LLM_END_EVENTS:
+            self._map_llm_end(event, attrs)
+        elif name == "EmbeddingStartEvent":
+            attrs[C.ATTR_SPAN_TYPE] = C.SPAN_TYPE_EMBEDDING
+            model = extract_model_name(getattr(event, "model_dict", None))
+            if model:
+                attrs[C.ATTR_EMBEDDING_MODEL] = model
+        elif name == "EmbeddingEndEvent":
+            self._map_embedding_end(event, attrs)
+        elif name == "RetrievalStartEvent":
+            attrs[C.ATTR_SPAN_TYPE] = C.SPAN_TYPE_RETRIEVAL
+            if self.capture_inputs:
+                query = extract_query_str(getattr(event, "str_or_query_bundle", None))
+                if query:
+                    attrs[C.ATTR_RETRIEVAL_QUERY] = truncate_text(query)
+        elif name == "RetrievalEndEvent":
+            self._map_retrieval_end(event, attrs)
+        elif name == "QueryStartEvent":
+            attrs[C.ATTR_SPAN_TYPE] = C.SPAN_TYPE_QUERY
+            if self.capture_inputs:
+                query = extract_query_str(getattr(event, "query", None))
+                if query:
+                    attrs[C.ATTR_QUERY_TEXT] = truncate_text(query)
+        elif name == "QueryEndEvent":
+            if self.capture_outputs:
+                response = getattr(event, "response", None)
+                if response is not None:
+                    attrs[C.ATTR_QUERY_RESPONSE] = truncate_text(str(response))
+        elif name == "ReRankStartEvent":
+            self._map_rerank_start(event, attrs)
+        elif name == "ReRankEndEvent":
+            nodes = getattr(event, "nodes", None)
+            if nodes is not None:
+                attrs[C.ATTR_RERANK_OUTPUT_NODE_COUNT] = len(nodes)
+
+        _set_attrs(noveum_span, attrs)
+
+    def _map_llm_start(self, event: Any, attrs: dict[str, Any]) -> None:
+        attrs[C.ATTR_SPAN_TYPE] = C.SPAN_TYPE_LLM
+        model = extract_model_name(getattr(event, "model_dict", None))
+        if model:
+            attrs[C.ATTR_LLM_MODEL] = model
+            provider = derive_provider(model)
+            if provider:
+                attrs[C.ATTR_LLM_PROVIDER] = provider
+        if self.capture_llm_messages:
+            messages = serialize_messages(getattr(event, "messages", None))
+            if messages:
+                attrs[C.ATTR_LLM_INPUT] = messages
+            prompt = getattr(event, "prompt", None)
+            if prompt is not None:
+                attrs[C.ATTR_LLM_INPUT] = truncate_text(prompt)
+
+    def _map_llm_end(self, event: Any, attrs: dict[str, Any]) -> None:
+        response = getattr(event, "response", None)
+        usage = extract_token_usage(response)
+        if usage["input_tokens"] is not None:
+            attrs[C.ATTR_LLM_INPUT_TOKENS] = usage["input_tokens"]
+        if usage["output_tokens"] is not None:
+            attrs[C.ATTR_LLM_OUTPUT_TOKENS] = usage["output_tokens"]
+        if usage["total_tokens"] is not None:
+            attrs[C.ATTR_LLM_TOTAL_TOKENS] = usage["total_tokens"]
+        if self.capture_outputs:
+            text = extract_response_text(response)
+            if text is None:
+                output = getattr(event, "output", None)
+                text = str(output) if output is not None else None
+            if text:
+                attrs[C.ATTR_LLM_OUTPUT] = truncate_text(text)
+
+    def _map_embedding_end(self, event: Any, attrs: dict[str, Any]) -> None:
+        chunks = getattr(event, "chunks", None)
+        if chunks is not None:
+            attrs[C.ATTR_EMBEDDING_CHUNK_COUNT] = len(chunks)
+        embeddings = getattr(event, "embeddings", None)
+        if embeddings is not None:
+            attrs[C.ATTR_EMBEDDING_VECTOR_COUNT] = len(embeddings)
+
+    def _map_retrieval_end(self, event: Any, attrs: dict[str, Any]) -> None:
+        nodes = getattr(event, "nodes", None)
+        if nodes is not None:
+            attrs[C.ATTR_RETRIEVAL_NODE_COUNT] = len(nodes)
+            attrs[C.ATTR_RETRIEVAL_SCORES] = extract_node_scores(nodes)
+            if self.capture_outputs:
+                attrs[C.ATTR_RETRIEVAL_NODES] = extract_node_contents(
+                    nodes, C.MAX_NODE_CONTENT_LENGTH
+                )
+
+    def _map_rerank_start(self, event: Any, attrs: dict[str, Any]) -> None:
+        attrs[C.ATTR_SPAN_TYPE] = C.SPAN_TYPE_RERANK
+        model = getattr(event, "model_name", None)
+        if model:
+            attrs[C.ATTR_RERANK_MODEL] = str(model)
+        top_n = getattr(event, "top_n", None)
+        if top_n is not None:
+            attrs[C.ATTR_RERANK_TOP_N] = top_n
+        nodes = getattr(event, "nodes", None)
+        if nodes is not None:
+            attrs[C.ATTR_RERANK_INPUT_NODE_COUNT] = len(nodes)
+
+
+def setup_llamaindex_tracing(
+    client: Any = None,
+    *,
+    capture_inputs: bool = False,
+    capture_outputs: bool = False,
+    capture_llm_messages: bool = False,
+    trace_name_prefix: str = C.DEFAULT_TRACE_NAME_PREFIX,
+    dispatcher: Any = None,
+) -> NoveumLlamaIndexSpanHandler:
+    """
+    Register Noveum span + event handlers on LlamaIndex's dispatcher.
+
+    Requires ``noveum_trace.init(...)`` to have been called (or an explicit
+    ``client=``). Handlers are added to the root dispatcher by default, so all
+    LlamaIndex activity is traced.
+
+    Args:
+        client: Explicit Noveum client. Defaults to the globally initialised one.
+        capture_inputs: Capture query / retrieval query text (default off).
+        capture_outputs: Capture response text and retrieved node content
+            (default off).
+        capture_llm_messages: Capture full LLM prompt/response messages
+            (default off — the most sensitive payload).
+        trace_name_prefix: Prefix used when an operation name cannot be derived.
+        dispatcher: Dispatcher to register on. Defaults to the root dispatcher
+            (``get_dispatcher()``).
+
+    Returns:
+        The registered :class:`NoveumLlamaIndexSpanHandler`.
+    """
+    span_handler = NoveumLlamaIndexSpanHandler(
+        client=client,
+        trace_name_prefix=trace_name_prefix,
+    )
+    event_handler = NoveumLlamaIndexEventHandler(
+        span_handler=span_handler,
+        capture_inputs=capture_inputs,
+        capture_outputs=capture_outputs,
+        capture_llm_messages=capture_llm_messages,
+    )
+    target = dispatcher if dispatcher is not None else get_dispatcher()
+    target.add_span_handler(span_handler)
+    target.add_event_handler(event_handler)
+    return span_handler

--- a/src/noveum_trace/integrations/llamaindex/utils.py
+++ b/src/noveum_trace/integrations/llamaindex/utils.py
@@ -339,10 +339,14 @@ def vector_dimensions(embeddings: Any) -> Optional[int]:
     Only the width is recorded — the vectors themselves are never attached to a
     span. They are large, and a float array is not something a trace viewer or
     an evaluation can use.
+
+    The emptiness check uses ``len()`` rather than truthiness so that a provider
+    returning a NumPy array does not raise "truth value of an array ... is
+    ambiguous" out of this helper.
     """
-    if not embeddings:
-        return None
     try:
+        if embeddings is None or len(embeddings) == 0:
+            return None
         first = embeddings[0]
         return len(first) if hasattr(first, "__len__") else None
     except Exception as exc:  # pragma: no cover - defensive

--- a/src/noveum_trace/integrations/llamaindex/utils.py
+++ b/src/noveum_trace/integrations/llamaindex/utils.py
@@ -1,9 +1,17 @@
 """
 Utility helpers for the LlamaIndex integration.
 
+Framework-agnostic helpers (serialization, provider derivation, token usage,
+cost) live in :mod:`noveum_trace.integrations._common` and are re-exported here.
+What remains below is specific to LlamaIndex shapes: instrumentation span ids,
+``ChatMessage`` arrays, ``NodeWithScore`` lists and ``ToolMetadata``.
+
 All helpers are zero-impact: every public function absorbs exceptions internally
 and returns a sensible default so a crashing utility can never break the host
 application or the LlamaIndex query pipeline.
+
+Nothing here truncates. Retrieved node text and prompts routinely exceed any
+fixed budget, and a clipped node is not usable for evaluation or replay.
 """
 
 from __future__ import annotations
@@ -12,9 +20,37 @@ import logging
 import re
 from typing import Any, Optional
 
+from noveum_trace.integrations._common import (
+    derive_provider,
+    estimate_cost_safe,
+    extract_usage_tokens,
+    probe,
+    safe_serialize,
+    stringify,
+)
 from noveum_trace.integrations.llamaindex import constants as C
 
 logger = logging.getLogger(__name__)
+
+__all__ = [
+    "classify_operation",
+    "derive_provider",
+    "estimate_cost_safe",
+    "extract_model_name",
+    "extract_node_contents",
+    "extract_node_scores",
+    "extract_query_str",
+    "extract_response_text",
+    "extract_system_prompt",
+    "extract_token_usage",
+    "extract_tool_metadata",
+    "operation_from_span_id",
+    "safe_serialize",
+    "serialize_messages",
+    "serialize_nodes",
+    "stringify",
+    "vector_dimensions",
+]
 
 # ``id_`` values look like ``"RetrieverQueryEngine.query-<uuid4>"``; strip the
 # trailing UUID to recover a readable operation name.
@@ -22,16 +58,7 @@ _UUID_SUFFIX = re.compile(
     r"-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}" r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
 
-_OPENAI_MODEL_PREFIXES = (
-    "gpt",
-    "o1",
-    "o3",
-    "o4",
-    "text-",
-    "ada",
-    "babbage",
-    "davinci",
-)
+_SYSTEM_ROLES = frozenset({"system", "developer"})
 
 
 def operation_from_span_id(id_: str) -> str:
@@ -60,59 +87,12 @@ def classify_operation(operation: str) -> str:
     return C.SPAN_TYPE_OTHER
 
 
-def derive_provider(model: Optional[str]) -> Optional[str]:
-    """Best-effort provider name from a model string."""
-    if not model or not isinstance(model, str):
-        return None
-    lowered = model.lower()
-    if any(lowered.startswith(prefix) for prefix in _OPENAI_MODEL_PREFIXES):
-        return "openai"
-    if lowered.startswith("claude"):
-        return "anthropic"
-    if lowered.startswith("gemini") or lowered.startswith("models/gemini"):
-        return "google"
-    if lowered.startswith(("mistral", "mixtral")):
-        return "mistral"
-    if "/" in lowered:
-        return lowered.split("/", 1)[0]
-    return None
-
-
-def truncate_text(text: Any, max_len: int = 8_192) -> str:
-    """Stringify *text* and truncate to *max_len* characters with an ellipsis."""
-    if not isinstance(text, str):
-        text = str(text)
-    if len(text) <= max_len:
-        return text
-    return text[:max_len] + "…"
-
-
-def _get(source: Any, *keys: str) -> Any:
-    """Read *keys* from a dict or object, returning the first non-None value."""
-    for key in keys:
-        value = (
-            source.get(key) if isinstance(source, dict) else getattr(source, key, None)
-        )
-        if value is not None:
-            return value
-    return None
-
-
 def extract_model_name(model_dict: Any) -> Optional[str]:
     """Pull the model name out of an event's ``model_dict`` payload."""
     if not model_dict:
         return None
-    value = _get(model_dict, "model", "model_name", "model_id")
+    value = probe(model_dict, "model", "model_name", "model_id")
     return str(value) if value is not None else None
-
-
-def _coerce_int(value: Any) -> Optional[int]:
-    if value is None:
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def extract_token_usage(response: Any) -> dict[str, Optional[int]]:
@@ -121,44 +101,55 @@ def extract_token_usage(response: Any) -> dict[str, Optional[int]]:
 
     Token usage is not a first-class field on LlamaIndex responses; it lives on
     ``response.raw`` (provider-native, e.g. OpenAI ``usage``) or
-    ``response.additional_kwargs``. Probes both. Returns ``None`` values when a
-    count is unavailable and computes ``total`` when possible.
+    ``response.additional_kwargs``. Probes both, then normalises through the
+    shared extractor so cached and reasoning token breakdowns come through too.
     """
-    result: dict[str, Optional[int]] = {
-        "input_tokens": None,
-        "output_tokens": None,
-        "total_tokens": None,
-    }
     if response is None:
-        return result
+        return dict.fromkeys(
+            (
+                "input_tokens",
+                "output_tokens",
+                "total_tokens",
+                "cached_input_tokens",
+                "cache_write_input_tokens",
+                "reasoning_tokens",
+            )
+        )
+    merged: dict[str, Optional[int]] = {}
     try:
+        raw = probe(response, "raw")
         sources = [
-            getattr(response, "additional_kwargs", None),
-            getattr(response, "raw", None),
-            _get(getattr(response, "raw", None) or {}, "usage"),
+            probe(response, "additional_kwargs"),
+            raw,
+            probe(raw, "usage") if raw is not None else None,
         ]
         for source in sources:
             if not source:
                 continue
-            if result["input_tokens"] is None:
-                result["input_tokens"] = _coerce_int(
-                    _get(source, "prompt_tokens", "input_tokens")
-                )
-            if result["output_tokens"] is None:
-                result["output_tokens"] = _coerce_int(
-                    _get(source, "completion_tokens", "output_tokens")
-                )
-            if result["total_tokens"] is None:
-                result["total_tokens"] = _coerce_int(_get(source, "total_tokens"))
+            for key, value in extract_usage_tokens(source).items():
+                if merged.get(key) is None and value is not None:
+                    merged[key] = value
+        input_tokens = merged.get("input_tokens")
+        output_tokens = merged.get("output_tokens")
         if (
-            result["total_tokens"] is None
-            and result["input_tokens"] is not None
-            and result["output_tokens"] is not None
+            merged.get("total_tokens") is None
+            and input_tokens is not None
+            and output_tokens is not None
         ):
-            result["total_tokens"] = result["input_tokens"] + result["output_tokens"]
+            merged["total_tokens"] = input_tokens + output_tokens
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("extract_token_usage failed: %s", exc)
-    return result
+    return {
+        key: merged.get(key)
+        for key in (
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "cached_input_tokens",
+            "cache_write_input_tokens",
+            "reasoning_tokens",
+        )
+    }
 
 
 def extract_query_str(query: Any) -> Optional[str]:
@@ -167,8 +158,8 @@ def extract_query_str(query: Any) -> Optional[str]:
         return None
     if isinstance(query, str):
         return query
-    value = _get(query, "query_str")
-    return str(value) if value is not None else str(query)
+    value = probe(query, "query_str")
+    return str(value) if value is not None else stringify(query)
 
 
 def serialize_messages(messages: Any) -> Optional[list[dict[str, Any]]]:
@@ -178,18 +169,42 @@ def serialize_messages(messages: Any) -> Optional[list[dict[str, Any]]]:
     result: list[dict[str, Any]] = []
     try:
         for message in messages:
-            role = _get(message, "role")
-            content = _get(message, "content")
-            result.append(
-                {
-                    "role": str(getattr(role, "value", role)) if role else None,
-                    "content": None if content is None else str(content),
-                }
-            )
+            role = probe(message, "role")
+            content = probe(message, "content")
+            entry: dict[str, Any] = {
+                "role": str(getattr(role, "value", role)) if role else None,
+                "content": None if content is None else stringify(content),
+            }
+            tool_calls = probe(message, "additional_kwargs")
+            calls = probe(tool_calls, "tool_calls") if tool_calls else None
+            if calls:
+                entry["tool_calls"] = safe_serialize(calls)
+            result.append(entry)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("serialize_messages failed: %s", exc)
         return None
     return result or None
+
+
+def extract_system_prompt(messages: Any) -> Optional[str]:
+    """Join the content of every ``system`` / ``developer`` message."""
+    if not messages:
+        return None
+    try:
+        collected: list[str] = []
+        for message in messages:
+            role = probe(message, "role")
+            role_name = str(getattr(role, "value", role) or "").lower()
+            if role_name not in _SYSTEM_ROLES:
+                continue
+            content = probe(message, "content")
+            if content is not None:
+                collected.append(stringify(content))
+        joined = "\n\n".join(part for part in collected if part)
+        return joined or None
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_system_prompt failed: %s", exc)
+        return None
 
 
 def extract_response_text(response: Any) -> Optional[str]:
@@ -201,18 +216,39 @@ def extract_response_text(response: Any) -> Optional[str]:
         if message is not None:
             content = getattr(message, "content", None)
             if content is not None:
-                return str(content)
+                return stringify(content)
         text = getattr(response, "text", None)
         if text is not None:
-            return str(text)
-        return str(response)
+            return stringify(text)
+        return stringify(response)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("extract_response_text failed: %s", exc)
         return None
 
 
+# ---------------------------------------------------------------------------
+# Nodes
+# ---------------------------------------------------------------------------
+
+
+def _node_text(node: Any) -> Optional[str]:
+    inner = getattr(node, "node", node)
+    getter = getattr(inner, "get_content", None)
+    try:
+        text = getter() if callable(getter) else getattr(inner, "text", None)
+    except Exception:  # pragma: no cover - defensive
+        text = getattr(inner, "text", None)
+    return None if text is None else stringify(text)
+
+
 def extract_node_scores(nodes: Any) -> list[Optional[float]]:
-    """Return the similarity scores of a list of ``NodeWithScore`` objects."""
+    """
+    Return the similarity scores of a list of ``NodeWithScore`` objects.
+
+    These are the retriever's own top-k scores — cosine similarity for most
+    vector stores, or the store's native distance metric. The list is ordered
+    best-match first, matching the order the nodes were returned in.
+    """
     scores: list[Optional[float]] = []
     if not nodes:
         return scores
@@ -225,18 +261,90 @@ def extract_node_scores(nodes: Any) -> list[Optional[float]]:
     return scores
 
 
-def extract_node_contents(nodes: Any, max_len: int = 2_048) -> list[str]:
-    """Return truncated text content of a list of ``NodeWithScore`` objects."""
+def serialize_nodes(nodes: Any) -> list[dict[str, Any]]:
+    """
+    Serialise ``NodeWithScore`` objects to ``{id, score, text, metadata}`` entries.
+
+    ``text`` is the node's full chunk content — the actual passage the retriever
+    returned and the synthesizer read, not a summary or a reference. Node
+    ``metadata`` (source file, page, custom tags) is carried alongside so a
+    retrieved chunk can be traced back to its document.
+    """
+    entries: list[dict[str, Any]] = []
+    if not nodes:
+        return entries
+    try:
+        for node in nodes:
+            inner = getattr(node, "node", node)
+            entry: dict[str, Any] = {}
+            node_id = probe(inner, "node_id", "id_", "id")
+            if node_id is not None:
+                entry["id"] = stringify(node_id)
+            score = getattr(node, "score", None)
+            if score is not None:
+                entry["score"] = float(score)
+            text = _node_text(node)
+            if text is not None:
+                entry["text"] = text
+            metadata = probe(inner, "metadata", "extra_info")
+            if metadata:
+                entry["metadata"] = safe_serialize(metadata)
+            entries.append(entry)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("serialize_nodes failed: %s", exc)
+    return entries
+
+
+def extract_node_contents(nodes: Any) -> list[str]:
+    """Return the full text content of a list of ``NodeWithScore`` objects."""
     contents: list[str] = []
     if not nodes:
         return contents
     try:
         for node in nodes:
-            inner = getattr(node, "node", node)
-            getter = getattr(inner, "get_content", None)
-            text = getter() if callable(getter) else getattr(inner, "text", None)
+            text = _node_text(node)
             if text is not None:
-                contents.append(truncate_text(text, max_len))
+                contents.append(text)
     except Exception as exc:  # pragma: no cover - defensive
         logger.debug("extract_node_contents failed: %s", exc)
     return contents
+
+
+# ---------------------------------------------------------------------------
+# Tools / embeddings
+# ---------------------------------------------------------------------------
+
+
+def extract_tool_metadata(tool: Any) -> dict[str, Any]:
+    """Normalise a LlamaIndex ``ToolMetadata`` to ``{name, description}``."""
+    entry: dict[str, Any] = {}
+    if tool is None:
+        return entry
+    try:
+        name = probe(tool, "name")
+        if name is not None:
+            entry["name"] = stringify(name)
+        description = probe(tool, "description")
+        if description is not None:
+            entry["description"] = stringify(description)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_tool_metadata failed: %s", exc)
+    return entry
+
+
+def vector_dimensions(embeddings: Any) -> Optional[int]:
+    """
+    Return the dimensionality of the first embedding vector, if determinable.
+
+    Only the width is recorded — the vectors themselves are never attached to a
+    span. They are large, and a float array is not something a trace viewer or
+    an evaluation can use.
+    """
+    if not embeddings:
+        return None
+    try:
+        first = embeddings[0]
+        return len(first) if hasattr(first, "__len__") else None
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("vector_dimensions failed: %s", exc)
+        return None

--- a/src/noveum_trace/integrations/llamaindex/utils.py
+++ b/src/noveum_trace/integrations/llamaindex/utils.py
@@ -1,0 +1,242 @@
+"""
+Utility helpers for the LlamaIndex integration.
+
+All helpers are zero-impact: every public function absorbs exceptions internally
+and returns a sensible default so a crashing utility can never break the host
+application or the LlamaIndex query pipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+from noveum_trace.integrations.llamaindex import constants as C
+
+logger = logging.getLogger(__name__)
+
+# ``id_`` values look like ``"RetrieverQueryEngine.query-<uuid4>"``; strip the
+# trailing UUID to recover a readable operation name.
+_UUID_SUFFIX = re.compile(
+    r"-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}" r"-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+_OPENAI_MODEL_PREFIXES = (
+    "gpt",
+    "o1",
+    "o3",
+    "o4",
+    "text-",
+    "ada",
+    "babbage",
+    "davinci",
+)
+
+
+def operation_from_span_id(id_: str) -> str:
+    """Recover the ``Class.method`` operation name from an instrumentation id."""
+    if not isinstance(id_, str):
+        return str(id_)
+    return _UUID_SUFFIX.sub("", id_)
+
+
+def classify_operation(operation: str) -> str:
+    """
+    Best-effort span-type from an operation name (``"other"`` when unknown).
+
+    The method name (the part after the last ``.``) is the strongest signal, so
+    it is matched first — ``"RetrieverQueryEngine.query"`` classifies as a query,
+    not a retrieval, even though the class name contains "Retriever".
+    """
+    lowered = operation.lower()
+    method = lowered.rsplit(".", 1)[-1]
+    for needle, span_type in C.OPERATION_TYPE_HINTS:
+        if needle in method:
+            return span_type
+    for needle, span_type in C.OPERATION_TYPE_HINTS:
+        if needle in lowered:
+            return span_type
+    return C.SPAN_TYPE_OTHER
+
+
+def derive_provider(model: Optional[str]) -> Optional[str]:
+    """Best-effort provider name from a model string."""
+    if not model or not isinstance(model, str):
+        return None
+    lowered = model.lower()
+    if any(lowered.startswith(prefix) for prefix in _OPENAI_MODEL_PREFIXES):
+        return "openai"
+    if lowered.startswith("claude"):
+        return "anthropic"
+    if lowered.startswith("gemini") or lowered.startswith("models/gemini"):
+        return "google"
+    if lowered.startswith(("mistral", "mixtral")):
+        return "mistral"
+    if "/" in lowered:
+        return lowered.split("/", 1)[0]
+    return None
+
+
+def truncate_text(text: Any, max_len: int = 8_192) -> str:
+    """Stringify *text* and truncate to *max_len* characters with an ellipsis."""
+    if not isinstance(text, str):
+        text = str(text)
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "…"
+
+
+def _get(source: Any, *keys: str) -> Any:
+    """Read *keys* from a dict or object, returning the first non-None value."""
+    for key in keys:
+        value = (
+            source.get(key) if isinstance(source, dict) else getattr(source, key, None)
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def extract_model_name(model_dict: Any) -> Optional[str]:
+    """Pull the model name out of an event's ``model_dict`` payload."""
+    if not model_dict:
+        return None
+    value = _get(model_dict, "model", "model_name", "model_id")
+    return str(value) if value is not None else None
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_token_usage(response: Any) -> dict[str, Optional[int]]:
+    """
+    Extract token counts from a LlamaIndex ``ChatResponse`` / ``CompletionResponse``.
+
+    Token usage is not a first-class field on LlamaIndex responses; it lives on
+    ``response.raw`` (provider-native, e.g. OpenAI ``usage``) or
+    ``response.additional_kwargs``. Probes both. Returns ``None`` values when a
+    count is unavailable and computes ``total`` when possible.
+    """
+    result: dict[str, Optional[int]] = {
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": None,
+    }
+    if response is None:
+        return result
+    try:
+        sources = [
+            getattr(response, "additional_kwargs", None),
+            getattr(response, "raw", None),
+            _get(getattr(response, "raw", None) or {}, "usage"),
+        ]
+        for source in sources:
+            if not source:
+                continue
+            if result["input_tokens"] is None:
+                result["input_tokens"] = _coerce_int(
+                    _get(source, "prompt_tokens", "input_tokens")
+                )
+            if result["output_tokens"] is None:
+                result["output_tokens"] = _coerce_int(
+                    _get(source, "completion_tokens", "output_tokens")
+                )
+            if result["total_tokens"] is None:
+                result["total_tokens"] = _coerce_int(_get(source, "total_tokens"))
+        if (
+            result["total_tokens"] is None
+            and result["input_tokens"] is not None
+            and result["output_tokens"] is not None
+        ):
+            result["total_tokens"] = result["input_tokens"] + result["output_tokens"]
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_token_usage failed: %s", exc)
+    return result
+
+
+def extract_query_str(query: Any) -> Optional[str]:
+    """Return the query text from a ``str`` or a ``QueryBundle``-like object."""
+    if query is None:
+        return None
+    if isinstance(query, str):
+        return query
+    value = _get(query, "query_str")
+    return str(value) if value is not None else str(query)
+
+
+def serialize_messages(messages: Any) -> Optional[list[dict[str, Any]]]:
+    """Serialise a list of ``ChatMessage`` objects to ``[{role, content}, ...]``."""
+    if not messages:
+        return None
+    result: list[dict[str, Any]] = []
+    try:
+        for message in messages:
+            role = _get(message, "role")
+            content = _get(message, "content")
+            result.append(
+                {
+                    "role": str(getattr(role, "value", role)) if role else None,
+                    "content": None if content is None else str(content),
+                }
+            )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("serialize_messages failed: %s", exc)
+        return None
+    return result or None
+
+
+def extract_response_text(response: Any) -> Optional[str]:
+    """Extract the assistant text from a ``ChatResponse`` / ``CompletionResponse``."""
+    if response is None:
+        return None
+    try:
+        message = getattr(response, "message", None)
+        if message is not None:
+            content = getattr(message, "content", None)
+            if content is not None:
+                return str(content)
+        text = getattr(response, "text", None)
+        if text is not None:
+            return str(text)
+        return str(response)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_response_text failed: %s", exc)
+        return None
+
+
+def extract_node_scores(nodes: Any) -> list[Optional[float]]:
+    """Return the similarity scores of a list of ``NodeWithScore`` objects."""
+    scores: list[Optional[float]] = []
+    if not nodes:
+        return scores
+    try:
+        for node in nodes:
+            score = getattr(node, "score", None)
+            scores.append(float(score) if score is not None else None)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_node_scores failed: %s", exc)
+    return scores
+
+
+def extract_node_contents(nodes: Any, max_len: int = 2_048) -> list[str]:
+    """Return truncated text content of a list of ``NodeWithScore`` objects."""
+    contents: list[str] = []
+    if not nodes:
+        return contents
+    try:
+        for node in nodes:
+            inner = getattr(node, "node", node)
+            getter = getattr(inner, "get_content", None)
+            text = getter() if callable(getter) else getattr(inner, "text", None)
+            if text is not None:
+                contents.append(truncate_text(text, max_len))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("extract_node_contents failed: %s", exc)
+    return contents

--- a/tests/unit/integrations/test_llamaindex_handler.py
+++ b/tests/unit/integrations/test_llamaindex_handler.py
@@ -242,7 +242,7 @@ class TestEventEnrichment:
         assert attrs["llm.input_tokens"] == 12
         assert attrs["llm.output_tokens"] == 7
         assert attrs["llm.total_tokens"] == 19
-        assert "llm.output" not in attrs  # capture_outputs is off by default
+        assert "llm.output" not in attrs  # capture_outputs=False for this handler
 
     def test_capture_outputs_and_messages(self) -> None:
         sh, eh, child = self._setup(capture_outputs=True, capture_llm_messages=True)
@@ -543,3 +543,37 @@ class TestRichCapture:
             instance=retriever,
         )
         assert span.noveum_span.attributes["retrieval.top_k"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Vector dimensions
+# ---------------------------------------------------------------------------
+
+
+class _AmbiguousTruthiness(list):
+    """Stand-in for an array whose ``bool()`` raises, as NumPy's does."""
+
+    def __bool__(self) -> bool:
+        raise ValueError(
+            "The truth value of an array with more than one element is ambiguous"
+        )
+
+
+class TestVectorDimensions:
+    def test_list_of_vectors(self) -> None:
+        assert utils.vector_dimensions([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]) == 3
+
+    def test_missing_or_empty_input(self) -> None:
+        assert utils.vector_dimensions(None) is None
+        assert utils.vector_dimensions([]) is None
+
+    def test_ambiguous_truthiness_does_not_raise(self) -> None:
+        # The emptiness guard must not evaluate bool() on the container: a
+        # provider returning an array type would otherwise raise out of here.
+        embeddings = _AmbiguousTruthiness([[0.1, 0.2], [0.3, 0.4]])
+        assert utils.vector_dimensions(embeddings) == 2
+
+    def test_numpy_array_of_vectors(self) -> None:
+        np = pytest.importorskip("numpy")
+        assert utils.vector_dimensions(np.zeros((4, 8))) == 8
+        assert utils.vector_dimensions(np.array([])) is None

--- a/tests/unit/integrations/test_llamaindex_handler.py
+++ b/tests/unit/integrations/test_llamaindex_handler.py
@@ -1,0 +1,328 @@
+"""
+Unit tests for the LlamaIndex integration handlers.
+
+The handlers subclass LlamaIndex's real (Pydantic) instrumentation base classes,
+so these tests require the optional ``llamaindex`` extra and are skipped when it
+is absent. The Noveum client/trace/span are faked, and the handler lifecycle is
+driven directly (``new_span`` / ``handle`` / ``prepare_to_exit_span``).
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip(
+    "llama_index.core.instrumentation",
+    reason="requires optional 'llamaindex' extra",
+)
+
+_src = Path(__file__).parents[3] / "src"
+if str(_src) not in sys.path:
+    sys.path.insert(0, str(_src))
+
+from noveum_trace.integrations.llamaindex import utils  # noqa: E402
+from noveum_trace.integrations.llamaindex.handler import (  # noqa: E402
+    NoveumLlamaIndexEventHandler,
+    NoveumLlamaIndexSpanHandler,
+    setup_llamaindex_tracing,
+)
+
+_BOUND_ARGS = inspect.signature(lambda: None).bind()
+_RID = "RetrieverQueryEngine.query-11111111-1111-1111-1111-111111111111"
+_CID = "OpenAI.chat-22222222-2222-2222-2222-222222222222"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+def _make_noveum_span(span_id: str, trace_id: str = "nt") -> MagicMock:
+    span = MagicMock()
+    span.span_id = span_id
+    span.trace_id = trace_id
+    span.attributes = {}
+    span.set_attributes = MagicMock(
+        side_effect=lambda attrs: span.attributes.update(attrs)
+    )
+    span.set_status = MagicMock()
+    span.finish = MagicMock()
+    span.is_finished = MagicMock(return_value=False)
+    return span
+
+
+def _make_client(trace_id: str = "nt") -> MagicMock:
+    client = MagicMock()
+    trace = MagicMock()
+    trace.trace_id = trace_id
+    counter = {"n": 0}
+
+    def _create_span(name, parent_span_id=None, attributes=None, start_time=None):
+        counter["n"] += 1
+        span = _make_noveum_span(f"ns{counter['n']}", trace_id=trace_id)
+        span.name = name
+        span.parent_span_id = parent_span_id
+        if attributes:
+            span.attributes.update(attributes)
+        return span
+
+    trace.create_span = MagicMock(side_effect=_create_span)
+    trace.finish = MagicMock()
+    client._trace = trace
+    client.start_trace = MagicMock(return_value=trace)
+    client.finish_trace = MagicMock()
+    client.flush = MagicMock()
+    return client
+
+
+def _event(class_name: str, **fields):
+    obj = type(class_name, (), {})()
+    for key, value in fields.items():
+        setattr(obj, key, value)
+    return obj
+
+
+def _message(role: str, content: str):
+    return type("ChatMessage", (), {"role": role, "content": content})()
+
+
+def _open(sh: NoveumLlamaIndexSpanHandler, id_: str, parent: str | None = None):
+    span = sh.new_span(id_=id_, bound_args=_BOUND_ARGS, parent_span_id=parent)
+    if span is not None:
+        sh.open_spans[id_] = span
+    return span
+
+
+# ---------------------------------------------------------------------------
+# Utils
+# ---------------------------------------------------------------------------
+
+
+class TestUtils:
+    def test_operation_from_span_id_strips_uuid(self) -> None:
+        assert utils.operation_from_span_id(_RID) == "RetrieverQueryEngine.query"
+
+    def test_operation_from_span_id_no_uuid(self) -> None:
+        assert utils.operation_from_span_id("plain-name") == "plain-name"
+
+    def test_classify_operation(self) -> None:
+        assert utils.classify_operation("VectorIndexRetriever.retrieve") == "retrieval"
+        assert utils.classify_operation("OpenAI.chat") == "llm"
+        assert utils.classify_operation("Mystery.thing") == "other"
+
+    def test_token_usage_from_raw_usage(self) -> None:
+        response = type("R", (), {})()
+        response.raw = {"usage": {"prompt_tokens": 3, "completion_tokens": 4}}
+        response.additional_kwargs = {}
+        tokens = utils.extract_token_usage(response)
+        assert tokens["input_tokens"] == 3
+        assert tokens["output_tokens"] == 4
+        assert tokens["total_tokens"] == 7
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_handlers_construct_with_config(self) -> None:
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client, trace_name_prefix="li")
+        eh = NoveumLlamaIndexEventHandler(span_handler=sh, capture_inputs=True)
+        assert sh.client is client
+        assert sh.trace_name_prefix == "li"
+        assert eh.span_handler is sh
+        assert eh.capture_inputs is True
+
+    def test_privacy_safe_defaults(self) -> None:
+        eh = NoveumLlamaIndexEventHandler()
+        assert eh.capture_inputs is False
+        assert eh.capture_outputs is False
+        assert eh.capture_llm_messages is False
+
+
+# ---------------------------------------------------------------------------
+# Span mapping
+# ---------------------------------------------------------------------------
+
+
+class TestSpanMapping:
+    def test_root_span_opens_trace(self) -> None:
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        root = _open(sh, _RID)
+        assert root is not None
+        assert root.is_root is True
+        client.start_trace.assert_called_once()
+        assert (
+            root.noveum_span.attributes["llamaindex.operation"]
+            == "RetrieverQueryEngine.query"
+        )
+        assert root.noveum_span.attributes["llamaindex.span_type"] == "query"
+
+    def test_child_span_linked_to_parent(self) -> None:
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        root = _open(sh, _RID)
+        child = _open(sh, _CID, parent=_RID)
+        assert child is not None
+        assert child.is_root is False
+        assert child.noveum_trace is root.noveum_trace
+        child_call = client._trace.create_span.call_args_list[-1]
+        assert child_call.kwargs["parent_span_id"] == root.noveum_span.span_id
+
+    def test_missing_parent_becomes_new_root(self) -> None:
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        orphan = _open(sh, _CID, parent="never-opened")
+        assert orphan is not None
+        assert orphan.is_root is True
+
+    def test_no_client_returns_none(self) -> None:
+        sh = NoveumLlamaIndexSpanHandler()  # no client, global not initialised
+        assert (
+            sh.new_span(id_=_RID, bound_args=_BOUND_ARGS, parent_span_id=None) is None
+        )
+
+
+# ---------------------------------------------------------------------------
+# Event enrichment
+# ---------------------------------------------------------------------------
+
+
+class TestEventEnrichment:
+    def _setup(self, **eh_kwargs):
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        eh = NoveumLlamaIndexEventHandler(span_handler=sh, **eh_kwargs)
+        _open(sh, _RID)
+        child = _open(sh, _CID, parent=_RID)
+        return sh, eh, child
+
+    def test_llm_events_map_model_and_tokens(self) -> None:
+        sh, eh, child = self._setup()
+        eh.handle(
+            _event("LLMChatStartEvent", span_id=_CID, model_dict={"model": "gpt-4o"})
+        )
+        response = type("R", (), {})()
+        response.raw = {"usage": {"prompt_tokens": 12, "completion_tokens": 7}}
+        response.message = _message("assistant", "hello")
+        eh.handle(_event("LLMChatEndEvent", span_id=_CID, response=response))
+
+        attrs = child.noveum_span.attributes
+        assert attrs["llamaindex.span_type"] == "llm"
+        assert attrs["llm.model"] == "gpt-4o"
+        assert attrs["llm.provider"] == "openai"
+        assert attrs["llm.input_tokens"] == 12
+        assert attrs["llm.output_tokens"] == 7
+        assert attrs["llm.total_tokens"] == 19
+        assert "llm.output" not in attrs  # capture_outputs is off by default
+
+    def test_capture_outputs_and_messages(self) -> None:
+        sh, eh, child = self._setup(capture_outputs=True, capture_llm_messages=True)
+        eh.handle(
+            _event(
+                "LLMChatStartEvent",
+                span_id=_CID,
+                model_dict={"model": "gpt-4o"},
+                messages=[_message("user", "hi")],
+            )
+        )
+        response = type("R", (), {})()
+        response.message = _message("assistant", "hello there")
+        eh.handle(_event("LLMChatEndEvent", span_id=_CID, response=response))
+
+        attrs = child.noveum_span.attributes
+        assert attrs["llm.input"] == [{"role": "user", "content": "hi"}]
+        assert attrs["llm.output"] == "hello there"
+
+    def test_retrieval_end_records_nodes(self) -> None:
+        sh, eh, child = self._setup()
+        node = type("NodeWithScore", (), {"score": 0.9})()
+        eh.handle(_event("RetrievalEndEvent", span_id=_CID, nodes=[node, node]))
+        attrs = child.noveum_span.attributes
+        assert attrs["retrieval.node_count"] == 2
+        assert attrs["retrieval.scores"] == [0.9, 0.9]
+
+    def test_embedding_end_records_counts(self) -> None:
+        sh, eh, child = self._setup()
+        eh.handle(
+            _event(
+                "EmbeddingEndEvent",
+                span_id=_CID,
+                chunks=["a", "b", "c"],
+                embeddings=[[0.1], [0.2], [0.3]],
+            )
+        )
+        attrs = child.noveum_span.attributes
+        assert attrs["embedding.chunk_count"] == 3
+        assert attrs["embedding.vector_count"] == 3
+
+    def test_event_for_unknown_span_is_noop(self) -> None:
+        sh, eh, _child = self._setup()
+        eh.handle(_event("LLMChatStartEvent", span_id="not-open"))  # must not raise
+
+    def test_exception_event_marks_error(self) -> None:
+        sh, eh, child = self._setup()
+        eh.handle(_event("ExceptionEvent", span_id=_CID, exception=ValueError("boom")))
+        attrs = child.noveum_span.attributes
+        assert attrs["llamaindex.status"] == "error"
+        assert attrs["error.type"] == "ValueError"
+        child.noveum_span.set_status.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_exit_finishes_span_and_trace(self) -> None:
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        root = _open(sh, _RID)
+        child = _open(sh, _CID, parent=_RID)
+
+        sh.prepare_to_exit_span(id_=_CID, bound_args=_BOUND_ARGS)
+        assert child.noveum_span.finish.called
+        assert not client.finish_trace.called  # child is not root
+
+        sh.prepare_to_exit_span(id_=_RID, bound_args=_BOUND_ARGS)
+        assert root.noveum_span.finish.called
+        client.finish_trace.assert_called_once_with(root.noveum_trace)
+
+    def test_drop_marks_error_and_finishes(self) -> None:
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        root = _open(sh, _RID)
+        sh.prepare_to_drop_span(
+            id_=_RID, bound_args=_BOUND_ARGS, err=RuntimeError("nope")
+        )
+        assert root.noveum_span.attributes["llamaindex.status"] == "error"
+        assert root.noveum_span.finish.called
+        client.finish_trace.assert_called_once()
+
+    def test_exit_unknown_span_is_noop(self) -> None:
+        sh = NoveumLlamaIndexSpanHandler(client=_make_client())
+        assert sh.prepare_to_exit_span(id_="unknown", bound_args=_BOUND_ARGS) is None
+
+
+# ---------------------------------------------------------------------------
+# Setup factory
+# ---------------------------------------------------------------------------
+
+
+class TestSetup:
+    def test_setup_registers_on_dispatcher(self) -> None:
+        client = _make_client()
+        dispatcher = MagicMock()
+        handler = setup_llamaindex_tracing(client=client, dispatcher=dispatcher)
+        assert isinstance(handler, NoveumLlamaIndexSpanHandler)
+        dispatcher.add_span_handler.assert_called_once()
+        dispatcher.add_event_handler.assert_called_once()

--- a/tests/unit/integrations/test_llamaindex_handler.py
+++ b/tests/unit/integrations/test_llamaindex_handler.py
@@ -140,11 +140,31 @@ class TestConstruction:
         assert eh.span_handler is sh
         assert eh.capture_inputs is True
 
-    def test_privacy_safe_defaults(self) -> None:
+    def test_captures_everything_by_default(self) -> None:
         eh = NoveumLlamaIndexEventHandler()
+        assert eh.capture_inputs is True
+        assert eh.capture_outputs is True
+        assert eh.capture_llm_messages is True
+        assert eh.capture_cost is True
+
+    def test_embedding_chunk_capture_is_opt_in(self) -> None:
+        # Indexing a corpus emits one embedding call per batch, so the chunk
+        # text stays behind an explicit opt-in even though everything else is
+        # captured by default.
+        eh = NoveumLlamaIndexEventHandler()
+        assert eh.capture_embedding_chunks is False
+
+    def test_capture_flags_can_be_disabled(self) -> None:
+        eh = NoveumLlamaIndexEventHandler(
+            capture_inputs=False,
+            capture_outputs=False,
+            capture_llm_messages=False,
+            capture_cost=False,
+        )
         assert eh.capture_inputs is False
         assert eh.capture_outputs is False
         assert eh.capture_llm_messages is False
+        assert eh.capture_cost is False
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +226,7 @@ class TestEventEnrichment:
         return sh, eh, child
 
     def test_llm_events_map_model_and_tokens(self) -> None:
-        sh, eh, child = self._setup()
+        sh, eh, child = self._setup(capture_outputs=False)
         eh.handle(
             _event("LLMChatStartEvent", span_id=_CID, model_dict={"model": "gpt-4o"})
         )
@@ -342,3 +362,184 @@ class TestSetup:
             client=_make_client(), dispatcher=MagicMock()
         )
         assert isinstance(handler, NoveumLlamaIndexSpanHandler)
+
+
+# ---------------------------------------------------------------------------
+# Full-payload capture: nodes, rerank, tools, cost, embeddings
+# ---------------------------------------------------------------------------
+
+
+def _node(text: str, score: float, node_id: str = "n1", metadata=None):
+    inner = type("TextNode", (), {})()
+    inner.node_id = node_id
+    inner.text = text
+    inner.metadata = metadata or {}
+    inner.get_content = lambda: text
+    wrapper = type("NodeWithScore", (), {})()
+    wrapper.node = inner
+    wrapper.score = score
+    return wrapper
+
+
+class TestRichCapture:
+    def _setup(self, **eh_kwargs):
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        eh = NoveumLlamaIndexEventHandler(span_handler=sh, **eh_kwargs)
+        _open(sh, _RID)
+        child = _open(sh, _CID, parent=_RID)
+        return sh, eh, child
+
+    def test_retrieved_nodes_carry_text_score_and_metadata(self) -> None:
+        sh, eh, child = self._setup()
+        nodes = [
+            _node("chunk one", 0.91, "a", {"file": "a.md"}),
+            _node("chunk two", 0.42, "b", {"file": "b.md"}),
+        ]
+        eh.handle(_event("RetrievalEndEvent", span_id=_CID, nodes=nodes))
+
+        attrs = child.noveum_span.attributes
+        assert attrs["retrieval.node_count"] == 2
+        assert attrs["retrieval.scores"] == [0.91, 0.42]
+        serialized = attrs["retrieval.nodes"]
+        assert serialized[0]["id"] == "a"
+        assert serialized[0]["text"] == "chunk one"
+        assert serialized[0]["score"] == 0.91
+        assert serialized[0]["metadata"] == {"file": "a.md"}
+
+    def test_node_text_is_not_truncated(self) -> None:
+        sh, eh, child = self._setup()
+        huge = "y" * 40_000
+        eh.handle(_event("RetrievalEndEvent", span_id=_CID, nodes=[_node(huge, 0.5)]))
+        assert child.noveum_span.attributes["retrieval.nodes"][0]["text"] == huge
+
+    def test_rerank_captures_input_and_ranked_output(self) -> None:
+        sh, eh, child = self._setup()
+        before = [_node("low", 0.30, "a"), _node("high", 0.20, "b")]
+        after = [_node("high", 0.99, "b"), _node("low", 0.10, "a")]
+        eh.handle(
+            _event(
+                "ReRankStartEvent",
+                span_id=_CID,
+                nodes=before,
+                top_n=2,
+                model_name="rerank-v3",
+                query="which one?",
+            )
+        )
+        eh.handle(_event("ReRankEndEvent", span_id=_CID, nodes=after))
+
+        attrs = child.noveum_span.attributes
+        assert attrs["rerank.model"] == "rerank-v3"
+        assert attrs["rerank.query"] == "which one?"
+        assert attrs["rerank.input_node_count"] == 2
+        assert attrs["rerank.input_scores"] == [0.30, 0.20]
+        assert attrs["rerank.output_node_count"] == 2
+        assert attrs["rerank.output_scores"] == [0.99, 0.10]
+        assert [n["id"] for n in attrs["rerank.input_nodes"]] == ["a", "b"]
+        assert [n["id"] for n in attrs["rerank.output_nodes"]] == ["b", "a"]
+
+    def test_embedding_records_counts_and_dimensions_not_vectors(self) -> None:
+        sh, eh, child = self._setup()
+        eh.handle(
+            _event(
+                "EmbeddingEndEvent",
+                span_id=_CID,
+                chunks=["alpha", "beta"],
+                embeddings=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+            )
+        )
+        attrs = child.noveum_span.attributes
+        assert attrs["embedding.chunk_count"] == 2
+        assert attrs["embedding.vector_count"] == 2
+        assert attrs["embedding.dimensions"] == 3
+        assert "embedding.chunks" not in attrs
+        assert not any("0.1" in str(v) for v in attrs.values())
+
+    def test_embedding_chunks_captured_when_opted_in(self) -> None:
+        sh, eh, child = self._setup(capture_embedding_chunks=True)
+        eh.handle(
+            _event(
+                "EmbeddingEndEvent",
+                span_id=_CID,
+                chunks=["alpha", "beta"],
+                embeddings=[[0.1], [0.2]],
+            )
+        )
+        assert child.noveum_span.attributes["embedding.chunks"] == ["alpha", "beta"]
+
+    def test_llm_cost_estimated_from_start_event_model(self) -> None:
+        sh, eh, child = self._setup()
+        eh.handle(
+            _event("LLMChatStartEvent", span_id=_CID, model_dict={"model": "gpt-4o"})
+        )
+        response = type("R", (), {})()
+        response.raw = {"usage": {"prompt_tokens": 1000, "completion_tokens": 500}}
+        response.message = _message("assistant", "hi")
+        eh.handle(_event("LLMChatEndEvent", span_id=_CID, response=response))
+
+        attrs = child.noveum_span.attributes
+        assert attrs["llm.cost.total"] > 0
+        assert attrs["llm.cost.currency"] == "USD"
+
+    def test_llm_start_captures_system_prompt_and_tools(self) -> None:
+        sh, eh, child = self._setup()
+        tool = type("ToolMetadata", (), {})()
+        tool.name = "search"
+        tool.description = "Search the docs"
+        eh.handle(
+            _event(
+                "LLMChatStartEvent",
+                span_id=_CID,
+                model_dict={"model": "gpt-4o"},
+                additional_kwargs={"tools": [tool]},
+                messages=[
+                    _message("system", "You are terse."),
+                    _message("user", "hello"),
+                ],
+            )
+        )
+        attrs = child.noveum_span.attributes
+        assert attrs["llm.system_prompt"] == "You are terse."
+        assert attrs["llm.available_tool_count"] == 1
+        assert attrs["llm.available_tools"][0]["name"] == "search"
+
+    def test_agent_tool_call_event_is_mapped(self) -> None:
+        sh, eh, child = self._setup()
+        tool = type("ToolMetadata", (), {})()
+        tool.name = "get_weather"
+        tool.description = "Look up weather"
+        eh.handle(
+            _event(
+                "AgentToolCallEvent",
+                span_id=_CID,
+                tool=tool,
+                arguments='{"city":"Paris"}',
+            )
+        )
+        attrs = child.noveum_span.attributes
+        assert attrs["tool.name"] == "get_weather"
+        assert attrs["tool.description"] == "Look up weather"
+        assert attrs["tool.input"] == '{"city":"Paris"}'
+
+    def test_query_end_captures_response_and_source_nodes(self) -> None:
+        sh, eh, child = self._setup()
+        response = type("Response", (), {"__str__": lambda self: "the answer"})()
+        response.source_nodes = [_node("src", 0.7, "s1")]
+        eh.handle(_event("QueryEndEvent", span_id=_CID, response=response))
+
+        attrs = child.noveum_span.attributes
+        assert attrs["query.response"] == "the answer"
+        assert attrs["query.source_nodes"][0]["id"] == "s1"
+
+    def test_top_k_read_from_retriever_instance(self) -> None:
+        client = _make_client()
+        sh = NoveumLlamaIndexSpanHandler(client=client)
+        retriever = type("VectorIndexRetriever", (), {})()
+        retriever.similarity_top_k = 7
+        span = sh.new_span(
+            id_="VectorIndexRetriever.retrieve-33333333-3333-3333-3333-333333333333",
+            bound_args=_BOUND_ARGS,
+            instance=retriever,
+        )
+        assert span.noveum_span.attributes["retrieval.top_k"] == 7

--- a/tests/unit/integrations/test_llamaindex_handler.py
+++ b/tests/unit/integrations/test_llamaindex_handler.py
@@ -326,3 +326,19 @@ class TestSetup:
         assert isinstance(handler, NoveumLlamaIndexSpanHandler)
         dispatcher.add_span_handler.assert_called_once()
         dispatcher.add_event_handler.assert_called_once()
+
+    def test_setup_requires_initialization(self, monkeypatch) -> None:
+        import noveum_trace
+
+        monkeypatch.setattr(noveum_trace, "is_initialized", lambda: False)
+        with pytest.raises(RuntimeError):
+            setup_llamaindex_tracing()  # no client, SDK not initialised
+
+    def test_setup_with_explicit_client_skips_init_check(self, monkeypatch) -> None:
+        import noveum_trace
+
+        monkeypatch.setattr(noveum_trace, "is_initialized", lambda: False)
+        handler = setup_llamaindex_tracing(
+            client=_make_client(), dispatcher=MagicMock()
+        )
+        assert isinstance(handler, NoveumLlamaIndexSpanHandler)


### PR DESCRIPTION
# Pull Request

## Description

Adds a **net-new LlamaIndex integration** so Noveum can trace LlamaIndex query
pipelines. It registers a **span handler** and an **event handler** on
LlamaIndex's modern instrumentation dispatcher
(`llama_index.core.instrumentation`) and mirrors every operation — query engines,
retrievers, synthesizers, LLM calls, embedding calls, rerankers — as a Noveum
trace/span, preserving parent-child ordering.

Highlights:
- **Span handler** (`NoveumLlamaIndexSpanHandler`) maps LlamaIndex spans onto
  Noveum traces/spans; each top-level span opens a new trace, nested spans become
  children. The Noveum handles ride on the returned span object, so parentage is
  resolved purely from `open_spans` — no separate bookkeeping.
- **Event handler** (`NoveumLlamaIndexEventHandler`) enriches the enclosing span
  (correlated by `event.span_id`) with `llm.*` / `embedding.*` / `retrieval.*` /
  `rerank.*` attributes. `llm.*` keys feed the existing `otel_compat` crosswalk.
- **Privacy-safe defaults**: query text, node content, and LLM message content are
  opt-in via `capture_inputs` / `capture_outputs` / `capture_llm_messages`.
  Metadata (model, token usage, node counts/scores, embedding counts, latency,
  errors) is always captured.
- `setup_llamaindex_tracing()` registers both handlers on the root dispatcher.
- Optional dependency stays optional: `import noveum_trace` works without the
  extra (the module import is guarded), and the export is gated on the guard.
- Handlers are non-fatal — failures are logged at debug level; LlamaIndex also
  swallows handler exceptions in its dispatcher.

Verified upstream interface: `llama-index-core` **0.14.23** (via
`llama_index_instrumentation` 0.5.0). Import path
`from llama_index.core.instrumentation import get_dispatcher`;
`BaseSpanHandler.new_span(id_, bound_args, instance, parent_span_id, tags, **kwargs)`
/ `prepare_to_exit_span(..., result, ...)` / `prepare_to_drop_span(..., err, ...)`;
`BaseEventHandler.handle(event, **kwargs)`; `event.span_id` correlation. Note:
`BaseSpanHandler` defines a custom `__init__`, so the handler bridges its config
through an `__init__` override.

Fixes # (NOVEU-275 — LlamaIndex adapter)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test improvements

## How Has This Been Tested?

- [x] Unit tests — `tests/unit/integrations/test_llamaindex_handler.py`
  (20 tests) fake the Noveum client and drive the handler lifecycle directly.
- [x] Integration testing — ran a real LlamaIndex pipeline
  (`VectorStoreIndex.from_documents(...).as_query_engine().query(...)` with
  `MockLLM` + `MockEmbedding`, no network) through the live dispatcher: produced
  Noveum traces/spans correctly classified as query / retrieval / synthesize /
  embedding / llm, with traces finished.

## Test Configuration

* Python version: 3.13 (supported floor: **3.10+** — current `llama-index-core`
  requires `>=3.10`, so the extra carries a `python_version>='3.10'` marker)
* Operating System: macOS (CI matrix: ubuntu/windows/macos)
* Dependencies: `llama-index-core>=0.11,<1.0; python_version>='3.10'` (optional
  extra); core needs none

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

`pre-commit run` (black 25.1.0, isort 6.0.1, ruff 0.12.3, mypy 1.13.0, bandit)
passes on the changed files; `mypy src/noveum_trace/` is clean.

## Additional Notes

- **Draft** — not for merge yet. Opened per NOVEU-275 P2 to review the adapter
  interface independently from the OpenAI Agents adapter.
- CI now installs `llama-index-core` on the **3.10+** unit-test legs, so the
  handler tests run across macOS/Ubuntu/Windows × 3.10–3.13; on 3.9 they
  `importorskip` cleanly (the extra is not installed there). All unit-test legs
  pass, including 3.9.
- `import noveum_trace` is hardened: the LlamaIndex integration guard catches any
  exception (not just `ImportError`), so an unusable `llama-index` on an
  unsupported runtime can never break base import.
- `docs/integrations/upstream.md` is updated with the LlamaIndex support-matrix
  row, version-compatibility row (3.10+), quick-start, and capture-flag reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LlamaIndex tracing for LLM, embedding, retrieval, query, reranking, tool-call, and error operations.
  * Added configurable privacy controls for capturing inputs, outputs, messages, and embedding content.
  * Added optional installation support, public setup APIs, and a runnable integration example.
  * Added metadata capture for token usage, costs, models, source nodes, and retrieval scores.

* **Documentation**
  * Added setup, compatibility, configuration, privacy, troubleshooting, and usage guidance.

* **Tests**
  * Added comprehensive integration tests with automatic skipping when LlamaIndex is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an optional LlamaIndex instrumentation integration that maps dispatcher spans and events into Noveum traces while exposing configurable payload-capture controls.
- Registers span and event handlers for query, retrieval, synthesis, LLM, embedding, reranking, and tool activity.
- Adds the optional dependency, guarded public exports, CI installation, documentation, examples, and unit coverage.
- Introduces shared serialization, token-usage, provider, cost, and span-lifecycle helpers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, although CI still does not exercise the advertised LlamaIndex 0.11.0 compatibility floor.

The previously reported lower-bound coverage gap remains because CI resolves the newest compatible LlamaIndex release, but no blocking runtime, build, data-integrity, or security failure is established.

**Files Needing Attention:** .github/workflows/tests.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/noveum_trace/integrations/llamaindex/handler.py | Implements LlamaIndex span lifecycle mapping, event correlation, metadata enrichment, and setup registration. |
| src/noveum_trace/integrations/llamaindex/utils.py | Adds defensive extraction and serialization helpers for LlamaIndex events and payloads. |
| src/noveum_trace/integrations/_common.py | Adds shared framework-integration helpers for span updates, serialization, token normalization, provider detection, and cost estimation. |
| .github/workflows/tests.yml | Installs the supported LlamaIndex dependency range on Python 3.10+ unit-test legs. |
| pyproject.toml | Defines the optional LlamaIndex dependency range and type-checker module coverage. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App
    participant LI as LlamaIndex Dispatcher
    participant SH as Noveum Span Handler
    participant EH as Noveum Event Handler
    participant NT as Noveum Trace
    App->>LI: Execute query pipeline
    LI->>SH: new_span(...)
    SH->>NT: Start trace or child span
    LI->>EH: LLM/retrieval/embedding events
    EH->>NT: Enrich correlated open span
    LI->>SH: prepare_to_exit_span / prepare_to_drop_span
    SH->>NT: Finish span and root trace
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: correct capture-flag contract, scor..."](https://github.com/noveum/noveum-trace/commit/373042a1235e83dcca150e2837bc194805473589) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50351729)</sub>

<!-- /greptile_comment -->